### PR TITLE
Use np.frombuffer rather than np.fromstring to read binary data.

### DIFF
--- a/baseband/helpers/tests/test_sequentialfile.py
+++ b/baseband/helpers/tests/test_sequentialfile.py
@@ -20,7 +20,7 @@ class Sequencer(object):
 class TestSequentialFileReader(object):
     def setup(self):
         self.data = b'abcdefghijklmnopqrstuvwxyz'
-        self.uint8_data = np.fromstring(self.data, dtype=np.uint8)
+        self.uint8_data = np.frombuffer(self.data, dtype=np.uint8)
         self.size = len(self.data)
         self.files = ['file{:1d}.raw'.format(i) for i in range(3)]
         self.max_file_size = 10
@@ -171,7 +171,7 @@ class TestSequentialFileReader(object):
 class TestSequentialFileWriter(object):
     def _setup(self, tmpdir):
         self.data = b'abcdefghijklmnopqrstuvwxyz'
-        self.uint8_data = np.fromstring(self.data, dtype=np.uint8)
+        self.uint8_data = np.frombuffer(self.data, dtype=np.uint8)
         self.files = [str(tmpdir.join('file{:1d}.raw'.format(i)))
                       for i in range(3)]
 

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -99,7 +99,7 @@ class Mark4FileReader(VLBIFileBase):
         for frame in iterate:
             fh.seek(frame)
 
-            data = np.fromstring(fh.read(block), dtype=np.uint8)
+            data = np.frombuffer(fh.read(block), dtype=np.uint8)
             assert len(data) == block
             # Find header pattern.
             databits1 = nbits[data]
@@ -127,7 +127,7 @@ class Mark4FileReader(VLBIFileBase):
                             break
 
                 fh.seek(check + 32 * 2 * ntrack // 8)
-                check_data = np.fromstring(fh.read(len(nunset)),
+                check_data = np.frombuffer(fh.read(len(nunset)),
                                            dtype=np.uint8)
                 databits2 = nbits[check_data]
                 if np.all(databits2 >= 6):

--- a/baseband/mark4/header.py
+++ b/baseband/mark4/header.py
@@ -293,7 +293,7 @@ class Mark4Header(Mark4TrackHeader):
         dtype = cls._stream_dtype(ntrack)
         size = ntrack * 5 * 32 // 8
         try:
-            stream = np.fromstring(fh.read(size), dtype=dtype)
+            stream = np.frombuffer(fh.read(size), dtype=dtype)
             assert len(stream) * dtype.itemsize == size
         except (ValueError, AssertionError):
             raise EOFError("Could not read full Mark 4 Header.")

--- a/baseband/mark4/payload.py
+++ b/baseband/mark4/payload.py
@@ -234,7 +234,7 @@ class Mark4Payload(VLBIPayloadBase):
         s = fh.read(header.payloadsize)
         if len(s) < header.payloadsize:
             raise EOFError("Could not read full payload.")
-        return cls(np.fromstring(s, dtype=header.stream_dtype), header)
+        return cls(np.frombuffer(s, dtype=header.stream_dtype), header)
 
     @classmethod
     def fromdata(cls, data, header):

--- a/baseband/vdif/payload.py
+++ b/baseband/vdif/payload.py
@@ -163,7 +163,7 @@ class VDIFPayload(VLBIPayloadBase):
         s = fh.read(header.payloadsize)
         if len(s) < header.payloadsize:
             raise EOFError("Could not read full payload.")
-        return cls(np.fromstring(s, dtype=cls._dtype_word), header)
+        return cls(np.frombuffer(s, dtype=cls._dtype_word), header)
 
     @classmethod
     def fromdata(cls, data, header=None, bps=2, edv=None):

--- a/baseband/vlbi_base/payload.py
+++ b/baseband/vlbi_base/payload.py
@@ -79,7 +79,7 @@ class VLBIPayloadBase(object):
         s = fh.read(payloadsize)
         if len(s) < payloadsize:
             raise EOFError("Could not read full payload.")
-        return cls(np.fromstring(s, dtype=cls._dtype_word), *args, **kwargs)
+        return cls(np.frombuffer(s, dtype=cls._dtype_word), *args, **kwargs)
 
     def tofile(self, fh):
         """Write VLBI payload to filehandle."""


### PR DESCRIPTION
https://github.com/numpy/numpy/pull/9487 made me realize I've been misusing `np.fromstring`, and that to interpret a byte string as numbers, one really should use `np.frombuffer`. (This should avoid deprecation errors with numpy >=1.14.)