### PR TITLE
Added named tuple sample shapes to all formats

### DIFF
--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -6,7 +6,6 @@ import re
 import numpy as np
 from astropy.extern import six
 from astropy.utils import lazyproperty
-from collections import namedtuple
 
 from ..helpers import sequentialfile as sf
 from ..vlbi_base.base import (make_opener, VLBIFileBase, VLBIStreamBase,

--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -252,8 +252,8 @@ class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase, DADAFileReader):
         -------
         out : array of float or complex
             Dimensions are (sample-time, thread (polarization), channel), with
-            dimensions of length unity possibly removed (if ``squeeze`` is
-            `True`).
+            dimensions of length unity possibly removed if the file
+            was opened with ``squeeze=True`` (which is the default).
         """
         if out is None:
             if count is None or count < 0:
@@ -308,7 +308,7 @@ class DADAStreamWriter(DADAStreamBase, VLBIStreamWriterBase, DADAFileWriter):
     header : :class:`~baseband.dada.DADAHeader`
         Header for the file, holding time information, etc.
     squeeze : bool, optional
-        If `True` (default), `write` accepts squeezed arrays as input,
+        If `True` (default), ``write`` accepts squeezed arrays as input,
         and adds channel and thread dimensions if unity.
     """
     def __init__(self, fh_raw, header, squeeze=True):
@@ -382,7 +382,7 @@ squeeze : bool, optional
 header : `~baseband.dada.DADAHeader`, optional
     Header for the first frame, holding time information, etc.
 squeeze : bool, optional
-    If `True` (default), `write` accepts squeezed arrays as input,
+    If `True` (default), ``write`` accepts squeezed arrays as input,
     and adds channel and thread dimensions if unity.
 **kwargs
     If the header is not given, an attempt will be made to construct one

--- a/baseband/dada/payload.py
+++ b/baseband/dada/payload.py
@@ -43,7 +43,7 @@ class DADAPayload(VLBIPayloadBase):
     _encoders = {
         8: encode_8bit}
 
-    _sample_shape_cls = namedtuple('sample_shape', 'npol, nchan')
+    _sample_shape_cls = namedtuple('SampleShape', 'npol, nchan')
 
     def __init__(self, words, header=None, bps=8, sample_shape=(),
                  complex_data=False):
@@ -97,20 +97,3 @@ class DADAPayload(VLBIPayloadBase):
                               else (payloadsize // cls._dtype_word.itemsize,))
             fh.seek(offset + words.size * words.dtype.itemsize)
         return cls(words, header=header, **kwargs)
-
-    @classmethod
-    def fromdata(cls, data, bps=2):
-        """Encode data as payload.
-
-        Parameters
-        ----------
-        data : `numpy.ndarray`
-            Data to be encoded. The last dimension is taken as the number of
-            channels.
-        bps : int
-            Number of bits per sample to use (for complex data, for real and
-            imaginary part separately; default: 2).
-        """
-        payload = super(DADAPayload, cls).fromdata(data, bps=bps)
-        payload.sample_shape = cls._sample_shape_cls(*data.shape[1:])
-        return payload

--- a/baseband/dada/payload.py
+++ b/baseband/dada/payload.py
@@ -44,7 +44,6 @@ class DADAPayload(VLBIPayloadBase):
         8: encode_8bit}
 
     _sample_shape_cls = namedtuple('sample_shape', 'npol, nchan')
-    _sample_shape_cls.__doc__ = "DADA sample shape."
 
     def __init__(self, words, header=None, bps=8, sample_shape=(),
                  complex_data=False):
@@ -98,3 +97,20 @@ class DADAPayload(VLBIPayloadBase):
                               else (payloadsize // cls._dtype_word.itemsize,))
             fh.seek(offset + words.size * words.dtype.itemsize)
         return cls(words, header=header, **kwargs)
+
+    @classmethod
+    def fromdata(cls, data, bps=2):
+        """Encode data as payload.
+
+        Parameters
+        ----------
+        data : `numpy.ndarray`
+            Data to be encoded. The last dimension is taken as the number of
+            channels.
+        bps : int
+            Number of bits per sample to use (for complex data, for real and
+            imaginary part separately; default: 2).
+        """
+        payload = super(DADAPayload, cls).fromdata(data, bps=bps)
+        payload.sample_shape = cls._sample_shape_cls(*data.shape[1:])
+        return payload

--- a/baseband/dada/payload.py
+++ b/baseband/dada/payload.py
@@ -3,6 +3,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import numpy as np
+from collections import namedtuple
 
 from ..vlbi_base.payload import VLBIPayloadBase
 
@@ -42,12 +43,16 @@ class DADAPayload(VLBIPayloadBase):
     _encoders = {
         8: encode_8bit}
 
+    _sample_shape_cls = namedtuple('sample_shape', 'npol, nchan')
+    _sample_shape_cls.__doc__ = "DADA sample shape."
+
     def __init__(self, words, header=None, bps=8, sample_shape=(),
                  complex_data=False):
         if header is not None:
             bps = header.bps
             sample_shape = header.sample_shape
             complex_data = header.complex_data
+        sample_shape = self._sample_shape_cls(*sample_shape)
         super(DADAPayload, self).__init__(words, sample_shape=sample_shape,
                                           bps=bps, complex_data=complex_data)
 

--- a/baseband/dada/payload.py
+++ b/baseband/dada/payload.py
@@ -43,7 +43,7 @@ class DADAPayload(VLBIPayloadBase):
     _encoders = {
         8: encode_8bit}
 
-    _sample_shape_cls = namedtuple('SampleShape', 'npol, nchan')
+    _sample_shape_maker = namedtuple('SampleShape', 'npol, nchan')
 
     def __init__(self, words, header=None, bps=8, sample_shape=(),
                  complex_data=False):
@@ -51,7 +51,6 @@ class DADAPayload(VLBIPayloadBase):
             bps = header.bps
             sample_shape = header.sample_shape
             complex_data = header.complex_data
-        sample_shape = self._sample_shape_cls(*sample_shape)
         super(DADAPayload, self).__init__(words, sample_shape=sample_shape,
                                           bps=bps, complex_data=complex_data)
 

--- a/baseband/gsb/base.py
+++ b/baseband/gsb/base.py
@@ -312,12 +312,6 @@ class GSBStreamWriter(GSBStreamBase, VLBIStreamWriterBase):
 
     def write(self, data):
         """Write data, buffering by frames as needed."""
-        #if squeezed and data.ndim < 3:
-        #    if (self.header0.mode == 'phased' and
-        #            self._sample_shape.nthread == 1):
-        #        data = np.expand_dims(data, axis=1)
-        #    if self._sample_shape.nchan == 1:
-        #        data = np.expand_dims(data, axis=-1)
         if self.squeeze:
             data = self._unsqueeze(data)
 

--- a/baseband/gsb/base.py
+++ b/baseband/gsb/base.py
@@ -235,7 +235,9 @@ class GSBStreamReader(GSBStreamBase, VLBIStreamReaderBase):
         Returns
         -------
         out : array of float or complex
-            Dimensions are (sample-time, vlbi-thread, channel).
+            Dimensions are (sample-time, thread (polarization), channel), with
+            dimensions of length unity possibly removed if the file
+            was opened with ``squeeze=True`` (which is the default).
         """
         if out is None:
             if count is None or count < 0:

--- a/baseband/gsb/payload.py
+++ b/baseband/gsb/payload.py
@@ -77,8 +77,8 @@ class GSBPayload(VLBIPayloadBase):
                  8: decode_8bit}
     _dtype_word = np.int8
 
-    _sample_shape_cls_1thread = namedtuple('sample_shape', 'nchan')
-    _sample_shape_cls_nthread = namedtuple('sample_shape', 'nthread, nchan')
+    _sample_shape_cls_1thread = namedtuple('SampleShape', 'nchan')
+    _sample_shape_cls_nthread = namedtuple('SampleShape', 'nthread, nchan')
 
     @classmethod
     def fromfile(cls, fh, payloadsize=None, bps=4, nchan=1,
@@ -151,11 +151,11 @@ class GSBPayload(VLBIPayloadBase):
         """
         payload = super(GSBPayload, cls).fromdata(data, bps=bps)
         if len(data.shape[1:]) == 1:
-            payload.sample_shape = \
-                cls._sample_shape_cls_1thread(*data.shape[1:])
+            payload.sample_shape = cls._sample_shape_cls_1thread(
+                *data.shape[1:])
         else:
-            payload.sample_shape = \
-                cls._sample_shape_cls_nthread(*data.shape[1:])
+            payload.sample_shape = cls._sample_shape_cls_nthread(
+                *data.shape[1:])
         return payload
 
     def tofile(self, fh):

--- a/baseband/gsb/tests/test_gsb.py
+++ b/baseband/gsb/tests/test_gsb.py
@@ -35,7 +35,7 @@ class TestGSB(object):
         self.data = np.clip(np.round(np.random.uniform(-8.5, 7.5, size=2048)),
                             -8, 7).reshape(-1, 1)
 
-    def test_header(self):
+    def test_header(self, tmpdir):
         with gsb.open(SAMPLE_HEADER, 'rt') as fh:
             header = gsb.GSBHeader.fromfile(fh, verify=True)
             fh.seek(0)
@@ -54,7 +54,7 @@ class TestGSB(object):
         with pytest.raises(TypeError):
             header['sub_int'] = 0
 
-        with io.StringIO() as s:
+        with open(str(tmpdir.join('test.timestamp')), 'w+t') as s:
             header.tofile(s)
             s.seek(0)
             assert s.readline().strip() == h_raw
@@ -206,7 +206,7 @@ class TestGSB(object):
         d2 = decode_4bit(b2)
         assert np.all(d2 == areal2)
 
-    def test_payload(self):
+    def test_payload(self, tmpdir):
         payload1 = gsb.GSBPayload.fromdata(self.data, bps=4)
         assert np.all(payload1.data == self.data)
         payload2 = gsb.GSBPayload.fromdata(self.data[:1024], bps=8)
@@ -222,7 +222,7 @@ class TestGSB(object):
         payload5 = gsb.GSBPayload.fromdata(channelized, bps=4)
         assert payload5.shape == channelized.shape
         assert np.all(payload5.words == payload1.words)
-        with io.BytesIO() as s:
+        with open(str(tmpdir.join('test.dat')), 'w+b') as s:
             payload1.tofile(s)
             s.seek(0)
             payload6 = gsb.GSBPayload.fromfile(s, bps=4,
@@ -231,10 +231,11 @@ class TestGSB(object):
         assert payload6 == payload1
 
     @pytest.mark.parametrize('bps', (4, 8))
-    def test_phased_payload_minimal(self, bps):
+    def test_phased_payload_minimal(self, bps, tmpdir):
         payload = gsb.GSBPayload.fromdata(self.data[:1024*8//bps], bps=bps)
         # create a "fake" phased payload by writing the same data to files
-        with io.BytesIO() as s1, io.BytesIO() as s2:
+        with open(str(tmpdir.join('test1.dat')), 'w+b') as s1, \
+                open(str(tmpdir.join('test2.dat')), 'w+b') as s2:
             payload.tofile(s1)
             payload.tofile(s2)
             s1.seek(0)
@@ -248,14 +249,15 @@ class TestGSB(object):
                                                  payloadsize=payload.size)
                 assert np.all(phased.data == payload.data[:, np.newaxis])
 
-    def test_rawdump_frame(self):
+    def test_rawdump_frame(self, tmpdir):
         header1 = gsb.GSBHeader(self.rawdump_ts.split())
         frame1 = gsb.GSBFrame.fromdata(self.data, header1, bps=4)
         assert np.all(frame1.data == self.data)
         assert frame1.size == len(self.data) // 2
         frame2 = gsb.GSBFrame(frame1.header, frame1.payload)
         assert frame2 == frame1
-        with io.StringIO() as sh, io.BytesIO() as sp:
+        with open(str(tmpdir.join('test.timestamp')), 'w+t') as sh, \
+                open(str(tmpdir.join('test.dat')), 'w+b') as sp:
             frame1.tofile(sh, sp)
             sh.seek(0)
             sp.seek(0)
@@ -263,7 +265,7 @@ class TestGSB(object):
                                            payloadsize=frame1.size)
         assert frame3 == frame1
 
-    def test_phased_frame(self):
+    def test_phased_frame(self, tmpdir):
         data = self.data.reshape(-1, 1, 2)
         with gsb.open(SAMPLE_HEADER, 'rt') as fh:
             header1 = gsb.GSBHeader.fromfile(fh, verify=True)
@@ -282,7 +284,9 @@ class TestGSB(object):
         frame2.valid = True
         assert frame2.valid is True
         assert np.all(frame2.data == cmplx)
-        with io.StringIO() as sh, io.BytesIO() as sp0, io.BytesIO() as sp1:
+        with open(str(tmpdir.join('test.timestamp')), 'w+t') as sh, \
+                open(str(tmpdir.join('test0.dat')), 'w+b') as sp0, \
+                open(str(tmpdir.join('test1.dat')), 'w+b') as sp1:
             frame1.tofile(sh, ((sp0, sp1),))
             assert sp0.tell() == frame1.size // 2
             assert sp1.tell() == frame1.size // 2
@@ -300,9 +304,11 @@ class TestGSB(object):
         assert frame4.size == frame1.size  # number of bytes doesn't change.
         assert frame4.shape == twopol.shape
         assert np.all(frame4.data == twopol)
-        with io.StringIO() as sh, \
-                io.BytesIO() as sp0, io.BytesIO() as sp1, \
-                io.BytesIO() as sp2, io.BytesIO() as sp3:
+        with open(str(tmpdir.join('test.timestamp')), 'w+t') as sh, \
+                open(str(tmpdir.join('test0.dat')), 'w+b') as sp0, \
+                open(str(tmpdir.join('test1.dat')), 'w+b') as sp1, \
+                open(str(tmpdir.join('test2.dat')), 'w+b') as sp2, \
+                open(str(tmpdir.join('test3.dat')), 'w+b') as sp3:
             frame4.tofile(sh, ((sp0, sp1), (sp2, sp3)))
             for s in sp0, sp1, sp2, sp3:
                 assert s.tell() == frame4.payload.size // 4
@@ -359,7 +365,7 @@ class TestGSB(object):
         raw_file = str(tmpdir.join('raw0.dat'))
         with gsb.open(ts_file, 'wt') as sh:
             sh.write_timestamp(header)
-        with io.open(raw_file, 'wb') as sp:
+        with open(raw_file, 'wb') as sp:
             payload.tofile(sp)
 
         # Open here with payloadsize given, below with samples_per_frame
@@ -377,9 +383,10 @@ class TestGSB(object):
         assert np.all(data == self.data.ravel())
         assert np.all(out == self.data)
 
-        with io.BytesIO() as sh, io.BytesIO() as sp, gsb.open(
-                sh, 'ws', raw=sp, sample_rate=4096*u.Hz,
-                samples_per_frame=payload.nsample, **header) as fh_w:
+        with open(str(tmpdir.join('test_time.dat')), 'w+b') as sh, \
+                open(str(tmpdir.join('test.dat')), 'w+b') as sp, \
+                gsb.open(sh, 'ws', raw=sp, sample_rate=4096*u.Hz,
+                         samples_per_frame=payload.nsample, **header) as fh_w:
             fh_w.write(self.data.ravel())
             fh_w.write(self.data.ravel())
             assert fh_w.tell() == 2 * len(self.data)
@@ -399,7 +406,8 @@ class TestGSB(object):
 
         # Test that opening that raises an exception correctly handles
         # file closing. (Note that the timestamp file always gets closed).
-        with io.BytesIO() as sh, io.BytesIO() as sp:
+        with open(str(tmpdir.join('test_time.dat')), 'w+b') as sh, \
+                open(str(tmpdir.join('test.dat')), 'w+b') as sp:
             with pytest.raises(u.UnitsError):
                 gsb.open(sh, 'ws', raw=sp, sample_rate=4096*u.m,
                          samples_per_frame=payload.nsample, **header)
@@ -447,9 +455,11 @@ class TestGSB(object):
         assert np.all(data[onepol.shape[0]:] == onepol[::-1].squeeze())
         # Two polarisations, 16 channels
         twopol = cmplx.reshape(-1, 2, 16)
-        with io.BytesIO() as sh, \
-                io.BytesIO() as sp0, io.BytesIO() as sp1, \
-                io.BytesIO() as sp2, io.BytesIO() as sp3, \
+        with open(str(tmpdir.join('test.timestamp')), 'w+b') as sh, \
+                open(str(tmpdir.join('test0.dat')), 'w+b') as sp0, \
+                open(str(tmpdir.join('test1.dat')), 'w+b') as sp1, \
+                open(str(tmpdir.join('test2.dat')), 'w+b') as sp2, \
+                open(str(tmpdir.join('test3.dat')), 'w+b') as sp3, \
                 gsb.open(sh, 'ws', raw=((sp0, sp1), (sp2, sp3)),
                          bps=bps, sample_rate=128*u.Hz,
                          samples_per_frame=twopol.shape[0] // 2,
@@ -484,7 +494,8 @@ class TestGSB(object):
         with pytest.raises(ValueError):
             # no r or w in mode
             gsb.open('ts.dat', 's')
-        with pytest.raises(TypeError), io.TextIOBase() as s:
+        with pytest.raises(TypeError), \
+                open(str(tmpdir.join('test.timestamp')), 'w+t') as s:
             # TextIOBase for fh
             gsb.open(s, 'rt')
         with pytest.raises(IOError):

--- a/baseband/gsb/tests/test_gsb.py
+++ b/baseband/gsb/tests/test_gsb.py
@@ -442,9 +442,11 @@ class TestGSB(object):
                       header=header) as fh_w:
             # Write data.
             fh_w.write(onepol)
+            assert fh_w.sample_shape == (1, onepol.shape[2])
             # Write data again, but reversed and squeezed
             fh_w.squeeze = True
             fh_w.write(onepol[::-1].squeeze())
+            assert fh_w.sample_shape == (onepol.shape[2],)
             assert fh_w.tell() == onepol.shape[0] * 2
             assert_quantity_allclose(fh_w.tell(unit=u.s), 0.5 * u.s)
             assert fh_w._header['seq_nr'] == fh_w.header0['seq_nr'] + 3
@@ -479,6 +481,7 @@ class TestGSB(object):
                          nchan=twopol.shape[2], nthread=twopol.shape[1],
                          complex_data=True, header=header) as fh_w:
             # Write data twice.
+            assert fh_w.sample_shape == (2, twopol.shape[2])
             fh_w.write(twopol)
             fh_w.write(twopol[::-1])
             assert fh_w.tell() == twopol.shape[0] * 2

--- a/baseband/gsb/tests/test_gsb.py
+++ b/baseband/gsb/tests/test_gsb.py
@@ -1,6 +1,6 @@
 # Licensed under the GPLv3 - see LICENSE.rst
-import io
 import pytest
+import io
 import numpy as np
 import astropy.units as u
 from astropy.time import Time
@@ -383,7 +383,7 @@ class TestGSB(object):
         assert np.all(data == self.data.ravel())
         assert np.all(out == self.data)
 
-        with open(str(tmpdir.join('test_time.dat')), 'w+b') as sh, \
+        with io.open(str(tmpdir.join('test_time.dat')), 'w+b') as sh, \
                 open(str(tmpdir.join('test.dat')), 'w+b') as sp, \
                 gsb.open(sh, 'ws', raw=sp, sample_rate=4096*u.Hz,
                          samples_per_frame=payload.nsample, **header) as fh_w:
@@ -406,7 +406,7 @@ class TestGSB(object):
 
         # Test that opening that raises an exception correctly handles
         # file closing. (Note that the timestamp file always gets closed).
-        with open(str(tmpdir.join('test_time.dat')), 'w+b') as sh, \
+        with io.open(str(tmpdir.join('test.timestamp')), 'w+b') as sh, \
                 open(str(tmpdir.join('test.dat')), 'w+b') as sp:
             with pytest.raises(u.UnitsError):
                 gsb.open(sh, 'ws', raw=sp, sample_rate=4096*u.m,
@@ -455,7 +455,7 @@ class TestGSB(object):
         assert np.all(data[onepol.shape[0]:] == onepol[::-1].squeeze())
         # Two polarisations, 16 channels
         twopol = cmplx.reshape(-1, 2, 16)
-        with open(str(tmpdir.join('test.timestamp')), 'w+b') as sh, \
+        with io.open(str(tmpdir.join('test.timestamp')), 'w+b') as sh, \
                 open(str(tmpdir.join('test0.dat')), 'w+b') as sp0, \
                 open(str(tmpdir.join('test1.dat')), 'w+b') as sp1, \
                 open(str(tmpdir.join('test2.dat')), 'w+b') as sp2, \
@@ -495,7 +495,7 @@ class TestGSB(object):
             # no r or w in mode
             gsb.open('ts.dat', 's')
         with pytest.raises(TypeError), \
-                open(str(tmpdir.join('test.timestamp')), 'w+t') as s:
+                io.open(str(tmpdir.join('test.timestamp')), 'w+t') as s:
             # TextIOBase for fh
             gsb.open(s, 'rt')
         with pytest.raises(IOError):

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -291,14 +291,15 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
         Returns
         -------
         out : array of float
-            Dimensions are (sample-time, channel) with dimensions
-            of length unity possibly removed (if ``squeeze`` is `True`).
+            Dimensions are (sample-time, channel), with dimensions of length
+            unity possibly removed if the file was opened with ``squeeze=True``
+            (which is the default).
         """
         if out is None:
             if count is None or count < 0:
                 count = self.size - self.offset
 
-            result = np.empty((self._sample_shape.nchan, count),
+            result = np.empty(self._sample_shape + (count,),
                               dtype=self._frame.dtype).T
             out = result.squeeze() if self.squeeze else result
         else:
@@ -350,7 +351,7 @@ class Mark4StreamWriter(VLBIStreamWriterBase, Mark4FileWriter):
     header : `~baseband.mark4.Mark4Header`
         Header for the first frame, holding start time information, etc.
     squeeze : bool, optional
-        If `True` (default), `write` accepts squeezed arrays as input,
+        If `True` (default), ``write`` accepts squeezed arrays as input,
         and adds channel and thread dimensions if unity.
     **kwargs
         If no header is give, an attempt is made to construct the header from
@@ -456,7 +457,7 @@ sample_rate : `~astropy.units.Quantity`, optional
 header : `~baseband.mark4.Mark4Header`
     Header for the first frame, holding time information, etc.
 squeeze : bool, optional
-    If `True` (default), `write` accepts squeezed arrays as input,
+    If `True` (default), ``write`` accepts squeezed arrays as input,
     and adds channel and thread dimensions if unity.
 **kwargs
     If the header is not given, an attempt will be made to construct one

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -226,7 +226,8 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
         self._frame_data = None
         self._frame_nr = None
         header = self._frame.header
-        sample_shape = self._frame.payload.sample_shape
+        sample_shape = Mark4Payload._sample_shape_cls(len(thread_ids)) if \
+            thread_ids else self._frame.payload.sample_shape
         super(Mark4StreamReader, self).__init__(
             fh_raw, header0=header, sample_shape=sample_shape,
             bps=header.bps, complex_data=False, thread_ids=thread_ids,
@@ -284,7 +285,7 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
             Value to use for invalid or missing data.
         out : `None` or array
             Array to store the data in. If given, count will be inferred,
-            and squeeze is set to `False`.
+            and squeeze behavior will be overridden to False.
 
         Returns
         -------
@@ -433,6 +434,8 @@ frames_per_second : int, optional
     ``sample_rate``, or by scanning the file.
 sample_rate : `~astropy.units.Quantity`, optional
     Rate at which each thread is sampled (bandwidth * 2; frequency units).
+squeeze : bool
+    If `True` (default), remove channel and thread dimensions if unity.
 
 --- For writing a stream : (see `~baseband.mark4.base.Mark4StreamWriter`)
 

--- a/baseband/mark4/payload.py
+++ b/baseband/mark4/payload.py
@@ -212,7 +212,6 @@ class Mark4Payload(VLBIPayloadBase):
                  (8, 2, 4): decode_8chan_2bit_fanout4}
 
     _sample_shape_cls = namedtuple('sample_shape', 'nchan')
-    _sample_shape_cls.__doc__ = "Mark 4 sample shape."
 
     def __init__(self, words, header=None, nchan=1, bps=2, fanout=1):
         if header is not None:

--- a/baseband/mark4/payload.py
+++ b/baseband/mark4/payload.py
@@ -211,7 +211,7 @@ class Mark4Payload(VLBIPayloadBase):
                  (8, 2, 2): decode_8chan_2bit_fanout2,
                  (8, 2, 4): decode_8chan_2bit_fanout4}
 
-    _sample_shape_cls = namedtuple('SampleShape', 'nchan')
+    _sample_shape_maker = namedtuple('SampleShape', 'nchan')
 
     def __init__(self, words, header=None, nchan=1, bps=2, fanout=1):
         if header is not None:
@@ -221,9 +221,8 @@ class Mark4Payload(VLBIPayloadBase):
             self._size = header.payloadsize
         self._dtype_word = MARK4_DTYPES[nchan * bps * fanout]
         self.fanout = fanout
-        sample_shape = self._sample_shape_cls(nchan)
         super(Mark4Payload, self).__init__(words, bps=bps,
-                                           sample_shape=sample_shape,
+                                           sample_shape=(nchan,),
                                            complex_data=False)
         self._coder = (self.sample_shape.nchan, bps, fanout)
 

--- a/baseband/mark4/payload.py
+++ b/baseband/mark4/payload.py
@@ -211,7 +211,7 @@ class Mark4Payload(VLBIPayloadBase):
                  (8, 2, 2): decode_8chan_2bit_fanout2,
                  (8, 2, 4): decode_8chan_2bit_fanout4}
 
-    _sample_shape_cls = namedtuple('sample_shape', 'nchan')
+    _sample_shape_cls = namedtuple('SampleShape', 'nchan')
 
     def __init__(self, words, header=None, nchan=1, bps=2, fanout=1):
         if header is not None:

--- a/baseband/mark4/payload.py
+++ b/baseband/mark4/payload.py
@@ -11,6 +11,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import sys
 import numpy as np
+from collections import namedtuple
 from ..vlbi_base.payload import VLBIPayloadBase
 from ..vlbi_base.encoding import encode_2bit_base, decoder_levels
 from .header import MARK4_DTYPES
@@ -210,6 +211,9 @@ class Mark4Payload(VLBIPayloadBase):
                  (8, 2, 2): decode_8chan_2bit_fanout2,
                  (8, 2, 4): decode_8chan_2bit_fanout4}
 
+    _sample_shape_cls = namedtuple('sample_shape', 'nchan')
+    _sample_shape_cls.__doc__ = "Mark 4 sample shape."
+
     def __init__(self, words, header=None, nchan=1, bps=2, fanout=1):
         if header is not None:
             nchan = header.nchan
@@ -218,11 +222,11 @@ class Mark4Payload(VLBIPayloadBase):
             self._size = header.payloadsize
         self._dtype_word = MARK4_DTYPES[nchan * bps * fanout]
         self.fanout = fanout
+        sample_shape = self._sample_shape_cls(nchan)
         super(Mark4Payload, self).__init__(words, bps=bps,
-                                           sample_shape=(nchan,),
+                                           sample_shape=sample_shape,
                                            complex_data=False)
-        self.nchan = nchan
-        self._coder = (nchan, bps, fanout)
+        self._coder = (self.sample_shape.nchan, bps, fanout)
 
     @classmethod
     def fromfile(cls, fh, header):

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -1,7 +1,6 @@
 # Licensed under the GPLv3 - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-import io
 import pytest
 import numpy as np
 from astropy import units as u

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -502,6 +502,21 @@ class TestMark4(object):
                 conv_bytes = s.read()
                 assert conv_bytes == orig_bytes
 
+        # Test that squeeze attribute works on read - except when out is
+        # passed - and sample_shape.
+        with mark4.open(SAMPLE_FILE, 'rs') as fh:
+            assert tuple(fh.sample_shape) == (8,)
+            assert fh.read(1).shape == (8,)
+            fh.seek(0)
+            out = np.zeros((12, 8))
+            fh.read(out=out)
+            assert fh.tell() == 12
+            assert np.all(out.squeeze() == record[:12])
+
+        with mark4.open(SAMPLE_FILE, 'rs', squeeze=False) as fh:
+            assert tuple(fh.sample_shape) == (8,)
+            assert fh.read(1).shape == (1, 8)
+
     def test_corrupt_stream(self):
         with mark4.open(SAMPLE_FILE, 'rb') as fh, io.BytesIO() as s:
             fh.seek(0xa88)

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -1,6 +1,5 @@
 import numpy as np
 from astropy import units as u
-from collections import namedtuple
 
 from ..vlbi_base.base import (VLBIFileBase, VLBIStreamReaderBase,
                               VLBIStreamWriterBase, make_opener)

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -222,7 +222,7 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
             if count is None or count < 0:
                 count = self.size - self.offset
 
-            result = np.empty((self._sample_shape.nchan, count),
+            result = np.empty(self._sample_shape + (count,),
                               dtype=self._frame.dtype).T
             out = result.squeeze() if self.squeeze else result
         else:
@@ -286,7 +286,7 @@ class Mark5BStreamWriter(VLBIStreamWriterBase, Mark5BFileWriter):
     header : `~baseband.mark5b.Mark5BHeader`, optional
         Header for the first frame, holding time information, etc.
     squeeze : bool, optional
-        If `True` (default), `write` accepts squeezed arrays as input,
+        If `True` (default), ``write`` accepts squeezed arrays as input,
         and adds channel and thread dimensions if unity.
     **kwargs
         If no header is give, an attempt is made to construct the header from
@@ -401,7 +401,7 @@ bps : int
 header : :class:`~baseband.mark5b.Mark5BHeader`, optional
     Header for the first frame, holding time information, etc.
 squeeze : bool, optional
-    If `True` (default), `write` accepts squeezed arrays as input,
+    If `True` (default), ``write`` accepts squeezed arrays as input,
     and adds channel and thread dimensions if unity.
 **kwargs
     If the header is not given, an attempt will be made to construct one

--- a/baseband/mark5b/payload.py
+++ b/baseband/mark5b/payload.py
@@ -10,6 +10,7 @@ http://www.haystack.edu/tech/vlbi/mark5/docs/Mark%205B%20users%20manual.pdf
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import numpy as np
+from collections import namedtuple
 from ..vlbi_base.payload import VLBIPayloadBase
 from ..vlbi_base.encoding import encode_2bit_base, decoder_levels
 
@@ -109,14 +110,17 @@ class Mark5BPayload(VLBIPayloadBase):
     _encoders = {2: encode_2bit}
     _decoders = {2: decode_2bit}
 
+    _sample_shape_cls = namedtuple('sample_shape', 'nchan')
+    _sample_shape_cls.__doc__ = "Mark 5B sample shape."
+
     def __init__(self, words, nchan=1, bps=2, complex_data=False):
         if complex_data:
             raise ValueError("Mark5B format does not support complex data.")
 
+        sample_shape = self._sample_shape_cls(nchan)
         super(Mark5BPayload, self).__init__(words, bps=bps,
-                                            sample_shape=(nchan,),
+                                            sample_shape=sample_shape,
                                             complex_data=False)
-        self.nchan = nchan
 
     @classmethod
     def fromdata(cls, data, bps=2):

--- a/baseband/mark5b/payload.py
+++ b/baseband/mark5b/payload.py
@@ -110,7 +110,7 @@ class Mark5BPayload(VLBIPayloadBase):
     _encoders = {2: encode_2bit}
     _decoders = {2: decode_2bit}
 
-    _sample_shape_cls = namedtuple('sample_shape', 'nchan')
+    _sample_shape_cls = namedtuple('SampleShape', 'nchan')
 
     def __init__(self, words, nchan=1, bps=2, complex_data=False):
         if complex_data:

--- a/baseband/mark5b/payload.py
+++ b/baseband/mark5b/payload.py
@@ -110,15 +110,14 @@ class Mark5BPayload(VLBIPayloadBase):
     _encoders = {2: encode_2bit}
     _decoders = {2: decode_2bit}
 
-    _sample_shape_cls = namedtuple('SampleShape', 'nchan')
+    _sample_shape_maker = namedtuple('SampleShape', 'nchan')
 
     def __init__(self, words, nchan=1, bps=2, complex_data=False):
         if complex_data:
             raise ValueError("Mark5B format does not support complex data.")
 
-        sample_shape = self._sample_shape_cls(nchan)
         super(Mark5BPayload, self).__init__(words, bps=bps,
-                                            sample_shape=sample_shape,
+                                            sample_shape=(nchan,),
                                             complex_data=False)
 
     @classmethod

--- a/baseband/mark5b/payload.py
+++ b/baseband/mark5b/payload.py
@@ -111,7 +111,6 @@ class Mark5BPayload(VLBIPayloadBase):
     _decoders = {2: decode_2bit}
 
     _sample_shape_cls = namedtuple('sample_shape', 'nchan')
-    _sample_shape_cls.__doc__ = "Mark 5B sample shape."
 
     def __init__(self, words, nchan=1, bps=2, complex_data=False):
         if complex_data:

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -1,7 +1,6 @@
 # Licensed under the GPLv3 - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-import io
 import pytest
 import numpy as np
 from astropy import units as u
@@ -432,7 +431,7 @@ class TestMark5B(object):
                              sample_rate=32*u.MHz, ref_mjd=57000) as fr:
                 record = fr.read(10)
                 with mark5b.open(m5_incomplete, 'ws', header=fr.header0,
-                                nchan=8, sample_rate=32*u.MHz) as fw:
+                                 nchan=8, sample_rate=32*u.MHz) as fw:
                     fw.write(record)
         assert len(w) == 1
         assert 'partial buffer' in str(w[0].message)

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -125,6 +125,9 @@ class TestMark5B(object):
         assert payload._size == 10000
         assert payload.size == 10000
         assert payload.shape == (5000, 8)
+        # Check sample shape validity
+        assert payload.sample_shape == (8,)
+        assert payload.sample_shape.nchan == 8
         assert payload.dtype == np.float32
         assert np.all(payload[:3].astype(int) ==
                       np.array([[-3, -1, +1, -1, +3, -3, -3, +3],
@@ -217,7 +220,7 @@ class TestMark5B(object):
             time0 = header0.time
             samples_per_frame = header0.payloadsize * 8 // 2 // 8
             frame_rate = 32. * u.MHz / samples_per_frame
-            frame_duration = 1./frame_rate
+            frame_duration = 1. / frame_rate
             fh.seek(0)
             while True:
                 try:
@@ -264,7 +267,7 @@ class TestMark5B(object):
             fh.seek(-10000, 2)
             header_m10000b = fh.find_header(template_header=header0,
                                             forward=False)
-            assert fh.tell() == 3*header0.framesize
+            assert fh.tell() == 3 * header0.framesize
             fh.seek(-30, 2)
             header_end = fh.find_header(template_header=header0, forward=True)
             assert header_end is None
@@ -285,10 +288,9 @@ class TestMark5B(object):
                                            forward=True)
             assert fh.tell() == header0.framesize * 2 - 9960
         # for completeness, also check a really short file...
-        m5_test2 = str(tmpdir.join('test2.m5b'))
-        with open(m5_test2, 'wb') as s, open(SAMPLE_FILE, 'rb') as f:
+        with open(m5_test, 'wb') as s, open(SAMPLE_FILE, 'rb') as f:
             s.write(f.read(10018))
-        with mark5b.open(m5_test2, 'rb') as fh:
+        with mark5b.open(m5_test, 'rb') as fh:
             fh.seek(10)
             header_10 = fh.find_header(template_header=header0,
                                        forward=False)
@@ -312,7 +314,7 @@ class TestMark5B(object):
             fh.seek(10000)
             record2 = fh.read(2)
             assert fh.tell() == 10002
-            assert fh.fh_raw.tell() == 3.*header.framesize
+            assert fh.fh_raw.tell() == 3. * header.framesize
             assert np.abs(fh.tell(unit='time') -
                           (fh.time0 + 10002 / (32*u.MHz))) < 1. * u.ns
             fh.seek(fh.time0 + 1000 / (32*u.MHz))
@@ -355,10 +357,7 @@ class TestMark5B(object):
                          bps=2, sample_rate=32*u.MHz) as fw:
             # Write in pieces to ensure squeezed data can be handled,
             # And add in an invalid frame for good measure.
-            fw.write(record[:10])
-            fw.write(record[10])
-            with pytest.raises(ValueError):
-                fw.write(record[10], squeezed=False)
+            fw.write(record[:11])
             fw.write(record[11:5000])
             fw.write(record[5000:10000], invalid_data=True)
             fw.write(record[10000:])
@@ -374,49 +373,69 @@ class TestMark5B(object):
             assert np.all(record2[10000:] == record[10000:])
 
         # Check files can be made byte-for-byte identical.
-        m5_test2 = str(tmpdir.join('test2.m5b'))
-        with mark5b.open(m5_test2, 'ws', time=time0, nchan=8, bps=2,
+        with mark5b.open(m5_test, 'ws', time=time0, nchan=8, bps=2,
                          sample_rate=32*u.MHz, user=header['user'],
                          internal_tvg=header['internal_tvg'],
                          frame_nr=header['frame_nr']) as fw:
             fw.write(record)
 
-        with open(SAMPLE_FILE, 'rb') as fr, open(m5_test2, 'rb') as fs:
+        with open(SAMPLE_FILE, 'rb') as fr, open(m5_test, 'rb') as fs:
             orig_bytes = fr.read()
             conv_bytes = fs.read()
             assert conv_bytes == orig_bytes
 
         # Check if data can be read across days.  Write out sample Mark 5B
         # with fake timecode and step, and see if it can be re-read.
-        m5_test3 = str(tmpdir.join('test3.m5b'))
         time_premidnight = Time('2014:164:23:59:59')
-        with mark5b.open(m5_test3, 'ws', time=time_premidnight,
+        with mark5b.open(m5_test, 'ws', time=time_premidnight,
                          nchan=8, bps=2, sample_rate=10*u.kHz) as fw:
             fw.write(record)
 
-        with mark5b.open(m5_test3, 'rs', nchan=8, bps=2,
+        with mark5b.open(m5_test, 'rs', nchan=8, bps=2,
                          sample_rate=10*u.kHz, ref_mjd=57000) as fh:
             record5 = fh.read()     # Read across days.
             assert np.all(record5 == record)
             assert fh.tell(unit='time').iso == '2014-06-14 00:00:01.000000000'
 
-        # Test that squeeze attribute works on read and sample shape, but is
-        # overridden when reading in-place.
+        # Test that squeeze attribute works on read (including in-place read)
+        # and write, but can be turned off if needed.
         with mark5b.open(SAMPLE_FILE, 'rs', nchan=8, bps=2,
                          sample_rate=32*u.MHz, ref_mjd=57000) as fh:
-            assert tuple(fh.sample_shape) == (8,)
+            assert fh.sample_shape == (8,)
+            assert fh.sample_shape.nchan == 8
             assert fh.read(1).shape == (8,)
             fh.seek(0)
             out = np.zeros((12, 8))
             fh.read(out=out)
             assert fh.tell() == 12
-            assert np.all(out.squeeze() == record[:12])
+            assert np.all(out == record[:12])
 
         with mark5b.open(SAMPLE_FILE, 'rs', nchan=8, bps=2,
                          sample_rate=32*u.MHz, ref_mjd=57000,
-                         squeeze=False) as fh:
-            assert tuple(fh.sample_shape) == (8,)
-            assert fh.read(1).shape == (1, 8)
+                         thread_ids=[0], squeeze=False) as fh:
+            assert fh.sample_shape == (1,)
+            assert fh.sample_shape.nchan == 1
+            assert fh.read(1).shape == (1, 1)
+            fh.seek(0)
+            out = np.zeros((12, 1))
+            fh.read(out=out)
+            assert fh.tell() == 12
+            assert np.all(out.squeeze() == record[:12, 0])
+
+        with mark5b.open(m5_test, 'ws', time=time0, nchan=1, bps=2,
+                         sample_rate=32*u.MHz) as fw:
+            assert fw.sample_shape == ()
+            fw.write(record[:10000, 0])
+            fw.squeeze = False
+            assert fw.sample_shape == (1,)
+            assert fw.sample_shape.nchan == 1
+            fw.write(record[10000:, 0:1])   # 0:1 to keep record 2-dimensional.
+            # Write some dummy data to fill up the rest of the frame.
+            fw.write(np.zeros((20000, 1), dtype='float32'))
+
+        with mark5b.open(m5_test, 'rs', nchan=1, bps=2,
+                         sample_rate=32*u.MHz, ref_mjd=57000) as fh:
+            assert np.all(fh.read(20000) == record[:, 0])
 
     def test_stream_invalid(self):
         with pytest.raises(ValueError):

--- a/baseband/tests/test_conversion.py
+++ b/baseband/tests/test_conversion.py
@@ -48,8 +48,8 @@ class TestVDIFMark5B(object):
             assert header.framesize == 10032
             assert header.size == 32
             assert header.payloadsize == m5h.payloadsize
-            assert header.samples_per_frame == \
-                10000*8//m5pl.bps//m5pl.sample_shape.nchan
+            assert (header.samples_per_frame ==
+                    10000 * 8 // m5pl.bps // m5pl.sample_shape.nchan)
 
         # A copy might remove any `kday` keywords set, but should still work
         # (Regression test for #34)

--- a/baseband/tests/test_conversion.py
+++ b/baseband/tests/test_conversion.py
@@ -29,10 +29,10 @@ class TestVDIFMark5B(object):
             # A not-at-the-start header for checking times.
             m5h2 = mark5b.Mark5BHeader.fromfile(fh, ref_mjd=ref_mjd)
         # Create VDIF headers based on both the Mark 5B header and payload.
-        header1 = vdif.VDIFHeader.from_mark5b_header(m5h1, nchan=m5pl.nchan,
-                                                     bps=m5pl.bps)
-        header2 = vdif.VDIFHeader.from_mark5b_header(m5h2, nchan=m5pl.nchan,
-                                                     bps=m5pl.bps)
+        header1 = vdif.VDIFHeader.from_mark5b_header(
+            m5h1, nchan=m5pl.sample_shape.nchan, bps=m5pl.bps)
+        header2 = vdif.VDIFHeader.from_mark5b_header(
+            m5h2, nchan=m5pl.sample_shape.nchan, bps=m5pl.bps)
         for i, (m5h, header) in enumerate(((m5h1, header1), (m5h2, header2))):
             assert m5h['frame_nr'] == i
             # Check all direct information is set correctly.
@@ -48,7 +48,8 @@ class TestVDIFMark5B(object):
             assert header.framesize == 10032
             assert header.size == 32
             assert header.payloadsize == m5h.payloadsize
-            assert header.samples_per_frame == 10000*8//m5pl.bps//m5pl.nchan
+            assert header.samples_per_frame == \
+                10000*8//m5pl.bps//m5pl.sample_shape.nchan
 
         # A copy might remove any `kday` keywords set, but should still work
         # (Regression test for #34)
@@ -76,8 +77,8 @@ class TestVDIFMark5B(object):
         with open(SAMPLE_M5B, 'rb') as fh:
             m5h = mark5b.Mark5BHeader.fromfile(fh, Time('2014-06-01').mjd)
             m5pl = mark5b.Mark5BPayload.fromfile(fh, nchan=8, bps=2)
-        header = vdif.VDIFHeader.from_mark5b_header(m5h, nchan=m5pl.nchan,
-                                                    bps=m5pl.bps)
+        header = vdif.VDIFHeader.from_mark5b_header(
+            m5h, nchan=m5pl.sample_shape.nchan, bps=m5pl.bps)
         # Create VDIF payload from the Mark 5B encoded payload.
         payload = vdif.VDIFPayload(m5pl.words, header)
         # Check that the payload (i.e., encoded data) is the same.
@@ -124,7 +125,7 @@ class TestVDIF0VDIF1(object):
                 h1w = f1w.header0
                 assert list(h1w.words[:4]) == list(h0.words[:4])
                 assert h1w.framerate == 10. * u.kHz
-                assert h1w.bandwidth == 1.28 * f0.nchan * u.MHz
+                assert h1w.bandwidth == 1.28 * f0.sample_shape.nchan * u.MHz
                 f1w.write(d0)
                 f1w.fh_raw.flush()
 
@@ -134,7 +135,7 @@ class TestVDIF0VDIF1(object):
                     d1r = f1r.read(1024)
                 assert h1r.words[:4] == h0.words[:4]
                 assert h1r.framerate == 10. * u.kHz
-                assert h1r.bandwidth == 1.28 * f0.nchan * u.MHz
+                assert h1r.bandwidth == 1.28 * f0.sample_shape.nchan * u.MHz
                 assert np.all(d1r == d0)
 
 
@@ -380,7 +381,7 @@ class TestDADAToVDIF1(object):
             assert fv.offset == offset1
             assert np.abs(fv.tell(unit='time') - time1) < 2.*u.ns
             vh = fv.header0
-            vnthread = fv.nthread
+            vnthread = fv.sample_shape.nthread
         assert np.allclose(dv, data)
 
         # Convert VDIF file back to DADA.

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -429,7 +429,7 @@ class VDIFStreamWriter(VDIFStreamBase, VLBIStreamWriterBase, VDIFFileWriter):
     header : :class:`~baseband.vdif.VDIFHeader`, optional
         Header for the first frame, holding time information, etc.
     squeeze : bool, optional
-        If `True` (default), `write` accepts squeezed arrays as input,
+        If `True` (default), ``write`` accepts squeezed arrays as input,
         and adds channel and thread dimensions if unity.
     **kwargs
         If no header is give, an attempt is made to construct the header from
@@ -548,7 +548,7 @@ frames_per_second : int, optional
 sample_rate : `~astropy.units.Quantity`, optional
     Rate at which each channel in each thread is sampled.
 squeeze : bool, optional
-    If `True` (default), `write` accepts squeezed arrays as input,
+    If `True` (default), ``write`` accepts squeezed arrays as input,
     and adds channel and thread dimensions if unity.
 header : `~baseband.vdif.VDIFHeader`, optional
     Header for the first frame, holding time information, etc.

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -240,7 +240,6 @@ class VDIFStreamBase(VLBIStreamBase):
     _frame_class = VDIFFrame
 
     _sample_shape_cls = namedtuple('sample_shape', 'nthread, nchan')
-    _sample_shape_cls.__doc__ = "VDIF sample shape."
 
     def __init__(self, fh_raw, header0, thread_ids, frames_per_second=None,
                  sample_rate=None):

--- a/baseband/vdif/frame.py
+++ b/baseband/vdif/frame.py
@@ -11,7 +11,6 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import numpy as np
-from collections import namedtuple
 
 from ..vlbi_base.frame import VLBIFrameBase
 from .header import VDIFHeader

--- a/baseband/vdif/frame.py
+++ b/baseband/vdif/frame.py
@@ -152,7 +152,7 @@ class VDIFFrame(VLBIFrameBase):
         """
         m5h, m5pl = mark5b_frame.header, mark5b_frame.payload
         header = cls._header_class.from_mark5b_header(
-            m5h, nchan=m5pl.nchan, bps=m5pl.bps,
+            m5h, nchan=m5pl.sample_shape.nchan, bps=m5pl.bps,
             invalid_data=not mark5b_frame.valid, **kwargs)
         payload = cls._payload_class(m5pl.words, header)
         return cls(header, payload, verify)

--- a/baseband/vdif/frame.py
+++ b/baseband/vdif/frame.py
@@ -191,13 +191,8 @@ class VDIFFrameSet(object):
     """
     invalid_data_value = 0.
 
-    _sample_shape_cls = namedtuple('sample_shape', 'nthread, nchan')
-    _sample_shape_cls.__doc__ = "VDIF sample shape."
-
     def __init__(self, frames, header0=None):
         self.frames = frames
-        self.sample_shape = self._sample_shape_cls(
-            len(frames), frames[0].payload.sample_shape.nchan)
         # Used in .data below to decode data only once.
         self._data = None
         if header0 is None:

--- a/baseband/vdif/frame.py
+++ b/baseband/vdif/frame.py
@@ -11,6 +11,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import numpy as np
+from collections import namedtuple
 
 from ..vlbi_base.frame import VLBIFrameBase
 from .header import VDIFHeader
@@ -190,8 +191,13 @@ class VDIFFrameSet(object):
     """
     invalid_data_value = 0.
 
+    _sample_shape_cls = namedtuple('sample_shape', 'nthread, nchan')
+    _sample_shape_cls.__doc__ = "VDIF sample shape."
+
     def __init__(self, frames, header0=None):
         self.frames = frames
+        self.sample_shape = self._sample_shape_cls(
+            len(frames), frames[0].payload.sample_shape.nchan)
         # Used in .data below to decode data only once.
         self._data = None
         if header0 is None:

--- a/baseband/vdif/payload.py
+++ b/baseband/vdif/payload.py
@@ -10,6 +10,7 @@ specifications.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import numpy as np
+from collections import namedtuple
 
 from ..vlbi_base.payload import VLBIPayloadBase
 from ..vlbi_base.encoding import (encode_2bit_base, encode_4bit_base,
@@ -130,6 +131,8 @@ class VDIFPayload(VLBIPayloadBase):
                  4: encode_4bit,
                  8: encode_8bit}
 
+    _sample_shape_template = namedtuple('_sample_shape_template', ['nchan',])
+
     def __init__(self, words, header=None,
                  nchan=1, bps=2, complex_data=False):
         if header is not None:
@@ -143,8 +146,9 @@ class VDIFPayload(VLBIPayloadBase):
                 self._encoders = Mark5BPayload._encoders
                 if complex_data:
                     raise ValueError("VDIF/Mark5B payload cannot be complex.")
+        sample_shape = 
         super(VDIFPayload, self).__init__(words, bps=bps,
-                                          sample_shape=(nchan,),
+                                          sample_shape=sample_shape,
                                           complex_data=complex_data)
         self.nchan = nchan
 

--- a/baseband/vdif/payload.py
+++ b/baseband/vdif/payload.py
@@ -131,7 +131,7 @@ class VDIFPayload(VLBIPayloadBase):
                  4: encode_4bit,
                  8: encode_8bit}
 
-    _sample_shape_cls = namedtuple('SampleShape', 'nchan')
+    _sample_shape_maker = namedtuple('SampleShape', 'nchan')
 
     def __init__(self, words, header=None,
                  nchan=1, bps=2, complex_data=False):
@@ -146,11 +146,9 @@ class VDIFPayload(VLBIPayloadBase):
                 self._encoders = Mark5BPayload._encoders
                 if complex_data:
                     raise ValueError("VDIF/Mark5B payload cannot be complex.")
-        sample_shape = self._sample_shape_cls(nchan)
         super(VDIFPayload, self).__init__(words, bps=bps,
-                                          sample_shape=sample_shape,
+                                          sample_shape=(nchan,),
                                           complex_data=complex_data)
-        self.nchan = nchan
 
     @classmethod
     def fromfile(cls, fh, header):

--- a/baseband/vdif/payload.py
+++ b/baseband/vdif/payload.py
@@ -131,7 +131,8 @@ class VDIFPayload(VLBIPayloadBase):
                  4: encode_4bit,
                  8: encode_8bit}
 
-    _sample_shape_template = namedtuple('_sample_shape_template', ['nchan',])
+    _sample_shape_cls = namedtuple('sample_shape', 'nchan')
+    _sample_shape_cls.__doc__ = "VDIF sample shape (single frame)."
 
     def __init__(self, words, header=None,
                  nchan=1, bps=2, complex_data=False):
@@ -146,7 +147,7 @@ class VDIFPayload(VLBIPayloadBase):
                 self._encoders = Mark5BPayload._encoders
                 if complex_data:
                     raise ValueError("VDIF/Mark5B payload cannot be complex.")
-        sample_shape = 
+        sample_shape = self._sample_shape_cls(nchan)
         super(VDIFPayload, self).__init__(words, bps=bps,
                                           sample_shape=sample_shape,
                                           complex_data=complex_data)

--- a/baseband/vdif/payload.py
+++ b/baseband/vdif/payload.py
@@ -132,7 +132,6 @@ class VDIFPayload(VLBIPayloadBase):
                  8: encode_8bit}
 
     _sample_shape_cls = namedtuple('sample_shape', 'nchan')
-    _sample_shape_cls.__doc__ = "VDIF sample shape (single frame)."
 
     def __init__(self, words, header=None,
                  nchan=1, bps=2, complex_data=False):

--- a/baseband/vdif/payload.py
+++ b/baseband/vdif/payload.py
@@ -131,7 +131,7 @@ class VDIFPayload(VLBIPayloadBase):
                  4: encode_4bit,
                  8: encode_8bit}
 
-    _sample_shape_cls = namedtuple('sample_shape', 'nchan')
+    _sample_shape_cls = namedtuple('SampleShape', 'nchan')
 
     def __init__(self, words, header=None,
                  nchan=1, bps=2, complex_data=False):

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -2,7 +2,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import io
 import numpy as np
 import pytest
 from astropy.time import Time

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -516,8 +516,8 @@ class TestVDIF(object):
         assert np.all(record.astype(int)[:, 0] ==
                       np.array([-1, -1, 3, -1, 1, -1, 3, -1, 1, 3, -1, 1]))
 
-        # Test that squeeze attribute works on read - except when out is
-        # passed - and sample_shape.
+        # Test that squeeze attribute works on read and sample shape, but is
+        # overridden when reading in-place.
         with vdif.open(SAMPLE_FILE, 'rs') as fh:
             assert tuple(fh.sample_shape) == (8,)
             assert fh.read(1).shape == (8,)
@@ -558,6 +558,14 @@ class TestVDIF(object):
             fh.seek(16)
             record = fh.read(16)
         assert np.all(record == data)
+
+        # Try writing an incomplete file.
+        vdif_incomplete = str(tmpdir.join('incomplete.vdif'))
+        with vdif.open(SAMPLE_FILE, 'rs') as fr:
+            fw = vdif.open(vdif_incomplete, 'ws', header=fr.header0,
+                           nthread=8, frames_per_second=1600)
+            fw.write(fr.read(10))
+            fw.close()
 
     def test_corrupt_stream(self):
         with vdif.open(SAMPLE_FILE, 'rb') as fh, io.BytesIO() as s:

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -222,7 +222,6 @@ class VLBIStreamReaderBase(VLBIStreamBase):
             return self._squeezed_shape
         return self._sample_shape
 
-
     @lazyproperty
     def header1(self):
         """Last header of the file."""

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -297,9 +297,8 @@ class VLBIStreamWriterBase(VLBIStreamBase):
         if extra != 0:
             warnings.warn("Closing with partial buffer remaining."
                           "Writing padded frame, marked as invalid.")
-            self.write(np.zeros((self.samples_per_frame - extra,
-                                 self._sample_shape)),
-                       invalid_data=True)
+            self.write(np.zeros((self.samples_per_frame - extra,) +
+                                self._sample_shape), invalid_data=True)
             assert self.offset % self.samples_per_frame == 0
         return super(VLBIStreamWriterBase, self).close()
 

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -90,7 +90,8 @@ class VLBIStreamBase(VLBIFileBase):
                                              ','.join(sqz_names))
                     self._squeezed_shape = sqz_shp_cls(*sqz_dims)
             return self._squeezed_shape
-        return self._sample_shape
+        else:
+            return self._sample_shape
 
     def _unsqueeze(self, data):
         new_shape = list(data.shape)

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -218,7 +218,6 @@ class VLBIStreamReaderBase(VLBIStreamBase):
                 dims = np.array(self._sample_shape)
                 keep_dims = (dims > 1)
                 sqz_shp = namedtuple('sample_shape', field_names[keep_dims])
-                sqz_shp.__doc__ = format_name + " sample shape (squeezed)."
                 self._squeezed_shape = sqz_shp(*dims[keep_dims])
             return self._squeezed_shape
         return self._sample_shape

--- a/baseband/vlbi_base/payload.py
+++ b/baseband/vlbi_base/payload.py
@@ -44,11 +44,14 @@ class VLBIPayloadBase(object):
     _encoders = {}
     _decoders = {}
     # Placeholder for sample shape named tuple.
-    _sample_shape_cls = tuple
+    _sample_shape_maker = None
 
     def __init__(self, words, bps=2, sample_shape=(), complex_data=False):
         self.words = words
-        self.sample_shape = sample_shape
+        if self._sample_shape_maker is not None:
+            self.sample_shape = self._sample_shape_maker(*sample_shape)
+        else:
+            self.sample_shape = sample_shape
         self.bps = bps
         self.complex_data = complex_data
         self._bpfs = (bps * (2 if complex_data else 1) *
@@ -100,12 +103,7 @@ class VLBIPayloadBase(object):
             Number of bits per sample to use (for complex data, for real and
             imaginary part separately; default: 2).
         """
-        try:
-            sample_shape = cls._sample_shape_cls(*data.shape[1:])
-        # If _sample_shape_cls is an unnamed tuple (or list), the above returns
-        # a TypeError, so we try initialization without dereferencing.
-        except TypeError:
-            sample_shape = cls._sample_shape_cls(data.shape[1:])
+        sample_shape = data.shape[1:]
         complex_data = data.dtype.kind == 'c'
         try:
             encoder = cls._encoders[bps]

--- a/baseband/vlbi_base/payload.py
+++ b/baseband/vlbi_base/payload.py
@@ -37,12 +37,14 @@ class VLBIPayloadBase(object):
     """
     # Possible fixed payload size.
     _size = None
-    # Default type for encoded data
+    # Default type for encoded data.
     _dtype_word = np.dtype('<u4')
     """Default for words: 32-bit unsigned integers, with lsb first."""
     # To be defined by subclasses.
     _encoders = {}
     _decoders = {}
+    # Placeholder for sample shape named tuple.
+    _sample_shape_cls = None
 
     def __init__(self, words, bps=2, sample_shape=(), complex_data=False):
         self.words = words

--- a/baseband/vlbi_base/payload.py
+++ b/baseband/vlbi_base/payload.py
@@ -44,7 +44,7 @@ class VLBIPayloadBase(object):
     _encoders = {}
     _decoders = {}
     # Placeholder for sample shape named tuple.
-    _sample_shape_cls = None
+    _sample_shape_cls = tuple
 
     def __init__(self, words, bps=2, sample_shape=(), complex_data=False):
         self.words = words
@@ -100,7 +100,12 @@ class VLBIPayloadBase(object):
             Number of bits per sample to use (for complex data, for real and
             imaginary part separately; default: 2).
         """
-        sample_shape = data.shape[1:]
+        try:
+            sample_shape = cls._sample_shape_cls(*data.shape[1:])
+        # If _sample_shape_cls is an unnamed tuple (or list), the above returns
+        # a TypeError, so we try initialization without dereferencing.
+        except TypeError:
+            sample_shape = cls._sample_shape_cls(data.shape[1:])
         complex_data = data.dtype.kind == 'c'
         try:
             encoder = cls._encoders[bps]

--- a/baseband/vlbi_base/tests/test_vlbi_base.py
+++ b/baseband/vlbi_base/tests/test_vlbi_base.py
@@ -128,8 +128,8 @@ class TestVLBIBase(object):
         with pytest.raises(TypeError):
             header.mutable = True
 
-    def test_header_fromfile(self):
-        with io.BytesIO() as s:
+    def test_header_fromfile(self, tmpdir):
+        with open(str(tmpdir.join('test.dat')), 'w+b') as s:
             s.write(four_word_struct.pack(*self.header.words))
             s.seek(2)
             with pytest.raises(EOFError):
@@ -306,8 +306,8 @@ class TestVLBIBase(object):
         with pytest.raises(ValueError):
             payload[1:3, :1] = np.ones((1, 2))
 
-    def test_payload_fromfile(self):
-        with io.BytesIO() as s:
+    def test_payload_fromfile(self, tmpdir):
+        with open(str(tmpdir.join('test.dat')), 'w+b') as s:
             self.payload.tofile(s)
             s.seek(0)
             with pytest.raises(ValueError):
@@ -378,8 +378,8 @@ class TestVLBIBase(object):
         assert frame2[3, 1] == 5
         assert frame2.payload != self.payload
 
-    def test_frame_fromfile(self):
-        with io.BytesIO() as s:
+    def test_frame_fromfile(self, tmpdir):
+        with open(str(tmpdir.join('test.dat')), 'w+b') as s:
             self.frame.tofile(s)
             s.seek(0)
             frame = self.Frame.fromfile(s, payloadsize=self.payload.size,

--- a/docs/baseband/dada/index.rst
+++ b/docs/baseband/dada/index.rst
@@ -44,7 +44,8 @@ writing is in units of samples, and one has access to header information.
     >>> fh = dada.open(SAMPLE_DADA, 'rs')
     >>> fh
     <DADAStreamReader name=... offset=0
-        samples_per_frame=16000, nchan=1, frames_per_second=1000.0, bps=8,
+        frames_per_second=1000.0, samples_per_frame=16000,
+        sample_shape=SampleShape(npol=2), bps=8,
         thread_ids=[0, 1], (start) time=2013-07-02T01:39:20.000>
     >>> d = fh.read(10000)
     >>> d.shape

--- a/docs/baseband/mark4/index.rst
+++ b/docs/baseband/mark4/index.rst
@@ -39,7 +39,8 @@ can be calculated (for longer files, this can be calculated from the file)::
     ...                 frames_per_second=400)
     >>> fh
     <Mark4StreamReader name=... offset=0
-        samples_per_frame=80000, nchan=8, frames_per_second=400, bps=2,
+        frames_per_second=400, samples_per_frame=80000,
+        sample_shape=SampleShape(nchan=8), bps=2,
         (start) time=2014-06-16T07:38:12.47500>
     >>> d = fh.read(6400)
     >>> d.shape

--- a/docs/baseband/vdif/index.rst
+++ b/docs/baseband/vdif/index.rst
@@ -72,9 +72,10 @@ information::
     >>> fh = vdif.open(SAMPLE_VDIF, 'rs')
     >>> fh
     <VDIFStreamReader name=... offset=0
-        nthread=8, samples_per_frame=20000, nchan=1,
-        frames_per_second=1600, complex_data=False, bps=2, edv=3,
-        station=65532, (start) time=2014-06-16T05:56:07.000000000>
+        frames_per_second=1600, samples_per_frame=20000,
+        sample_shape=SampleShape(nthread=8),
+        complex_data=False, bps=2, edv=3, station=65532,
+        (start) time=2014-06-16T05:56:07.000000000>
     >>> d = fh.read(12)
     >>> d.shape
     (12, 8)

--- a/docs/baseband/vdif/index.rst
+++ b/docs/baseband/vdif/index.rst
@@ -121,7 +121,8 @@ identical.::
 For small files, one could just do::
 
     >>> with vdif.open(SAMPLE_VDIF, 'rs') as fr, vdif.open(
-    ...         'try.vdif', 'ws', header=fr.header0, nthread=fr.nthread) as fw:
+    ...         'try.vdif', 'ws', header=fr.header0,
+    ...         nthread=fr.sample_shape.nthread) as fw:
     ...     fw.write(fr.read())
 
 This copies everything to memory, though, and some header information is lost.


### PR DESCRIPTION
Added named tuple sample shapes to all format payloads and stream readers.  Created a `sample_shape` property in `vlbi_base` that's inherited by all formats to generate a squeezed sample shape as needed.  `squeeze` is now a keyword for stream reader `__init__`, which adds it as an instance property so that both `sample_shape` and `read` have access to it.  Left stream writers alone so that the user can write squeezed and unsqueezed data consecutively without having to change instance attributes.  All references to `nthread` or `nchan` now redirect to sample shape fields, allowing us to be self-consistent with the definition of `nthread`.  For formats where `nthread` used to be `len(thread_ids)` when `thread_ids` is user-defined and less than the total number of threads, now `sample_shape` takes this into account directly in `nchan` (leading to a mismatch between that value and `header.nchan`, but I think it's an acceptable loss).

User-selected threads/channels are still always called `thread_ids`, which feels wrong for Mark 4, DADA, etc.

Annoyingly DADA has a `sample_shape` header derived property.  I feel like we should either remove it, or include one for all other headers and have it passed to their payloads.  I think the former makes much more sense.