### PR TITLE
Modified VLBIStreamReaderBase to pass header instance rather than ...

### DIFF
--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -233,10 +233,25 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
     def _get_frame_rate(fh, header_template):
         """Returns the number of frames in one second of data.
 
+        Parameters
+        ----------
+        fh : io.BufferedReader
+            Binary file handle.
+        header_template : header class or instance
+            Definition or instance of file format's header class.
+
+        Returns
+        -------
+        fps : int
+            Frames per second.
+
+        Notes
+        -----
+
         Unlike VLBIStreamReaderBase._get_frame_rate, this function reads
-        only two frames, extracting the timestamps from each to determine
-        how much time has passed between frames.  If the function fails,
-        it is either because only one frame exists or file is corrupt.
+        only two consecutive frames, extracting their timestamps to determine
+        how much time has elapsed.  It will return an EOFError if there is
+        only one frame.
         """
         oldpos = fh.tell()
         header0 = header_template.fromfile(fh, header_template.ntrack,

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -229,6 +229,27 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
             samples_per_frame=header.samples_per_frame,
             frames_per_second=frames_per_second, sample_rate=sample_rate)
 
+    @staticmethod
+    def _get_frame_rate(fh, header_template):
+        """Returns the number of frames in one second of data.
+
+        Unlike VLBIStreamReaderBase._get_frame_rate, this function reads
+        only two frames, extracting the timestamps from each to determine
+        how much time has passed between frames.  If the function fails,
+        it is either because only one frame exists or file is corrupt.
+        """
+        oldpos = fh.tell()
+        header0 = header_template.fromfile(fh, header_template.ntrack,
+                                           decade=header_template.decade)
+        fh.seek(header0.payloadsize, 1)
+        header1 = header_template.fromfile(fh, header_template.ntrack,
+                                           decade=header_template.decade)
+        fh.seek(oldpos)
+        # Mark 4 specification states frames-lengths range from 1.25 ms
+        # to 160 ms.
+        tdelta = header1.ms[0] - header0.ms[0]
+        return int(np.round(1000. / tdelta))
+
     def read(self, count=None, fill_value=0., squeeze=True, out=None):
         """Read count samples.
 

--- a/baseband/mark4/header.py
+++ b/baseband/mark4/header.py
@@ -389,10 +389,12 @@ class Mark4Header(Mark4TrackHeader):
 
     @property
     def size(self):
+        """Header size, in bytes."""
         return self.ntrack * 160 // 8
 
     @property
     def framesize(self):
+        """Frame size, in bytes."""
         return self.ntrack * PAYLOADSIZE // 8
 
     @framesize.setter
@@ -402,7 +404,7 @@ class Mark4Header(Mark4TrackHeader):
 
     @property
     def payloadsize(self):
-        """Payloadsize; missing pieces are the header bytes."""
+        """Payload size, in bytes; missing pieces are the header bytes."""
         return self.framesize - self.size
 
     @payloadsize.setter

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -448,19 +448,14 @@ class TestMark4(object):
         assert not np.any(record2[1] == 0.)
         assert np.all(record3 == record2)
 
-        # Test _get_frame_rate automatic frame rate calculator works, and
+        # Test if _get_frame_rate automatic frame rate calculator works,
         # returns same header and payload info.
         with mark4.open(SAMPLE_FILE, 'rs', ntrack=64, decade=2010) as fh:
             assert header == fh.header0
             assert fh.frames_per_second * fh.samples_per_frame == 32000000
-            record = fh.read(642)
+            record4 = fh.read(642)
 
-        assert record.shape == (642, 8)
-        assert np.all(record[:640] == 0.)
-        assert np.all(record.astype(int)[640] ==
-                      np.array([-1, +1, +1, -3, -3, -3, +1, -1]))
-        assert np.all(record.astype(int)[641] ==
-                      np.array([+1, +1, -3, +1, +1, -3, -1, -1]))
+        assert np.all(record4 == record)
 
         with mark4.open(SAMPLE_FILE, 'rs', ntrack=64, decade=2010,
                         sample_rate=32*u.MHz) as fh:

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -448,6 +448,20 @@ class TestMark4(object):
         assert not np.any(record2[1] == 0.)
         assert np.all(record3 == record2)
 
+        # Test _get_frame_rate automatic frame rate calculator works, and
+        # returns same header and payload info.
+        with mark4.open(SAMPLE_FILE, 'rs', ntrack=64, decade=2010) as fh:
+            assert header == fh.header0
+            assert fh.frames_per_second * fh.samples_per_frame == 32000000
+            record = fh.read(642)
+
+        assert record.shape == (642, 8)
+        assert np.all(record[:640] == 0.)
+        assert np.all(record.astype(int)[640] ==
+                      np.array([-1, +1, +1, -3, -3, -3, +1, -1]))
+        assert np.all(record.astype(int)[641] ==
+                      np.array([+1, +1, -3, +1, +1, -3, -1, -1]))
+
         with mark4.open(SAMPLE_FILE, 'rs', ntrack=64, decade=2010,
                         sample_rate=32*u.MHz) as fh:
             time0 = fh.tell(unit='time')

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -134,10 +134,10 @@ class VLBIStreamReaderBase(VLBIStreamBase):
                                                          header0)
             except Exception as exc:
                 exc.args += ("The frame rate could not be auto-detected. "
-                             "This can happen if the file has less than "
-                             "one second of data, is in Mark 4 format and "
-                             "has only one frame, or because it is corrupted. "
-                             "Try passing in an explicit 'frames_per_second'.",)
+                             "This can happen if the file is too short to "
+                             "determine the frame rate, or because it is "
+                             "corrupted.  Try passing in an explicit "
+                             "'frames_per_second'.",)
                 raise
 
         super(VLBIStreamReaderBase, self).__init__(
@@ -147,6 +147,21 @@ class VLBIStreamReaderBase(VLBIStreamBase):
     @staticmethod
     def _get_frame_rate(fh, header_template):
         """Returns the number of frames in one second of data.
+
+        Parameters
+        ----------
+        fh : io.BufferedReader
+            Binary file handle.
+        header_template : header class or instance
+            Definition or instance of file format's header class.
+
+        Returns
+        -------
+        fps : int
+            Frames per second.
+
+        Notes
+        -----
 
         The function cycles through headers, starting from the file
         pointer's current position, to find the next frame whose


### PR DESCRIPTION
... class to `_get_frame_rate`, and changed names in `_get_frame_rate` to reflect this.  Created `_get_frame_rate` specific to Mark 4 which takes advantage of header time code.