### PR TITLE
(Re)define find_header for locating first/last header.

### DIFF
--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -15,7 +15,7 @@ __all__ = ['Mark5BFileReader', 'Mark5BFileWriter', 'Mark5BStreamReader',
 class Mark5BFileReader(io.BufferedReader):
     """Simple reader for Mark 5B files.
 
-    Adds ``read_frame`` and ``find_frame`` methods to the basic binary file
+    Adds ``read_frame`` and ``find_header`` methods to the basic binary file
     reader :class:`~io.BufferedReader`.
     """
 
@@ -41,8 +41,8 @@ class Mark5BFileReader(io.BufferedReader):
         return Mark5BFrame.fromfile(self, nchan=nchan, bps=bps,
                                     ref_mjd=ref_mjd)
 
-    def find_frame(self, kday=None, template_header=None, framesize=None,
-                   maximum=None, forward=True):
+    def find_header(self, template_header=None, kday=None, framesize=None,
+                    maximum=None, forward=True):
         """Look for the first occurrence of a frame.
 
         Search is from the current position.  If given, a template_header

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -13,7 +13,7 @@ from .frame import VDIFFrame, VDIFFrameSet
 
 __all__ = ['VDIFFileReader', 'VDIFFileWriter', 'VDIFStreamBase',
            'VDIFStreamReader', 'VDIFStreamWriter', 'open',
-           'find_frame']
+           'find_header']
 
 # Check code on 2015-MAY-30
 # 00000000  77 2c db 00 00 00 00 1c  75 02 00 20 fc ff 01 04  # header 0 - 3
@@ -239,9 +239,9 @@ class VDIFStreamReader(VDIFStreamBase, VLBIStreamReaderBase):
         found = False
         while not found:
             self.fh_raw.seek(-self.header0.framesize, 1)
-            header1 = find_frame(self.fh_raw, template_header=self.header0,
-                                 maximum=10*self.header0.framesize,
-                                 forward=False)
+            header1 = find_header(self.fh_raw, template_header=self.header0,
+                                  maximum=10*self.header0.framesize,
+                                  forward=False)
             if header1 is None:
                 raise TypeError("Corrupt VDIF? No thread_id={0} frame in last "
                                 "{1} bytes."
@@ -484,13 +484,13 @@ def open(name, mode='rs', *args, **kwargs):
                          "or writing (mode='r' or 'w').")
 
 
-def find_frame(fh, template_header=None, framesize=None, maximum=None,
-               forward=True):
-    """Look for the first occurrence of a frame, from the current position.
+def find_header(fh, template_header=None, framesize=None, maximum=None,
+                forward=True):
+    """Look for the first occurrence of a header, from the current position.
 
     Search for a valid header at a given position which is consistent with
-    ``other_header`` or with a header a framesize ahead.   Note that the latter
-    turns out to be an unexpectedly weak check on real data!
+    ``template_header`` or with a header a framesize ahead.   Note that the
+    latter turns out to be an unexpectedly weak check on real data!
     """
     if template_header:
         framesize = template_header.framesize

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -138,9 +138,9 @@ class VLBIStreamReaderBase(VLBIStreamBase):
         """Last header of the file."""
         raw_offset = self.fh_raw.tell()
         self.fh_raw.seek(-self.header0.framesize, 2)
-        header1 = self.fh_raw.find_frame(template_header=self.header0,
-                                         maximum=10*self.header0.framesize,
-                                         forward=False)
+        header1 = self.fh_raw.find_header(template_header=self.header0,
+                                          maximum=10*self.header0.framesize,
+                                          forward=False)
         self.fh_raw.seek(raw_offset)
         if header1 is None:
             raise TypeError("Corrupt VLBI frame? No frame in last {0} bytes."


### PR DESCRIPTION
Problem was that `find_frame` in some classes returned a header, in others (`mark4`) an offset. Since the latter was shown in the documentation, renamed the other usage as `find_header`.