### PR TITLE
Added automodapi flag to conf.py to include inherited members in docs…

### DIFF
--- a/baseband/mark4/header.py
+++ b/baseband/mark4/header.py
@@ -16,7 +16,8 @@ from astropy.extern import six
 from ..vlbi_base.header import HeaderParser, VLBIHeaderBase
 from ..vlbi_base.utils import bcd_decode, bcd_encode, CRC
 
-__all__ = ['stream2words', 'words2stream', 'Mark4TrackHeader', 'Mark4Header']
+__all__ = ['CRC12', 'crc12', 'stream2words', 'words2stream', 
+           'Mark4TrackHeader', 'Mark4Header']
 
 
 MARK4_DTYPES = {8: 'u1',

--- a/baseband/vdif/frame.py
+++ b/baseband/vdif/frame.py
@@ -38,7 +38,9 @@ class VDIFFrame(VLBIFrameBase):
         (e.g., that channel information and whether or not data are complex
         are consistent between header and data).  Default: `True`
 
-    The Frame can also be read instantiated using class methods:
+    Notes
+    -----
+    The Frame can also be instantiated using class methods:
 
       fromfile : read header and payload from a filehandle
 

--- a/baseband/vlbi_base/frame.py
+++ b/baseband/vlbi_base/frame.py
@@ -30,7 +30,6 @@ class VLBIFrameBase(object):
 
     Notes
     -----
-
     The Frame can also be instantiated using class methods:
 
       fromfile : read header and payload from a filehandle

--- a/docs/baseband/mark4/index.rst
+++ b/docs/baseband/mark4/index.rst
@@ -9,6 +9,7 @@ Reference/API
 
 .. automodapi:: baseband.mark4
 .. automodapi:: baseband.mark4.header
+   :include-all-objects:
 .. automodapi:: baseband.mark4.payload
 .. automodapi:: baseband.mark4.frame
 .. automodapi:: baseband.mark4.base

--- a/docs/baseband/mark5b/index.rst
+++ b/docs/baseband/mark5b/index.rst
@@ -9,6 +9,7 @@ Reference/API
 
 .. automodapi:: baseband.mark5b
 .. automodapi:: baseband.mark5b.header
+   :include-all-objects:
 .. automodapi:: baseband.mark5b.payload
 .. automodapi:: baseband.mark5b.frame
 .. automodapi:: baseband.mark5b.base

--- a/docs/baseband/vlbi_base/index.rst
+++ b/docs/baseband/vlbi_base/index.rst
@@ -16,4 +16,6 @@ Reference/API
 .. automodapi:: baseband.vlbi_base.frame
 .. automodapi:: baseband.vlbi_base.base
 .. automodapi:: baseband.vlbi_base.encoding
+   :include-all-objects:
 .. automodapi:: baseband.vlbi_base.utils
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -177,3 +177,6 @@ if eval(setup_cfg.get('edit_on_github')):
 # -- Resolving issue number to links in changelog -----------------------------
 github_issues_url = 'https://github.com/{0}/issues/'.format(setup_cfg['github_project'])
 
+
+# -- Include inherited members in class documentation -------------------------
+automodsumm_inherited_members = True


### PR DESCRIPTION
... and flags to .rst files to include all objects. Fixed formatting issue with baseband/vdif/frame.py docstring.  Changed `baseband.mark4.header.__all__()` to include `CRC12`, `crc12` to be consistent with `baseband.mark5b.header.__all__()`.


