### PR TITLE
Remove extraneous redefinition of seek in Mark5BStreamReader.

### DIFF
--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -181,16 +181,6 @@ class Mark5BStreamReader(VLBIStreamReaderBase):
             self.frames_per_second) + 1
         return n_frames * self.samples_per_frame
 
-    def seek(self, offset, from_what=0):
-        """Like normal seek, but with the offset in samples."""
-        if from_what == 0:
-            self.offset = offset
-        elif from_what == 1:
-            self.offset += offset
-        elif from_what == 2:
-            self.offset = self.size + offset
-        return self.offset
-
     def read(self, count=None, fill_value=0., squeeze=True, out=None):
         """Read count samples.
 

--- a/baseband/tests/test_mark5b.py
+++ b/baseband/tests/test_mark5b.py
@@ -209,6 +209,10 @@ class TestMark5B(object):
             record2 = fh.read(2)
             assert fh.tell() == 10002
             assert fh.fh_raw.tell() == 3.*header.framesize
+            assert np.abs(fh.tell(unit='time') -
+                          (fh.time0 + 10002 / (32*u.MHz))) < 1. * u.ns
+            fh.seek(fh.time0 + 1000 / (32*u.MHz))
+            assert fh.tell() == 1000
 
         assert header1['frame_nr'] == 3
         assert header1['user'] == header['user']


### PR DESCRIPTION
And add test that seeks/tells time.