### PR TITLE
Included link to documentation in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,4 +6,7 @@ Baseband data input and output
     :alt: Powered by Astropy Badge
 
 This is a package for reading and writing VLBI and other radio baseband
-files. It relies on numpy and astropy.
+files. It relies on numpy and astropy.  
+
+For installation and usage instructions, please see the `online documentation 
+<https://baseband.readthedocs.io/>`_.

--- a/docs/baseband/install.rst
+++ b/docs/baseband/install.rst
@@ -34,13 +34,13 @@ using::
 
     git clone git@github.com:mhvk/baseband.git
 
-Of course, even better to fork it on github, and then clone your own
+Of course, it is even better to fork it on GitHub, and then clone your own
 repository, so that you can more easily contribute!
 
 Running code without installing
 -------------------------------
 
-As baseband is pure python, it can be used without being built or installed,
+As baseband is pure Python, it can be used without being built or installed,
 by appending the directory it is located in to the ``PYTHON_PATH`` environment
 variable.  Alternatively, you can use ``sys.path`` within Python to append the
 path::
@@ -76,7 +76,7 @@ successfully be run on your system::
 
     python3 setup.py test
 
-or, inside of python::
+or, inside of Python::
 
     import baseband
     baseband.test()
@@ -98,7 +98,7 @@ Building documentation
     documentation is available online at `baseband.readthedocs.io 
     <https://baseband.readthedocs.io>`_.
 
-The ``baseband`` documentation can be build again using ``setup.py`` from the
+The ``baseband`` documentation can be built again using ``setup.py`` from the
 root directory::
 
     python3 setup.py build_docs


### PR DESCRIPTION
Added link to documentation in README.rst.

Also fixed a few spelling and grammar issues in docs/install.rst.  I noticed you removed the code block for appending baseband's path to PYTHONPATH, but kept the sys.path.append block.  I do this rarely enough in bash that I forget the syntax often, so I would find it useful, but can see the argument for leaving it out as trivial.