### PR TITLE
Replace the subclassing of BufferedIO with a wrapper.

### DIFF
--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -220,7 +220,7 @@ class DADAStreamBase(VLBIStreamBase):
     def _open_file(self, frame_nr, mode):
         if self.fh_raw:
             self.fh_raw.close()
-        self.fh_raw = open(self.files[frame_nr], mode)
+        self.fh_raw = io.open(self.files[frame_nr], mode)
 
     def _unsqueeze(self, data):
         if data.ndim < 3 and self.nthread == 1:
@@ -230,7 +230,7 @@ class DADAStreamBase(VLBIStreamBase):
         return data
 
 
-class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase):
+class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase, DADAFileReader):
     """DADA format stream reader.
 
     This wrapper allows one to access a DADA file as a continues series of
@@ -238,7 +238,7 @@ class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase):
 
     Parameters
     ----------
-    raw : filehandle
+    fh_raw : filehandle
         file handle of the (first) raw DADA stream.
     thread_ids : list of int, optional
         Specific threads to read.  By default, all threads are read.
@@ -251,12 +251,12 @@ class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase):
         something like '2013-07-02-01:37:40_{obs_offset:016d}.000000.dada'.
         For details, see :class:`~baseband.dada.base.DADAFileNameSequencer`.
     """
-    def __init__(self, raw, thread_ids=None, files=None, template=None):
-        header = DADAHeader.fromfile(raw)
-        super(DADAStreamReader, self).__init__(raw, header, thread_ids,
+    def __init__(self, fh_raw, thread_ids=None, files=None, template=None):
+        header = DADAHeader.fromfile(fh_raw)
+        super(DADAStreamReader, self).__init__(fh_raw, header, thread_ids,
                                                files=files, template=template)
         if self.files is None:
-            self._frame = DADAFrame(header, DADAPayload.fromfile(raw, header,
+            self._frame = DADAFrame(header, DADAPayload.fromfile(fh_raw, header,
                                                                  memmap=True))
             self._frame_nr = 0
         else:
@@ -326,13 +326,13 @@ class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase):
 
     def _get_frame(self, frame_nr):
         self._open_file(frame_nr, 'rb')
-        self._frame = self.fh_raw.read_frame(memmap=True)
+        self._frame = self.read_frame(memmap=True)
         assert (self._frame.header['OBS_OFFSET'] ==
                 self.header0['OBS_OFFSET'] + frame_nr *
                 self.header0.payloadsize)
 
 
-class DADAStreamWriter(DADAStreamBase, VLBIStreamWriterBase):
+class DADAStreamWriter(DADAStreamBase, VLBIStreamWriterBase, DADAFileWriter):
     """DADA format writer.
 
     Parameters
@@ -384,7 +384,7 @@ class DADAStreamWriter(DADAStreamBase, VLBIStreamWriterBase):
         super(DADAStreamWriter, self).__init__(raw, header, files=files,
                                                template=template)
         if self.files is None:
-            self._frame = self.fh_raw.memmap_frame(header)
+            self._frame = self.memmap_frame(header)
             self._frame_nr = 0
         else:
             self._get_frame(0)
@@ -434,12 +434,12 @@ class DADAStreamWriter(DADAStreamBase, VLBIStreamWriterBase):
             count -= nsample
 
     def _get_frame(self, frame_nr):
-        self._open_file(frame_nr, 'wb')
+        self._open_file(frame_nr, 'w+b')
         # set up header for new frame.
         header = self.header0.copy()
         header.update(obs_offset=self.header0['OBS_OFFSET'] +
                       frame_nr * self.header0.payloadsize)
-        self._frame = self.fh_raw.memmap_frame(header)
+        self._frame = self.memmap_frame(header)
         self._frame_nr = frame_nr
 
 
@@ -520,8 +520,10 @@ def open(name, mode='rs', *args, **kwargs):
         if not hasattr(name, 'write'):
             name = io.open(name, 'w+b')
         try:
-            fh = DADAFileWriter(name)
-            return fh if 'b' in mode else DADAStreamWriter(fh, *args, **kwargs)
+            if 'b' in mode:
+                return DADAFileWriter(name)
+            else:
+                return DADAStreamWriter(name, *args, **kwargs)
         except Exception:
             name.close()
             raise
@@ -529,8 +531,10 @@ def open(name, mode='rs', *args, **kwargs):
         if not hasattr(name, 'read'):
             name = io.open(name, 'rb')
         try:
-            fh = DADAFileReader(name)
-            return fh if 'b' in mode else DADAStreamReader(fh, *args, **kwargs)
+            if 'b' in mode:
+                return DADAFileReader(name)
+            else:
+                return DADAStreamReader(name, *args, **kwargs)
         except Exception:
             name.close()
             raise

--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -116,7 +116,7 @@ class DADAFileReader(VLBIFileBase):
             be too large to fit in memory, it may be better to access the
             parts of interest by slicing the frame.
         """
-        return DADAFrame.fromfile(self.fh, memmap=memmap)
+        return DADAFrame.fromfile(self.fh_raw, memmap=memmap)
 
 
 class DADAFileWriter(VLBIFileBase):
@@ -142,7 +142,7 @@ class DADAFileWriter(VLBIFileBase):
         """
         if not isinstance(data, DADAFrame):
             data = DADAFrame.fromdata(data, header, **kwargs)
-        return data.tofile(self.fh)
+        return data.tofile(self.fh_raw)
 
     def memmap_frame(self, header=None, **kwargs):
         """Get frame by writing the header to disk and mapping its payload.
@@ -164,8 +164,8 @@ class DADAFileWriter(VLBIFileBase):
         """
         if header is None:
             header = DADAHeader.fromvalues(**kwargs)
-        header.tofile(self.fh)
-        payload = DADAPayload.fromfile(self.fh, memmap=True, header=header)
+        header.tofile(self.fh_raw)
+        payload = DADAPayload.fromfile(self.fh_raw, memmap=True, header=header)
         return DADAFrame(header, payload)
 
 

--- a/baseband/gsb/base.py
+++ b/baseband/gsb/base.py
@@ -71,7 +71,7 @@ class GSBFileReader(VLBIFileBase):
         frame : `~baseband.gsb.GSBPayload`
             With a ``.data`` property that returns the data encoded.
         """
-        return GSBPayload.fromfile(self.fh, payloadsize=payloadsize,
+        return GSBPayload.fromfile(self.fh_raw, payloadsize=payloadsize,
                                    nchan=nchan, bps=bps,
                                    complex_data=complex_data)
 
@@ -94,7 +94,7 @@ class GSBFileWriter(VLBIFileBase):
         """
         if not isinstance(data, GSBPayload):
             data = GSBPayload.fromdata(data, bps=bps)
-        return data.tofile(self.fh)
+        return data.tofile(self.fh_raw)
 
 
 class GSBStreamBase(VLBIStreamBase):

--- a/baseband/gsb/base.py
+++ b/baseband/gsb/base.py
@@ -131,9 +131,6 @@ class GSBStreamBase(VLBIStreamBase):
             frames_per_second=frames_per_second, sample_rate=sample_rate)
         self._payloadsize = payloadsize
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.close()
-
     def close(self):
         self.fh_ts.close()
         try:
@@ -148,7 +145,7 @@ class GSBStreamReader(GSBStreamBase, VLBIStreamReaderBase):
     # TODO: right now cannot inherit from GSBFileReader, unlike for other
     # baseband classes, since we need to access multiple files.  Can this
     # be solved with FileWriter/FileReader classes that handle timestamps and
-    # multiple blocks, combining these into a frame.
+    # multiple blocks, combining these into a frame?
     def __init__(self, fh_ts, fh_raw, thread_ids=None,
                  nchan=None, bps=None, complex_data=None,
                  samples_per_frame=None, payloadsize=None,

--- a/baseband/gsb/base.py
+++ b/baseband/gsb/base.py
@@ -5,7 +5,7 @@ import io
 import numpy as np
 from astropy.utils import lazyproperty
 import astropy.units as u
-from ..vlbi_base.base import (VLBIStreamBase,
+from ..vlbi_base.base import (VLBIFileBase, VLBIStreamBase,
                               VLBIStreamReaderBase, VLBIStreamWriterBase)
 from .header import GSBHeader
 from .payload import GSBPayload
@@ -46,11 +46,10 @@ class GSBTimeStampIO(io.TextIOWrapper):
         header.tofile(self)
 
 
-class GSBFileReader(io.BufferedReader):
+class GSBFileReader(VLBIFileBase):
     """Simple reader for GSB data files.
 
-    Adds ``read_payload`` method to the basic binary file reader
-    :class:`~io.BufferedReader`.
+    Adds ``read_payload`` method to the basic VLBI binary file wrapper.
     """
     def read_payload(self, payloadsize, nchan=1, bps=4, complex_data=False):
         """Read a single block.
@@ -72,16 +71,15 @@ class GSBFileReader(io.BufferedReader):
         frame : `~baseband.gsb.GSBPayload`
             With a ``.data`` property that returns the data encoded.
         """
-        return GSBPayload.fromfile(self, payloadsize=payloadsize,
+        return GSBPayload.fromfile(self.fh, payloadsize=payloadsize,
                                    nchan=nchan, bps=bps,
                                    complex_data=complex_data)
 
 
-class GSBFileWriter(io.BufferedWriter):
+class GSBFileWriter(VLBIFileBase):
     """Simple writer for GSB data files.
 
-    Adds ``write_payload`` method to the basic binary file writer
-    :class:`~io.BufferedWriter`.
+    Adds ``write_payload`` method to the basic VLBI binary file wrapper.
     """
     def write_payload(self, data, bps=4):
         """Write single data block.
@@ -96,7 +94,7 @@ class GSBFileWriter(io.BufferedWriter):
         """
         if not isinstance(data, GSBPayload):
             data = GSBPayload.fromdata(data, bps=bps)
-        return data.tofile(self)
+        return data.tofile(self.fh)
 
 
 class GSBStreamBase(VLBIStreamBase):

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -41,7 +41,7 @@ class Mark4FileReader(VLBIFileBase):
             :class:`~baseband.mark4.Mark4Header` and data encoded in the frame,
             respectively.
         """
-        return Mark4Frame.fromfile(self.fh, ntrack=ntrack, decade=decade)
+        return Mark4Frame.fromfile(self.fh_raw, ntrack=ntrack, decade=decade)
 
     def find_frame(self, ntrack, maximum=None, forward=True):
         """Look for the first occurrence of a frame, from the current position.
@@ -70,7 +70,7 @@ class Mark4FileReader(VLBIFileBase):
         -------
         offset : int
         """
-        fh = self.fh
+        fh = self.fh_raw
         nset = np.ones(32 * ntrack // 8, dtype=np.int16)
         nunset = np.ones(ntrack // 8, dtype=np.int16)
         framesize = ntrack * 2500
@@ -157,7 +157,7 @@ class Mark4FileReader(VLBIFileBase):
         offset = self.find_frame(ntrack, maximum, forward)
         if offset is None:
             return None
-        header = Mark4Header.fromfile(self.fh, ntrack=ntrack, decade=decade)
+        header = Mark4Header.fromfile(self.fh_raw, ntrack=ntrack, decade=decade)
         self.seek(offset)
         return header
 
@@ -184,7 +184,7 @@ class Mark4FileWriter(VLBIFileBase):
         """
         if not isinstance(data, Mark4Frame):
             data = Mark4Frame.fromdata(data, header, **kwargs)
-        return data.tofile(self.fh)
+        return data.tofile(self.fh_raw)
 
 
 class Mark4StreamReader(VLBIStreamReaderBase):

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -38,7 +38,7 @@ class Mark5BFileReader(VLBIFileBase):
             With ``header`` and ``data`` properties that return the
             Mark5BHeader and data encoded in the frame, respectively.
         """
-        return Mark5BFrame.fromfile(self.fh, nchan=nchan, bps=bps,
+        return Mark5BFrame.fromfile(self.fh_raw, nchan=nchan, bps=bps,
                                     ref_mjd=ref_mjd)
 
     def find_header(self, template_header=None, kday=None, framesize=None,
@@ -48,7 +48,7 @@ class Mark5BFileReader(VLBIFileBase):
         Search is from the current position.  If given, a template_header
         is used to initialize the framesize, as well as kday in the header.
         """
-        fh = self.fh
+        fh = self.fh_raw
         if template_header:
             kday = template_header.kday
             framesize = template_header.framesize
@@ -139,7 +139,7 @@ class Mark5BFileWriter(VLBIFileBase):
         if not isinstance(data, Mark5BFrame):
             data = Mark5BFrame.fromdata(data, header, bps=bps, valid=valid,
                                         **kwargs)
-        return data.tofile(self.fh)
+        return data.tofile(self.fh_raw)
 
 
 class Mark5BStreamReader(VLBIStreamReaderBase):

--- a/baseband/tests/test_sequential_baseband.py
+++ b/baseband/tests/test_sequential_baseband.py
@@ -1,0 +1,47 @@
+# Licensed under the GPLv3 - see LICENSE.rst
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+import os
+import numpy as np
+from astropy.time import Time
+from .. import vdif
+from ..helpers import sequentialfile
+from ..helpers.tests.test_sequentialfile import Sequencer
+
+
+def test_sequentialfile_vdif_stream(tmpdir):
+    vdif_sequencer = Sequencer(str(tmpdir.join('{:07d}.vdif')))
+    # try writing a very simple file, using edv=0
+    data = np.ones((16, 16, 2, 2))
+    for i, dat in enumerate(data):
+        dat[i, 0, 0] = -1.
+        dat[i, 1, 1] = -1.
+    data.shape = -1, 2, 2
+    # construct first header
+    header = vdif.VDIFHeader.fromvalues(
+        edv=0, time=Time('2010-01-01'), nchan=2, bps=2,
+        complex_data=False, frame_nr=0, thread_id=0, samples_per_frame=16,
+        station='me')
+    with sequentialfile.open(vdif_sequencer, 'wb',
+                             file_size=4*header.framesize) as sfh, vdif.open(
+            sfh, 'ws', header=header, nthread=2, frames_per_second=16) as fw:
+        fw.write(data)
+    # check that this wrote 8 frames
+    files = [vdif_sequencer[i] for i in range(8)]
+    for file_ in files:
+        assert os.path.isfile(file_)
+    assert not os.path.isfile(vdif_sequencer[8])
+
+    with sequentialfile.open(vdif_sequencer, 'rb') as sfh, vdif.open(
+            sfh, 'rs', frames_per_second=16) as fr:
+        record1 = fr.read(21)
+        assert np.all(record1 == data[:21])
+        fr.seek(7*16)
+        record2 = fr.read(61)
+        assert np.all(record2 == data[7*16:7*16+61])
+        assert fr.tell() == 7*16+61
+    # Might as well check file list too.
+    with sequentialfile.open(files, 'rb') as sfh, vdif.open(
+            sfh, 'rs', frames_per_second=16) as fr:
+        record1 = fr.read()
+        assert np.all(record1 == data)

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -65,7 +65,7 @@ class VDIFFileReader(VLBIFileBase):
     """Simple reader for VDIF files.
 
     Adds ``read_frame`` and ``read_frameset`` methods on top of a binary
-    file reader (which is wrapped as ``self.fh``).
+    file reader (which is wrapped as ``self.fh_raw``).
     """
     def read_frame(self):
         """Read a single frame (header plus payload).
@@ -77,7 +77,7 @@ class VDIFFileReader(VLBIFileBase):
             :class:`~baseband.vdif.VDIFHeader` and data encoded in the frame,
             respectively.
         """
-        return VDIFFrame.fromfile(self.fh)
+        return VDIFFrame.fromfile(self.fh_raw)
 
     def read_frameset(self, thread_ids=None, sort=True, edv=None, verify=True):
         """Read a single frame (header plus payload).
@@ -102,8 +102,8 @@ class VDIFFileReader(VLBIFileBase):
             :class:`~baseband.vdif.VDIFHeaders` and the data encoded in the
             frame set, respectively.
         """
-        return VDIFFrameSet.fromfile(self.fh, thread_ids, sort=sort, edv=edv,
-                                     verify=verify)
+        return VDIFFrameSet.fromfile(self.fh_raw, thread_ids, sort=sort,
+                                     edv=edv, verify=verify)
 
     def find_header(self, template_header=None, framesize=None, edv=None,
                     maximum=None, forward=True):
@@ -113,7 +113,7 @@ class VDIFFileReader(VLBIFileBase):
         ``template_header`` or with a header a framesize ahead.   Note that the
         latter turns out to be an unexpectedly weak check on real data!
         """
-        fh = self.fh
+        fh = self.fh_raw
         # Obtain current pointer position.
         file_pos = fh.tell()
         if template_header is not None:
@@ -210,7 +210,7 @@ class VDIFFileWriter(VLBIFileBase):
         """
         if not isinstance(data, VDIFFrame):
             data = VDIFFrame.fromdata(data, header, **kwargs)
-        return data.tofile(self.fh)
+        return data.tofile(self.fh_raw)
 
     def write_frameset(self, data, header=None, **kwargs):
         """Write a frame set (headers plus payloads).
@@ -232,7 +232,7 @@ class VDIFFileWriter(VLBIFileBase):
         """
         if not isinstance(data, VDIFFrameSet):
             data = VDIFFrameSet.fromdata(data, header, **kwargs)
-        return data.tofile(self.fh)
+        return data.tofile(self.fh_raw)
 
 
 class VDIFStreamBase(VLBIStreamBase):

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -26,6 +26,7 @@ class VLBIFileBase(object):
                 return getattr(self.fh_raw, attr)
             except AttributeError:
                 pass
+        #  __getattribute__ to raise appropriate error.
         return self.__getattribute__(attr)
 
     def __enter__(self):
@@ -33,7 +34,6 @@ class VLBIFileBase(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
-        self.fh_raw.__exit__(exc_type, exc_val, exc_tb)
 
     def close(self):
         self.fh_raw.close()
@@ -111,10 +111,6 @@ class VLBIStreamBase(VLBIFileBase):
         full_frame_nr, extra = divmod(offset, self.samples_per_frame)
         dt, frame_nr = divmod(full_frame_nr, self.frames_per_second)
         return int(dt), int(frame_nr), extra
-
-    def __enter__(self):
-        super(VLBIStreamBase, self).__enter__()
-        return self
 
     def __repr__(self):
         return ("<{s.__class__.__name__} name={s.name} offset={s.offset}\n"

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -10,6 +10,35 @@ __all__ = ['u_sample', 'VLBIStreamBase', 'VLBIStreamReaderBase',
 u_sample = u.def_unit('sample', doc='One sample from a data stream')
 
 
+class VLBIFileBase(object):
+    """VLBI file wrapper, used to add frame methods to a binary data file.
+
+    The underlying file is stored in ``fh`` and all attributes that do not
+    exist on the class itself are looked up on it.
+    """
+    def __init__(self, fh):
+        self.fh = fh
+
+    def __getattr__(self, attr):
+        """Try to get things on the current open file if it is not on self."""
+        if not attr.startswith('_'):
+            try:
+                return getattr(self.fh, attr)
+            except AttributeError:
+                pass
+        return self.__getattribute__(attr)
+
+    def __enter__(self):
+        self.fh.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.fh.__exit__(exc_type, exc_val, exc_tb)
+
+    def __repr__(self):
+        return "{0}(fh={1})".format(self.__class__.__name__, self.fh)
+
+
 class VLBIStreamBase(object):
     """VLBI file wrapper, allowing access as a stream of data."""
 

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -16,27 +16,27 @@ class VLBIFileBase(object):
     The underlying file is stored in ``fh`` and all attributes that do not
     exist on the class itself are looked up on it.
     """
-    def __init__(self, fh):
-        self.fh = fh
+    def __init__(self, fh_raw):
+        self.fh_raw = fh_raw
 
     def __getattr__(self, attr):
         """Try to get things on the current open file if it is not on self."""
         if not attr.startswith('_'):
             try:
-                return getattr(self.fh, attr)
+                return getattr(self.fh_raw, attr)
             except AttributeError:
                 pass
         return self.__getattribute__(attr)
 
     def __enter__(self):
-        self.fh.__enter__()
+        self.fh_raw.__enter__()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.fh.__exit__(exc_type, exc_val, exc_tb)
+        self.fh_raw.__exit__(exc_type, exc_val, exc_tb)
 
     def __repr__(self):
-        return "{0}(fh={1})".format(self.__class__.__name__, self.fh)
+        return "{0}(fh_raw={1})".format(self.__class__.__name__, self.fh_raw)
 
 
 class VLBIStreamBase(object):


### PR DESCRIPTION
This means that the filehandle that is wrapped no longer has to be a io.FileIO instance, but can also be, e.g., a SequentialFile.

@cczhu - I think this makes at least the file readers simpler. I now also wonder if the stream readers can become subclasses of these, so that they simply have the `read_frame` methods, etc. (of course, also still possible to remove the binary file readers altogether). Also, in principle, the `read_frame` methods are just syntactic sugar on top of `<type>Frame.fromfile(self.fh, *args, **kwargs)`, so possibly a meta-class could initialize these...

Anyway, not completely sure this is the final answer, but it seems better than the subclassing of `io.BufferedReader/Writer/Random` that I had before (even if it must be slightly slower because of the indirection in attribute getting; see the base class in `vlbi_base/base.by`)