### PR TITLE
Ensure mark4 reader works on big-endian systems like BGQ.

### DIFF
--- a/baseband/mark4/header.py
+++ b/baseband/mark4/header.py
@@ -19,6 +19,12 @@ from ..vlbi_base.utils import bcd_decode, bcd_encode, CRC
 __all__ = ['stream2words', 'words2stream', 'Mark4TrackHeader', 'Mark4Header']
 
 
+MARK4_DTYPES = {8: 'u1',
+                16: '<u2',
+                32: '<u4',
+                64: '<u8'}
+"""Integer dtype used to encode a given number of tracks."""
+
 PAYLOADSIZE = 20000
 """Number of bits per track per frame."""
 
@@ -67,7 +73,7 @@ def words2stream(words):
         For each int, every bit corresponds to a particular track.
     """
     ntrack = words.shape[1]
-    dtype = Mark4Header._dtypes[ntrack]
+    dtype = MARK4_DTYPES[ntrack]
     nbits = words.dtype.itemsize * 8
     bit = np.arange(nbits-1, -1, -1, dtype=words.dtype).reshape(-1, 1)
 
@@ -240,13 +246,7 @@ class Mark4Header(Mark4TrackHeader):
     _properties = (Mark4TrackHeader._properties +
                    ('ntrack', 'framesize', 'payloadsize', 'fanout',
                     'samples_per_frame', 'bps', 'nchan'))
-    _dtypes = {1: 'b',
-               2: 'u1',
-               4: 'u1',
-               8: 'u1',
-               16: '<u2',
-               32: '<u4',
-               64: '<u8'}
+    _dtypes = MARK4_DTYPES
 
     def __init__(self, words, ntrack=None, decade=None, verify=True):
         if words is None:

--- a/baseband/mark4/payload.py
+++ b/baseband/mark4/payload.py
@@ -13,6 +13,7 @@ import sys
 import numpy as np
 from ..vlbi_base.payload import VLBIPayloadBase
 from ..vlbi_base.encoding import encode_2bit_base, decoder_levels
+from .header import MARK4_DTYPES
 
 
 __all__ = ['reorder32', 'reorder64', 'init_luts', 'decode_8chan_2bit_fanout4',
@@ -199,8 +200,7 @@ class Mark4Payload(VLBIPayloadBase):
     The total number of tracks is `nchan` * `bps` * `fanout`.
     """
 
-    # Ensure that words can hold up to maximum number of channels.
-    _dtype_word = np.dtype('<u8')
+    _dtype_word = None
     # Decoders keyed by (nchan, nbit, fanout).
     _encoders = {(4, 2, 4): encode_4chan_2bit_fanout4,
                  (8, 2, 2): encode_8chan_2bit_fanout2,
@@ -215,6 +215,7 @@ class Mark4Payload(VLBIPayloadBase):
             bps = header.bps
             fanout = header.fanout
             self._size = header.payloadsize
+        self._dtype_word = MARK4_DTYPES[nchan * bps * fanout]
         self.fanout = fanout
         super(Mark4Payload, self).__init__(words, bps=bps,
                                            sample_shape=(nchan,),

--- a/baseband/mark4/payload.py
+++ b/baseband/mark4/payload.py
@@ -100,7 +100,7 @@ def decode_4chan_2bit_fanout4(frame):
     """Decode payload for 4 channels using 2 bits, fan-out 4 (32 tracks)."""
     # Bitwise reordering of tracks, to align sign and magnitude bits,
     # reshaping to get VLBI channels in sequential, but wrong order.
-    frame = reorder32(frame).view(np.uint8).reshape(-1, 4)
+    frame = reorder32(frame.view(np.uint32)).view(np.uint8).reshape(-1, 4)
     # Correct ordering.
     frame = frame.take(np.array([0, 2, 1, 3]), axis=1)
     # The look-up table splits each data byte into 4 measurements.
@@ -119,7 +119,7 @@ def encode_4chan_2bit_fanout4(values):
     reorder_bits.take(bitvalues, out=bitvalues)
     bitvalues <<= np.array([0, 2, 4, 6], dtype=np.uint8)
     out = np.bitwise_or.reduce(bitvalues, axis=-1).ravel().view(np.uint32)
-    return reorder32(out)
+    return reorder32(out).view('<u4')
 
 
 def decode_8chan_2bit_fanout2(frame):
@@ -157,7 +157,7 @@ def decode_8chan_2bit_fanout4(frame):
     """Decode payload for 8 channels using 2 bits, fan-out 4 (64 tracks)."""
     # Bitwise reordering of tracks, to align sign and magnitude bits,
     # reshaping to get VLBI channels in sequential, but wrong order.
-    frame = reorder64(frame).view(np.uint8).reshape(-1, 8)
+    frame = reorder64(frame.view(np.uint64)).view(np.uint8).reshape(-1, 8)
     # Correct ordering.
     frame = frame.take(np.array([0, 2, 1, 3, 4, 6, 5, 7]), axis=1)
     # The look-up table splits each data byte into 4 measurements.
@@ -176,7 +176,7 @@ def encode_8chan_2bit_fanout4(values):
     reorder_bits.take(bitvalues, out=bitvalues)
     bitvalues <<= np.array([0, 2, 4, 6], dtype=np.uint8)
     out = np.bitwise_or.reduce(bitvalues, axis=-1).ravel().view(np.uint64)
-    return reorder64(out)
+    return reorder64(out).view('<u8')
 
 
 class Mark4Payload(VLBIPayloadBase):

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -220,6 +220,8 @@ class TestMark4(object):
                 mark4.Mark4Payload.fromfile(s, header)
         payload3 = mark4.Mark4Payload.fromdata(payload.data, header)
         assert payload3 == payload
+        payload4 = mark4.Mark4Payload(payload.words, nchan=8, bps=2, fanout=4)
+        assert payload4 == payload
         with pytest.raises(ValueError):
             # Wrong number of channels.
             mark4.Mark4Payload.fromdata(np.empty((payload.shape[0], 2)),
@@ -232,6 +234,15 @@ class TestMark4(object):
             # Wrong data type
             mark4.Mark4Payload.fromdata(np.zeros((5000, 8), np.complex64),
                                         header)
+        with pytest.raises(ValueError):
+            # Wrong encoded data type for implied number of tracks of 32.
+            mark4.Mark4Payload(payload.words, nchan=4, bps=2, fanout=4)
+        with pytest.raises(ValueError):
+            # Not little-endian encoded data.
+            mark4.Mark4Payload(payload.words.astype('>u8'), header)
+        with pytest.raises(ValueError):
+            # Wrong number of tracks in encoded data.
+            mark4.Mark4Payload(payload.words.view('<u4'), header)
 
     @pytest.mark.parametrize('item', (2, (), -1, slice(1, 3), slice(2, 4),
                                       slice(2, 4), slice(-3, None),

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -47,7 +47,7 @@ class TestMark4(object):
     def test_header_stream(self):
         with open(SAMPLE_FILE, 'rb') as fh:
             fh.seek(0xa88)
-            stream = np.fromfile(fh, dtype=np.uint64, count=5 * 32)
+            stream = np.fromfile(fh, dtype='<u8', count=5 * 32)
         # check sync words in right place
         assert np.all(stream[64:80] == 0xffffffffffffffff)
         assert mark4.header.crc12.check(stream)
@@ -190,10 +190,10 @@ class TestMark4(object):
 
     def test_payload_reorder(self):
         """Test that bit reordering is consistent with mark5access."""
-        check = np.array([738811025863578102], dtype=np.uint64)
-        expected = np.array([118, 209, 53, 244, 148, 217, 64, 10], np.uint8)
+        check = np.array([738811025863578102], dtype='<u8').view('u8')
+        expected = np.array([118, 209, 53, 244, 148, 217, 64, 10])
         assert np.all(reorder64(check).view(np.uint8) == expected)
-        assert np.all(reorder32(check.view(np.uint32)).view(np.uint8) ==
+        assert np.all(reorder32(check.view('u4')).view(np.uint8) ==
                       expected)
 
     def test_payload(self):

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -203,7 +203,7 @@ class TestVDIF(object):
         assert np.all(-vdif.payload.lut4bit[0x11] ==
                       vdif.payload.lut4bit[0xff])
         aint = np.arange(0, 256, dtype=np.uint8)
-        words = aint.view(np.uint32)
+        words = aint.view('<u4')
         areal = np.linspace(-127.5, 127.5, 256).reshape(-1, 1) / 35.5
         acmplx = areal[::2] + 1j * areal[1::2]
         payload1 = vdif.VDIFPayload(words, bps=8, complex_data=False)

--- a/baseband/vlbi_base/payload.py
+++ b/baseband/vlbi_base/payload.py
@@ -55,6 +55,9 @@ class VLBIPayloadBase(object):
         if self._size is not None and self._size != self.size:
             raise ValueError("Encoded data should have length {0}"
                              .format(self._size))
+        if words.dtype != self._dtype_word:
+            raise ValueError("Encoded data should have dtype {0}"
+                             .format(self._dtype_word))
 
     @classmethod
     def fromfile(cls, fh, *args, **kwargs):

--- a/baseband/vlbi_base/tests/test_vlbi_base.py
+++ b/baseband/vlbi_base/tests/test_vlbi_base.py
@@ -203,6 +203,8 @@ class TestVLBIBase(object):
         payload = self.Payload(self.payload.words, bps=4)
         with pytest.raises(KeyError):
             payload.data
+        with pytest.raises(ValueError):
+            self.Payload(self.payload.words.astype('>u4'), bps=4)
         payload = self.Payload(self.payload.words, bps=8, complex_data=True)
         assert np.all(payload.data ==
                       self.payload.data[:, 0] + 1j * self.payload.data[:, 1])

--- a/baseband/vlbi_base/utils.py
+++ b/baseband/vlbi_base/utils.py
@@ -12,7 +12,7 @@ def bcd_decode(value):
         if not isinstance(value, np.ndarray):
             raise ValueError("Invalid BCD encoded value {0}={1}."
                              .format(value, hex(value)))
-    except:  # Might still be an array (newer python versions)
+    except TypeError:  # Might still be an array (newer python versions)
         if not isinstance(value, np.ndarray):
             raise
 
@@ -36,7 +36,7 @@ def bcd_encode(value):
     try:
         # Far faster than my routine for scalars
         return int('{:d}'.format(value), base=16)
-    except:  # Maybe an array?
+    except Exception:  # Maybe an array?
         if not isinstance(value, np.ndarray):
             raise
 


### PR DESCRIPTION
@theXYZT - could you check whether this fixes things? It seems mostly OK in my testing, but I've not done everything since for some reason pytest is not behaving.

cc @cczhu - since this is endianness in practice (what a mess...).