### PR TITLE
Auto opener

### DIFF
--- a/baseband/helpers/tests/test_sequentialfile.py
+++ b/baseband/helpers/tests/test_sequentialfile.py
@@ -45,8 +45,15 @@ class TestSequentialFileReader(object):
         assert fh.seekable()
         assert not fh.writable()
         assert not fh.closed
+        assert repr(fh).startswith('SequentialFileReader(files=')
         fh.close()
         assert fh.closed
+        with pytest.raises(ValueError):
+            # wrong mode: no r or w
+            sf.open(self.files, 'b')
+        with pytest.raises(TypeError):
+            # cannot pass in file_size for reading
+            sf.open(self.files, 'rb', file_size=10)
 
     def test_context(self):
         with sf.open(self.files) as fh:
@@ -63,6 +70,8 @@ class TestSequentialFileReader(object):
             assert fh.size == self.size
             assert fh._file_sizes == self.sizes
             assert fh._file_offsets == self.offsets
+            with pytest.raises(AttributeError):
+                fh.bla
 
     def test_seek(self):
         with sf.open(self.files) as fh:
@@ -143,7 +152,7 @@ class TestSequentialFileReader(object):
                 fh.memmap(offset=7, shape=(5,))
             offset = self.offsets[1]
             fh.seek(offset)
-            mm = fh.memmap(shape=(5,))
+            mm = fh.memmap(shape=5)
             assert (mm == self.uint8_data[offset:offset+5]).all()
             fh.seek(-2, 2)
             mm = fh.memmap()

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -1,9 +1,7 @@
 # Licensed under the GPLv3 - see LICENSE.rst
-import io
-
 import numpy as np
 
-from ..vlbi_base.base import (VLBIFileBase,
+from ..vlbi_base.base import (make_opener, VLBIFileBase,
                               VLBIStreamReaderBase, VLBIStreamWriterBase)
 from .header import Mark4Header
 from .frame import Mark4Frame
@@ -373,71 +371,38 @@ class Mark4StreamWriter(VLBIStreamWriterBase, Mark4FileWriter):
             count -= nsample
 
 
-def open(name, mode='rs', **kwargs):
-    """Open VLBI Mark 4 format file for reading or writing.
+open = make_opener('Mark4', globals(), doc="""
+--- For reading a stream : (see `~baseband.mark4.base.Mark4StreamReader`)
 
-    Opened as a binary file, one gets a standard file handle, but with
-    methods to read/write a frame.  Opened as a stream, the file handler
-    is wrapped, allowing access to it as a series of samples.
+ntrack : int
+    Number of tracks used to store the data.
+thread_ids: list of int, optional
+    Specific threads/channels to read.  By default, all are read.
+frames_per_second : int, optional
+    Needed to calculate timestamps. If not given, will be inferred from
+    ``sample_rate``, or by scanning the file.
+sample_rate : `~astropy.units.Quantity`, optional
+    Rate at which each thread is sampled (bandwidth * 2; frequency units).
 
-    Parameters
-    ----------
-    name : str
-        File name
-    mode : {'rb', 'wb', 'rs', or 'ws'}, optional
-        Whether to open for reading or writing, and as a regular binary file
-        or as a stream (default is reading a stream).
-    **kwargs
-        Additional arguments when opening the file as a stream
+--- For writing a stream : (see `~baseband.mark4.base.Mark4StreamWriter`)
 
-    --- For reading a stream : (see `~baseband.mark4.base.Mark4StreamReader`)
+frames_per_second : int, optional
+    Needed to calculate timestamps. If not given, inferred from
+    ``sample_rate``.
+sample_rate : `~astropy.units.Quantity`, optional
+    Rate at which each thread is sampled (bandwidth * 2; frequency units).
+header : `~baseband.mark4.Mark4Header`
+    Header for the first frame, holding time information, etc.
+**kwargs
+    If the header is not given, an attempt will be made to construct one
+    with any further keyword arguments.  See
+    :class:`~baseband.mark4.base.Mark4StreamWriter`.
 
-    ntrack : int
-        Number of tracks used to store the data.
-    thread_ids: list of int, optional
-        Specific threads/channels to read.  By default, all are read.
-    frames_per_second : int, optional
-        Needed to calculate timestamps. If not given, will be inferred from
-        ``sample_rate``, or by scanning the file.
-    sample_rate : `~astropy.units.Quantity`, optional
-        Rate at which each thread is sampled (bandwidth * 2; frequency units).
-
-    --- For writing a stream : (see `~baseband.mark4.base.Mark4StreamWriter`)
-
-    frames_per_second : int, optional
-        Needed to calculate timestamps. If not given, inferred from
-        ``sample_rate``.
-    sample_rate : `~astropy.units.Quantity`, optional
-        Rate at which each thread is sampled (bandwidth * 2; frequency units).
-    header : `~baseband.mark4.Mark4Header`
-        Header for the first frame, holding time information, etc.
-    **kwargs
-        If the header is not given, an attempt will be made to construct one
-        with any further keyword arguments.  See
-        :class:`~baseband.mark4.base.Mark4StreamWriter`.
-
-    Returns
-    -------
-    Filehandle
-        :class:`~baseband.mark4.base.Mark4FileReader` or
-        :class:`~baseband.mark4.base.Mark4FileWriter` instance (binary), or
-        :class:`~baseband.mark4.base.Mark4StreamReader` or
-        :class:`~baseband.mark4.base.Mark4StreamWriter` instance (stream)
-    """
-    if 'w' in mode:
-        if not hasattr(name, 'write'):
-            name = io.open(name, 'wb')
-        if 'b' in mode:
-            return Mark4FileWriter(name)
-        else:
-            return Mark4StreamWriter(name, **kwargs)
-    elif 'r' in mode:
-        if not hasattr(name, 'read'):
-            name = io.open(name, 'rb')
-        if 'b' in mode:
-            return Mark4FileReader(name)
-        else:
-            return Mark4StreamReader(name, **kwargs)
-    else:
-        raise ValueError("Only support opening Mark 4 file for reading "
-                         "or writing (mode='r' or 'w').")
+Returns
+-------
+Filehandle
+    :class:`~baseband.mark4.base.Mark4FileReader` or
+    :class:`~baseband.mark4.base.Mark4FileWriter` instance (binary), or
+    :class:`~baseband.mark4.base.Mark4StreamReader` or
+    :class:`~baseband.mark4.base.Mark4StreamWriter` instance (stream)
+""")

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -564,8 +564,12 @@ class TestVDIF(object):
                 with pytest.raises(ValueError):
                     f2.header1
 
-    def test_stream_invalid(self):
+    def test_io_invalid(self):
+        with pytest.raises(TypeError):
+            # extra argument
+            vdif.open('ts.dat', 'rb', bla=10)
         with pytest.raises(ValueError):
+            # missing w or r
             vdif.open('ts.dat', 's')
 
 


### PR DESCRIPTION
This removes duplicated code in the many definitions of `open`. As a result, it also ensures that in all openers, files that were opened in the process of setting up a stream reader are correctly closed if the setup fails.