### PR TITLE
Fixed small issue where a VDIFFrameSet instance vfs.header0…

### DIFF
--- a/baseband/vdif/frame.py
+++ b/baseband/vdif/frame.py
@@ -259,6 +259,7 @@ class VDIFFrameSet(object):
 
         if sort:
             frames.sort(key=lambda frame: frame['thread_id'])
+            header0 = frames[0].header
 
         return cls(frames, header0)
 


### PR DESCRIPTION
...doesn't correspond to the header with thread_id = 0.  Not sure if this was intentional or not, but it prevents frame sets read in from file from being identical to the same frame sets generated from bulk data, or user-initialized.