### PR TITLE
Incorporated fix for VDIFFileReader.find_header to seek…

### DIFF
--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -113,6 +113,10 @@ class VDIFFileReader(io.BufferedReader):
         ``template_header`` or with a header a framesize ahead.   Note that the
         latter turns out to be an unexpectedly weak check on real data!
         """
+
+        # Obtain current pointer position.
+        file_pos = self.tell()
+
         if template_header is not None:
             edv = template_header.edv
             # First check whether we are right at a frame marker (often true).
@@ -122,20 +126,21 @@ class VDIFFileReader(io.BufferedReader):
                 pass
             else:
                 if template_header.same_stream(header):
-                    self.seek(-header.size, 1)
+                    self.seek(file_pos)
                     return header
-            # Didn't work, so get searching.
+            # If we're not at frame marker, obtain framesize and get searching.
             framesize = template_header.framesize
 
         if maximum is None:
             maximum = 2 * framesize
 
-        file_pos = self.tell()
+        # Determine file size.
         self.seek(0, 2)
         size = self.tell()
+        # Generate file pointer positions to test.
         if forward:
-            iterate = range(file_pos, min(file_pos + maximum - 32,
-                                          size - framesize))
+            iterate = range(file_pos, min(file_pos + maximum - 31,
+                                          size - framesize + 1))
         else:
             iterate = range(min(file_pos, size - framesize),
                             max(file_pos - maximum, -1), -1)


### PR DESCRIPTION
… headers offset by less than 32 bytes (16 for legacy) from file pointer start position.  The old code would attempt to read the header, but only rewind the file pointer if a header was found.  This means that if we started (for whatever reason) the file header 8 bytes before the start of the next header, the code would read at least 16 bytes, completely skipping over the next header.

The second fix makes it possible to reach the first byte of the last frame of the file (range doesn't include the end number in the generator).