### PR TITLE
Time1 and header1 are now private, added properties in VLBIStreamBase so they're visible in documentation

### DIFF
--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -231,11 +231,11 @@ class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase, DADAFileReader):
         self._get_frame(0)
 
     @lazyproperty
-    def _header_last(self):
+    def _last_header(self):
         """Header of the last file for this stream."""
         self.fh_raw.seek(-self.header0.framesize, 2)
-        frame_last = self.read_frame(memmap=True)
-        return frame_last.header
+        last_frame = self.read_frame(memmap=True)
+        return last_frame.header
 
     def read(self, count=None, out=None):
         """Read count samples.

--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -231,7 +231,7 @@ class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase, DADAFileReader):
         self._get_frame(0)
 
     @lazyproperty
-    def header1(self):
+    def _header1(self):
         """Header of the last file for this stream."""
         self.fh_raw.seek(-self.header0.framesize, 2)
         frame1 = self.read_frame(memmap=True)

--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -231,11 +231,11 @@ class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase, DADAFileReader):
         self._get_frame(0)
 
     @lazyproperty
-    def _header1(self):
+    def _header_last(self):
         """Header of the last file for this stream."""
         self.fh_raw.seek(-self.header0.framesize, 2)
-        frame1 = self.read_frame(memmap=True)
-        return frame1.header
+        frame_last = self.read_frame(memmap=True)
+        return frame_last.header
 
     def read(self, count=None, out=None):
         """Read count samples.

--- a/baseband/dada/header.py
+++ b/baseband/dada/header.py
@@ -13,6 +13,7 @@ from collections import OrderedDict
 import astropy.units as u
 from astropy.time import Time
 from astropy.extern import six
+from astropy.utils import deprecated
 
 
 __all__ = ['DADAHeader']
@@ -54,7 +55,7 @@ class DADAHeader(OrderedDict):
 
     _properties = ('payloadsize', 'framesize', 'bps', 'complex_data',
                    'sample_shape', 'bandwidth', 'sideband', 'tsamp',
-                   'samples_per_frame', 'offset', 'time_start', 'time')
+                   'samples_per_frame', 'offset', 'start_time', 'time')
     """Properties accessible/usable in initialisation for all headers."""
 
     _defaults = [('HEADER', 'DADA'),
@@ -383,7 +384,7 @@ class DADAHeader(OrderedDict):
                                 self['NPOL'] * self['NCHAN'] + 7) // 8))
 
     @property
-    def time_start(self):
+    def start_time(self):
         """Start time of the observation."""
         mjd_int, frac = self['MJD_START'].split('.')
         mjd_int = int(mjd_int)
@@ -391,24 +392,31 @@ class DADAHeader(OrderedDict):
         # replace '-' between date and time with a 'T' and convert to Time
         return Time(mjd_int, frac, scale='utc', format='mjd')
 
-    @time_start.setter
-    def time_start(self, time_start):
-        time_start = Time(time_start, scale='utc', format='isot', precision=9)
-        self['UTC_START'] = (time_start.isot.replace('T', '-')
+    @start_time.setter
+    def start_time(self, start_time):
+        start_time = Time(start_time, scale='utc', format='isot', precision=9)
+        self['UTC_START'] = (start_time.isot.replace('T', '-')
                              .replace('.000000000', ''))
-        mjd_int = int(time_start.mjd)
-        mjd_frac = (time_start - Time(mjd_int, format='mjd',
-                                      scale=time_start.scale)).jd
+        mjd_int = int(start_time.mjd)
+        mjd_frac = (start_time - Time(mjd_int, format='mjd',
+                                      scale=start_time.scale)).jd
         if mjd_frac < 0:
             mjd_int -= 1
             mjd_frac += 1.
         self['MJD_START'] = ('{0:05d}'.format(mjd_int) +
                              ('{0:17.15f}'.format(mjd_frac))[1:])
 
+    @deprecated('0.X', name='time0', alternative='start_time',
+                obj_type='attribute')
+    def get_time0(self):
+        return self.start_time
+
+    time0 = property(get_time0, None, None)
+
     @property
     def time(self):
         """Start time the part of the observation covered by this header."""
-        return self.time_start + self.offset
+        return self.start_time + self.offset
 
     @time.setter
     def time(self, time):
@@ -422,7 +430,7 @@ class DADAHeader(OrderedDict):
         time : `~astropy.time.Time`
             Time for the first sample associated with this header.
         """
-        self.time_start = time - self.offset
+        self.start_time = time - self.offset
 
     def __eq__(self, other):
         """Whether headers have the same keys with the same values."""

--- a/baseband/dada/tests/test_dada.py
+++ b/baseband/dada/tests/test_dada.py
@@ -273,8 +273,8 @@ class TestDADA(object):
                           (time0 + 10002 / (16*u.MHz))) < 1. * u.ns
             fh.seek(fh.time0 + 1000 / (16*u.MHz))
             assert fh.tell() == 1000
-            assert fh.header1 == fh.header0
-            assert np.abs(fh.time1 - (time0 + 16000 / (16.*u.MHz))) < 1.*u.ns
+            assert fh._header1 == fh.header0
+            assert np.abs(fh._time1 - (time0 + 16000 / (16.*u.MHz))) < 1.*u.ns
 
         assert record1.shape == (12, 2)
         assert np.all(record1[:3] == np.array(
@@ -299,7 +299,7 @@ class TestDADA(object):
             assert fh.time0 == time0
             assert np.abs(fh.tell(unit='time') -
                           (time0 + 16000 / (16.*u.MHz))) < 1.*u.ns
-            assert fh.time1 == fh.tell(unit='time')
+            assert fh._time1 == fh.tell(unit='time')
         assert np.all(data == self.payload.data.squeeze())
         # Try single polarisation, and check initialisation by header keywords.
         h = self.header
@@ -314,7 +314,7 @@ class TestDADA(object):
         with dada.open(filename, 'rs') as fh:
             data = fh.read()
             assert np.abs(fh.time0 - time0) < 1.*u.ns
-            assert np.abs(fh.time1 - (time0 + 16000 / (16.*u.MHz))) < 1.*u.ns
+            assert np.abs(fh._time1 - (time0 + 16000 / (16.*u.MHz))) < 1.*u.ns
         assert np.all(data == self.payload.data[:, 0, 0])
 
         # Try reading a single polarization.
@@ -399,9 +399,9 @@ class TestDADA(object):
         with dada.open(filenames, 'rs') as fr:
             assert fr.time0 == time0
             assert fr.tell(unit='time') == time0
-            assert np.abs(fr.time1 - (time0 + 16000 / (16.*u.MHz))) < 1.*u.ns
+            assert np.abs(fr._time1 - (time0 + 16000 / (16.*u.MHz))) < 1.*u.ns
             data2 = fr.read()
-            assert fr.tell(unit='time') == fr.time1
+            assert fr.tell(unit='time') == fr._time1
         assert np.all(data2 == data)
 
     def test_template_stream(self, tmpdir):
@@ -420,16 +420,16 @@ class TestDADA(object):
 
         with dada.open(template.format(frame_nr=1), 'rs') as fr:
             data1 = fr.read()
-            assert fr.tell(unit='time') == fr.time1
+            assert fr.tell(unit='time') == fr._time1
             assert np.abs(fr.time0 - (time0 + 4000 / (16.*u.MHz))) < 1.*u.ns
-            assert np.abs(fr.time1 - (time0 + 8000 / (16.*u.MHz))) < 1.*u.ns
+            assert np.abs(fr._time1 - (time0 + 8000 / (16.*u.MHz))) < 1.*u.ns
         assert np.all(data1 == data[4000:8000])
 
         with dada.open(template, 'rs') as fr:
             assert fr.tell(unit='time') == time0
             data2 = fr.read()
-            assert fr.time1 == fr.tell(unit='time')
-            assert np.abs(fr.time1 -
+            assert fr._time1 == fr.tell(unit='time')
+            assert np.abs(fr._time1 -
                           (header.time + 16000 / (16.*u.MHz))) < 1.*u.ns
         assert np.all(data2 == data)
 
@@ -452,9 +452,9 @@ class TestDADA(object):
                                 3 * header.payloadsize)
         with dada.open(name3, 'rs') as fr:
             assert np.abs(fr.time0 - (time0 + 6000 / (16.*u.MHz))) < 1.*u.ns
-            assert np.abs(fr.time1 - (time0 + 8000 / (16.*u.MHz))) < 1.*u.ns
+            assert np.abs(fr._time1 - (time0 + 8000 / (16.*u.MHz))) < 1.*u.ns
             data1 = fr.read()
-            assert fr.time1 == fr.tell(unit='time')
+            assert fr._time1 == fr.tell(unit='time')
         assert np.all(data1 == data[6000:8000])
 
         # we cannot just open using the same template, since UTC_START is
@@ -470,8 +470,8 @@ class TestDADA(object):
             assert np.abs(fr.tell(unit='time') -
                           (time0 + 6000 / (16.*u.MHz))) < 1.*u.ns
             data2 = fr.read()
-            assert fr.tell(unit='time') == fr.time1
-            assert np.abs(fr.time1 - (time0 + 16000 / (16.*u.MHz))) < 1.*u.ns
+            assert fr.tell(unit='time') == fr._time1
+            assert np.abs(fr._time1 - (time0 + 16000 / (16.*u.MHz))) < 1.*u.ns
         assert np.all(data2 == data[6000:])
 
         # just to check internal checks are OK.

--- a/baseband/dada/tests/test_dada.py
+++ b/baseband/dada/tests/test_dada.py
@@ -70,13 +70,13 @@ class TestDADA(object):
         assert header3 == header
         assert header3.mutable is True
         # check attribute setting.
-        header3.time_start = header.time_start - 0.5 * u.day
-        assert np.abs(header3.time_start -
-                      (header.time_start - 0.5 * u.day)) < 1 * u.ns
+        header3.start_time = header.start_time - 0.5 * u.day
+        assert np.abs(header3.start_time -
+                      (header.start_time - 0.5 * u.day)) < 1 * u.ns
         assert np.abs(header3.time - (header.time - 0.5 * u.day)) < 1 * u.ns
         # check against rounding.
         just_below_int = Time(55000, -1e-15, format='mjd')
-        header3.time_start = just_below_int
+        header3.start_time = just_below_int
         assert header3['MJD_START'] == '54999.999999999999999'
         header3['NCHAN'] = 2
         assert header3['NCHAN'] == 2
@@ -85,8 +85,8 @@ class TestDADA(object):
         # # Try initialising with properties instead of keywords.
         # Here, we first just try the start time.
         header4 = dada.DADAHeader.fromvalues(
-            time_start=header.time_start,
-            offset=header.time-header.time_start,
+            start_time=header.start_time,
+            offset=header.time-header.start_time,
             bps=header.bps, complex_data=header.complex_data,
             bandwidth=header.bandwidth, sideband=header.sideband,
             samples_per_frame=header.samples_per_frame,
@@ -260,24 +260,25 @@ class TestDADA(object):
         assert frame9 == frame
 
     def test_filestreamer(self, tmpdir):
-        time_start = self.header.time
+        start_time = self.header.time
         with dada.open(SAMPLE_FILE, 'rs') as fh:
             assert fh.header0 == self.header
             assert fh.size == 16000
-            assert fh.time_start == time_start
+            assert fh.start_time == start_time
             record1 = fh.read(12)
             assert fh.tell() == 12
             fh.seek(10000)
             record2 = np.zeros((2, 2), dtype=np.complex64)
             record2 = fh.read(out=record2)
             assert fh.tell() == 10002
-            assert np.abs(fh.tell(unit='time') -
-                          (time_start + 10002 / (16*u.MHz))) < 1. * u.ns
-            fh.seek(fh.time_start + 1000 / (16*u.MHz))
+            assert fh.current_time == fh.tell(unit='time')
+            assert np.abs(fh.current_time -
+                          (start_time + 10002 / (16*u.MHz))) < 1. * u.ns
+            fh.seek(fh.start_time + 1000 / (16*u.MHz))
             assert fh.tell() == 1000
             assert fh._header_last == fh.header0
-            assert np.abs(fh.time_end -
-                          (time_start + 16000 / (16.*u.MHz))) < 1.*u.ns
+            assert np.abs(fh.stop_time -
+                          (start_time + 16000 / (16.*u.MHz))) < 1.*u.ns
 
         assert record1.shape == (12, 2)
         assert np.all(record1[:3] == np.array(
@@ -293,16 +294,16 @@ class TestDADA(object):
         with dada.open(filename, 'ws', header=self.header,
                        squeeze=False) as fw:
             fw.write(self.payload.data)
-            assert fw.time_start == time_start
-            assert np.abs(fw.tell(unit='time') -
-                          (time_start + 16000 / (16.*u.MHz))) < 1.*u.ns
+            assert fw.start_time == start_time
+            assert np.abs(fw.current_time -
+                          (start_time + 16000 / (16.*u.MHz))) < 1.*u.ns
 
         with dada.open(filename, 'rs') as fh:
             data = fh.read()
-            assert fh.time_start == time_start
-            assert np.abs(fh.tell(unit='time') -
-                          (time_start + 16000 / (16.*u.MHz))) < 1.*u.ns
-            assert fh.time_end == fh.tell(unit='time')
+            assert fh.start_time == start_time
+            assert np.abs(fh.current_time -
+                          (start_time + 16000 / (16.*u.MHz))) < 1.*u.ns
+            assert fh.stop_time == fh.current_time
         assert np.all(data == self.payload.data.squeeze())
         # Try single polarisation, and check initialisation by header keywords.
         h = self.header
@@ -310,14 +311,14 @@ class TestDADA(object):
                        complex_data=h.complex_data, bandwidth=h.bandwidth,
                        payloadsize=32000, nthread=1, nchan=1) as fw:
             fw.write(self.payload.data[:, 0, 0])
-            assert np.abs(fw.time_start - time_start) < 1.*u.ns
-            assert np.abs(fw.tell(unit='time') -
-                          (time_start + 16000 / (16.*u.MHz))) < 1.*u.ns
+            assert np.abs(fw.start_time - start_time) < 1.*u.ns
+            assert np.abs(fw.current_time -
+                          (start_time + 16000 / (16.*u.MHz))) < 1.*u.ns
 
         with dada.open(filename, 'rs') as fh:
             data = fh.read()
-            assert np.abs(fh.time_start - time_start) < 1.*u.ns
-            assert np.abs(fh.time_end - (time_start + 16000 / (16.*u.MHz))) < 1.*u.ns
+            assert np.abs(fh.start_time - start_time) < 1.*u.ns
+            assert np.abs(fh.stop_time - (start_time + 16000 / (16.*u.MHz))) < 1.*u.ns
         assert np.all(data == self.payload.data[:, 0, 0])
 
         # Try reading a single polarization.
@@ -377,64 +378,65 @@ class TestDADA(object):
             assert np.all(data[10:] == fwr._frame.invalid_data_value)
 
     def test_multiple_files_stream(self, tmpdir):
-        time_start = self.header.time
+        start_time = self.header.time
         data = self.payload.data.squeeze()
         header = self.header.copy()
         header.payloadsize = self.header.payloadsize // 2
         filenames = (str(tmpdir.join('a.dada')),
                      str(tmpdir.join('b.dada')))
         with dada.open(filenames, 'ws', header=header) as fw:
-            time_start = fw.time_start
+            start_time = fw.start_time
             fw.write(data[:1000])
-            time1000 = fw.tell(unit='time')
+            time1000 = fw.current_time
             fw.write(data[1000:])
-            time_end = fw.tell(unit='time')
-        assert time_start == header.time
-        assert np.abs(time1000 - (time_start + 1000 / (16.*u.MHz))) < 1.*u.ns
-        assert np.abs(time_end - (time_start + 16000 / (16.*u.MHz))) < 1.*u.ns
+            stop_time = fw.current_time
+        assert start_time == header.time
+        assert np.abs(time1000 - (start_time + 1000 / (16.*u.MHz))) < 1.*u.ns
+        assert np.abs(stop_time - (start_time + 16000 / (16.*u.MHz))) < 1.*u.ns
 
         with dada.open(filenames[1], 'rs') as fr:
-            assert np.abs(fr.tell(unit='time') -
-                          (time_start + 8000 / (16.*u.MHz))) < 1.*u.ns
+            assert np.abs(fr.current_time -
+                          (start_time + 8000 / (16.*u.MHz))) < 1.*u.ns
             data1 = fr.read()
         assert np.all(data1 == data[8000:])
 
         with dada.open(filenames, 'rs') as fr:
-            assert fr.time_start == time_start
-            assert fr.tell(unit='time') == time_start
-            assert np.abs(fr.time_end - (time_start + 16000 / (16.*u.MHz))) < 1.*u.ns
+            assert fr.start_time == start_time
+            assert fr.current_time == start_time
+            assert np.abs(fr.stop_time - (start_time + 16000 / (16.*u.MHz))) < 1.*u.ns
             data2 = fr.read()
-            assert fr.tell(unit='time') == fr.time_end
+            assert fr.current_time == fr.stop_time
         assert np.all(data2 == data)
 
     def test_template_stream(self, tmpdir):
-        time_start = self.header.time
+        start_time = self.header.time
         data = self.payload.data.squeeze()
         header = self.header.copy()
         header.payloadsize = self.header.payloadsize // 4
         template = str(tmpdir.join('a{frame_nr}.dada'))
         with dada.open(template, 'ws', header=header) as fw:
             fw.write(data[:1000])
-            time1000 = fw.tell(unit='time')
+            time1000 = fw.current_time
             fw.write(data[1000:])
-            time_end = fw.tell(unit='time')
+            stop_time = fw.current_time
         assert np.abs(time1000 - (header.time + 1000 / (16.*u.MHz))) < 1.*u.ns
-        assert np.abs(time_end - (header.time + 16000 / (16.*u.MHz))) < 1.*u.ns
+        assert np.abs(stop_time - (header.time + 16000 /
+                                   (16.*u.MHz))) < 1.*u.ns
 
         with dada.open(template.format(frame_nr=1), 'rs') as fr:
             data1 = fr.read()
-            assert fr.tell(unit='time') == fr.time_end
-            assert np.abs(fr.time_start -
-                          (time_start + 4000 / (16.*u.MHz))) < 1.*u.ns
-            assert np.abs(fr.time_end -
-                          (time_start + 8000 / (16.*u.MHz))) < 1.*u.ns
+            assert fr.current_time == fr.stop_time
+            assert np.abs(fr.start_time -
+                          (start_time + 4000 / (16.*u.MHz))) < 1.*u.ns
+            assert np.abs(fr.stop_time -
+                          (start_time + 8000 / (16.*u.MHz))) < 1.*u.ns
         assert np.all(data1 == data[4000:8000])
 
         with dada.open(template, 'rs') as fr:
-            assert fr.tell(unit='time') == time_start
+            assert fr.current_time == start_time
             data2 = fr.read()
-            assert fr.time_end == fr.tell(unit='time')
-            assert np.abs(fr.time_end -
+            assert fr.stop_time == fr.current_time
+            assert np.abs(fr.stop_time -
                           (header.time + 16000 / (16.*u.MHz))) < 1.*u.ns
         assert np.all(data2 == data)
 
@@ -444,24 +446,24 @@ class TestDADA(object):
                        .join('{utc_start}_{obs_offset:016d}.000000.dada'))
         with dada.open(template, 'ws', header=header) as fw:
             fw.write(data[:7000])
-            assert fw.time_start == header.time
-            assert np.abs(fw.tell(unit='time') -
-                          (time_start + 7000 / (16.*u.MHz))) < 1.*u.ns
+            assert fw.start_time == header.time
+            assert np.abs(fw.current_time -
+                          (start_time + 7000 / (16.*u.MHz))) < 1.*u.ns
             assert fw._frame_nr == 3
             fw.write(data[7000:])
-            assert np.abs(fw.tell(unit='time') -
-                          (time_start + 16000 / (16.*u.MHz))) < 1.*u.ns
+            assert np.abs(fw.current_time -
+                          (start_time + 16000 / (16.*u.MHz))) < 1.*u.ns
 
         name3 = template.format(utc_start=header['UTC_START'],
                                 obs_offset=header['OBS_OFFSET'] +
                                 3 * header.payloadsize)
         with dada.open(name3, 'rs') as fr:
-            assert np.abs(fr.time_start -
-                          (time_start + 6000 / (16.*u.MHz))) < 1.*u.ns
-            assert np.abs(fr.time_end -
-                          (time_start + 8000 / (16.*u.MHz))) < 1.*u.ns
+            assert np.abs(fr.start_time -
+                          (start_time + 6000 / (16.*u.MHz))) < 1.*u.ns
+            assert np.abs(fr.stop_time -
+                          (start_time + 8000 / (16.*u.MHz))) < 1.*u.ns
             data1 = fr.read()
-            assert fr.time_end == fr.tell(unit='time')
+            assert fr.stop_time == fr.current_time
         assert np.all(data1 == data[6000:8000])
 
         # we cannot just open using the same template, since UTC_START is
@@ -474,12 +476,12 @@ class TestDADA(object):
                       3 * header.payloadsize,
                       FILE_SIZE=header['FILE_SIZE'])
         with dada.open(template, 'rs', **kwargs) as fr:
-            assert np.abs(fr.tell(unit='time') -
-                          (time_start + 6000 / (16.*u.MHz))) < 1.*u.ns
+            assert np.abs(fr.current_time -
+                          (start_time + 6000 / (16.*u.MHz))) < 1.*u.ns
             data2 = fr.read()
-            assert fr.tell(unit='time') == fr.time_end
-            assert np.abs(fr.time_end -
-                          (time_start + 16000 / (16.*u.MHz))) < 1.*u.ns
+            assert fr.current_time == fr.stop_time
+            assert np.abs(fr.stop_time -
+                          (start_time + 16000 / (16.*u.MHz))) < 1.*u.ns
         assert np.all(data2 == data[6000:])
 
         # just to check internal checks are OK.

--- a/baseband/gsb/base.py
+++ b/baseband/gsb/base.py
@@ -200,7 +200,7 @@ class GSBStreamReader(GSBStreamBase, VLBIStreamReaderBase):
         self._frame_nr = None
 
     @lazyproperty
-    def header1(self):
+    def _header1(self):
         """Last header of the timestamp file."""
         fh_ts_offset = self.fh_ts.tell()
         from_end = 3 * self._header0_size // 2

--- a/baseband/gsb/base.py
+++ b/baseband/gsb/base.py
@@ -165,7 +165,7 @@ class GSBStreamBase(VLBIStreamBase):
                 "    frames_per_second={s.frames_per_second:.3f},"
                 " samples_per_frame={s.samples_per_frame},\n"
                 "    sample_shape={s.sample_shape}, bps={s.bps},\n"
-                "    {t}time_start={s.time_start.isot}>"
+                "    {t}start_time={s.start_time.isot}>"
                 .format(s=self, dn=data_name, t=(
                     'thread_ids={0}, '.format(self.thread_ids) if
                     self.thread_ids else '')))
@@ -263,7 +263,7 @@ class GSBStreamReader(GSBStreamBase, VLBIStreamReaderBase):
                 self._read_frame(fill_value)
                 assert np.isclose(self._frame_nr, self.frames_per_second *
                                   (self._frame.header.time -
-                                   self.time_start).to(u.s).value)
+                                   self.start_time).to(u.s).value)
 
             # Copy relevant data from frame into output.
             nsample = min(count, self.samples_per_frame - sample_offset)

--- a/baseband/gsb/base.py
+++ b/baseband/gsb/base.py
@@ -165,7 +165,7 @@ class GSBStreamBase(VLBIStreamBase):
                 "    frames_per_second={s.frames_per_second:.3f},"
                 " samples_per_frame={s.samples_per_frame},\n"
                 "    sample_shape={s.sample_shape}, bps={s.bps},\n"
-                "    {t}(start) time={s.time0.isot}>"
+                "    {t}time_start={s.time_start.isot}>"
                 .format(s=self, dn=data_name, t=(
                     'thread_ids={0}, '.format(self.thread_ids) if
                     self.thread_ids else '')))
@@ -200,7 +200,7 @@ class GSBStreamReader(GSBStreamBase, VLBIStreamReaderBase):
         self._frame_nr = None
 
     @lazyproperty
-    def _header1(self):
+    def _header_last(self):
         """Last header of the timestamp file."""
         fh_ts_offset = self.fh_ts.tell()
         from_end = 3 * self._header0_size // 2
@@ -263,7 +263,7 @@ class GSBStreamReader(GSBStreamBase, VLBIStreamReaderBase):
                 self._read_frame(fill_value)
                 assert np.isclose(self._frame_nr, self.frames_per_second *
                                   (self._frame.header.time -
-                                   self.time0).to(u.s).value)
+                                   self.time_start).to(u.s).value)
 
             # Copy relevant data from frame into output.
             nsample = min(count, self.samples_per_frame - sample_offset)

--- a/baseband/gsb/base.py
+++ b/baseband/gsb/base.py
@@ -200,7 +200,7 @@ class GSBStreamReader(GSBStreamBase, VLBIStreamReaderBase):
         self._frame_nr = None
 
     @lazyproperty
-    def _header_last(self):
+    def _last_header(self):
         """Last header of the timestamp file."""
         fh_ts_offset = self.fh_ts.tell()
         from_end = 3 * self._header0_size // 2

--- a/baseband/gsb/tests/test_gsb.py
+++ b/baseband/gsb/tests/test_gsb.py
@@ -379,7 +379,7 @@ class TestGSB(object):
             data = fh_r.read()
             assert fh_r.tell() == len(data)
             assert_quantity_allclose(fh_r.tell(unit=u.s), 1. * u.s)
-            assert fh_r._header_last == header
+            assert fh_r._last_header == header
             # recheck with output array given
             out = np.zeros_like(self.data).squeeze()
             fh_r.seek(0)
@@ -410,7 +410,7 @@ class TestGSB(object):
                 assert np.isclose(fh_r.frames_per_second, 2)
                 data = fh_r.read(len(self.data) * 2)
                 assert_quantity_allclose(
-                    (fh_r._header_last.time - fh_r.header0.time).to(u.s),
+                    (fh_r._last_header.time - fh_r.header0.time).to(u.s),
                     u.s/fh_r.frames_per_second)
             assert np.all(data.reshape(2, -1) == self.data.ravel())
 
@@ -464,7 +464,7 @@ class TestGSB(object):
                     fh_r.header0['seq_nr'] + 3)
             assert_quantity_allclose(fh_r.tell(unit=u.s), 0.5 * u.s)
             assert fh_r.fh_raw[0][0].tell() == 2048 * bps // 8
-            assert fh_r._frame.header == fh_r._header_last
+            assert fh_r._frame.header == fh_r._last_header
 
         assert np.all(data[:onepol.shape[0]] == onepol.squeeze())
         assert np.all(data[onepol.shape[0]:] == onepol[::-1].squeeze())
@@ -502,7 +502,7 @@ class TestGSB(object):
                         fh_r.header0['seq_nr'] + 3)
                 assert_quantity_allclose(fh_r.tell(unit=u.s), 0.5 * u.s)
                 assert sp0.tell() == 1024 * bps // 8
-                assert fh_r._frame.header == fh_r._header_last
+                assert fh_r._frame.header == fh_r._last_header
             assert np.all(data[:twopol.shape[0]] == twopol)
             assert np.all(data[twopol.shape[0]:] == twopol[::-1])
 

--- a/baseband/gsb/tests/test_gsb.py
+++ b/baseband/gsb/tests/test_gsb.py
@@ -379,7 +379,7 @@ class TestGSB(object):
             data = fh_r.read()
             assert fh_r.tell() == len(data)
             assert_quantity_allclose(fh_r.tell(unit=u.s), 1. * u.s)
-            assert fh_r._header1 == header
+            assert fh_r._header_last == header
             # recheck with output array given
             out = np.zeros_like(self.data).squeeze()
             fh_r.seek(0)
@@ -410,7 +410,7 @@ class TestGSB(object):
                 assert np.isclose(fh_r.frames_per_second, 2)
                 data = fh_r.read(len(self.data) * 2)
                 assert_quantity_allclose(
-                    (fh_r._header1.time - fh_r.header0.time).to(u.s),
+                    (fh_r._header_last.time - fh_r.header0.time).to(u.s),
                     u.s/fh_r.frames_per_second)
             assert np.all(data.reshape(2, -1) == self.data.ravel())
 
@@ -464,7 +464,7 @@ class TestGSB(object):
                     fh_r.header0['seq_nr'] + 3)
             assert_quantity_allclose(fh_r.tell(unit=u.s), 0.5 * u.s)
             assert fh_r.fh_raw[0][0].tell() == 2048 * bps // 8
-            assert fh_r._frame.header == fh_r._header1
+            assert fh_r._frame.header == fh_r._header_last
 
         assert np.all(data[:onepol.shape[0]] == onepol.squeeze())
         assert np.all(data[onepol.shape[0]:] == onepol[::-1].squeeze())
@@ -502,7 +502,7 @@ class TestGSB(object):
                         fh_r.header0['seq_nr'] + 3)
                 assert_quantity_allclose(fh_r.tell(unit=u.s), 0.5 * u.s)
                 assert sp0.tell() == 1024 * bps // 8
-                assert fh_r._frame.header == fh_r._header1
+                assert fh_r._frame.header == fh_r._header_last
             assert np.all(data[:twopol.shape[0]] == twopol)
             assert np.all(data[twopol.shape[0]:] == twopol[::-1])
 

--- a/baseband/gsb/tests/test_gsb.py
+++ b/baseband/gsb/tests/test_gsb.py
@@ -379,7 +379,7 @@ class TestGSB(object):
             data = fh_r.read()
             assert fh_r.tell() == len(data)
             assert_quantity_allclose(fh_r.tell(unit=u.s), 1. * u.s)
-            assert fh_r.header1 == header
+            assert fh_r._header1 == header
             # recheck with output array given
             out = np.zeros_like(self.data).squeeze()
             fh_r.seek(0)
@@ -410,7 +410,7 @@ class TestGSB(object):
                 assert np.isclose(fh_r.frames_per_second, 2)
                 data = fh_r.read(len(self.data) * 2)
                 assert_quantity_allclose(
-                    (fh_r.header1.time - fh_r.header0.time).to(u.s),
+                    (fh_r._header1.time - fh_r.header0.time).to(u.s),
                     u.s/fh_r.frames_per_second)
             assert np.all(data.reshape(2, -1) == self.data.ravel())
 
@@ -464,7 +464,7 @@ class TestGSB(object):
                     fh_r.header0['seq_nr'] + 3)
             assert_quantity_allclose(fh_r.tell(unit=u.s), 0.5 * u.s)
             assert fh_r.fh_raw[0][0].tell() == 2048 * bps // 8
-            assert fh_r._frame.header == fh_r.header1
+            assert fh_r._frame.header == fh_r._header1
 
         assert np.all(data[:onepol.shape[0]] == onepol.squeeze())
         assert np.all(data[onepol.shape[0]:] == onepol[::-1].squeeze())
@@ -502,7 +502,7 @@ class TestGSB(object):
                         fh_r.header0['seq_nr'] + 3)
                 assert_quantity_allclose(fh_r.tell(unit=u.s), 0.5 * u.s)
                 assert sp0.tell() == 1024 * bps // 8
-                assert fh_r._frame.header == fh_r.header1
+                assert fh_r._frame.header == fh_r._header1
             assert np.all(data[:twopol.shape[0]] == twopol)
             assert np.all(data[twopol.shape[0]:] == twopol[::-1])
 

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -560,7 +560,7 @@ class TestMark4(object):
                             sample_rate=32*u.MHz) as f2:
                 assert f2.header0 == frame.header
                 with pytest.raises(ValueError):
-                    f2.header1
+                    f2._header1
 
     def test_stream_invalid(self):
         with pytest.raises(ValueError):

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -319,7 +319,7 @@ class TestMark4(object):
         with mark4.open(SAMPLE_FILE, 'rb') as fh:
             fh.seek(0xa88)
             header0 = mark4.Mark4Header.fromfile(fh, ntrack=64, decade=2010)
-            time0 = header0.time
+            time_start = header0.time
             # use framesize, since header adds to payload.
             samples_per_frame = header0.framesize * 8 // 2 // 8
             frame_rate = 32. * u.MHz / samples_per_frame
@@ -331,7 +331,7 @@ class TestMark4(object):
                 except EOFError:
                     break
                 header_time = frame.header.time
-                expected = time0 + frame_nr * frame_duration
+                expected = time_start + frame_nr * frame_duration
                 assert abs(header_time - expected) < 1. * u.ns
 
     def test_find_header(self, tmpdir):
@@ -461,25 +461,25 @@ class TestMark4(object):
 
         with mark4.open(SAMPLE_FILE, 'rs', ntrack=64, decade=2010,
                         sample_rate=32*u.MHz) as fh:
-            time0 = fh.tell(unit='time')
+            time_start = fh.tell(unit='time')
             record = fh.read()
             fh_raw_tell1 = fh.fh_raw.tell()
-            time1 = fh.tell(unit='time')
+            time_end = fh.tell(unit='time')
 
         rewritten_file = str(tmpdir.join('rewritten.m4'))
         with mark4.open(rewritten_file, 'ws', sample_rate=32*u.MHz,
-                        time=time0, ntrack=64, bps=2, fanout=4) as fw:
+                        time=time_start, ntrack=64, bps=2, fanout=4) as fw:
             # write in bits and pieces and with some invalid data as well.
             fw.write(record[:11])
             fw.write(record[11:80000])
             fw.write(record[80000:], invalid_data=True)
-            assert fw.tell(unit='time') == time1
+            assert fw.tell(unit='time') == time_end
 
         with mark4.open(rewritten_file, 'rs', ntrack=64, decade=2010,
                         sample_rate=32*u.MHz, thread_ids=[3, 4]) as fh:
-            assert fh.tell(unit='time') == time0
+            assert fh.tell(unit='time') == time_start
             record2 = fh.read(160000)
-            assert fh.tell(unit='time') == time1
+            assert fh.tell(unit='time') == time_end
             assert np.all(record2[:80000] == record[:80000, 3:5])
             assert np.all(record2[80000:] == 0.)
 
@@ -522,7 +522,7 @@ class TestMark4(object):
             assert np.all(out.squeeze() == record[:12, 0])
 
         with mark4.open(str(tmpdir.join('test.m4')), 'ws',
-                        sample_rate=32*u.MHz, time=time0,
+                        sample_rate=32*u.MHz, time=time_start,
                         ntrack=64, bps=1, fanout=4) as fw:
             assert fw.sample_shape == (16,)
             assert fw.sample_shape.nchan == 16
@@ -560,7 +560,7 @@ class TestMark4(object):
                             sample_rate=32*u.MHz) as f2:
                 assert f2.header0 == frame.header
                 with pytest.raises(ValueError):
-                    f2._header1
+                    f2._header_last
 
     def test_stream_invalid(self):
         with pytest.raises(ValueError):
@@ -594,8 +594,8 @@ class Test32TrackFanout4():
                         frames_per_second=400) as fh:
             header0 = fh.header0
             assert fh.samples_per_frame == 80000
-            time0 = fh.time0
-            assert time0.yday == '2015:011:01:23:10.48500'
+            time_start = fh.time_start
+            assert time_start.yday == '2015:011:01:23:10.48500'
             record = fh.read(160000)
             fh_raw_tell1 = fh.fh_raw.tell()
             assert fh_raw_tell1 == 169656
@@ -617,7 +617,7 @@ class Test32TrackFanout4():
         # Note: this test would not work if we wrote only a single record.
         with mark4.open(fl, 'rs', ntrack=32, decade=2010,
                         frames_per_second=400) as fh:
-            assert fh.time0 == time0
+            assert fh.time_start == time_start
             record2 = fh.read(1000)
             assert np.all(record2 == record[:1000])
 
@@ -655,8 +655,8 @@ class Test32TrackFanout2():
                         frames_per_second=400) as fh:
             header0 = fh.header0
             assert fh.samples_per_frame == 40000
-            time0 = fh.time0
-            assert time0.yday == '2017:063:04:42:26.02500'
+            time_start = fh.time_start
+            assert time_start.yday == '2017:063:04:42:26.02500'
             record = fh.read(80000)
             fh_raw_tell1 = fh.fh_raw.tell()
             assert fh_raw_tell1 == 160000 + 17436
@@ -678,7 +678,7 @@ class Test32TrackFanout2():
         # Note: this test would not work if we wrote only a single record.
         with mark4.open(fl, 'rs', ntrack=32, decade=2010,
                         frames_per_second=400) as fh:
-            assert fh.time0 == time0
+            assert fh.time_start == time_start
             record2 = fh.read(1000)
             assert np.all(record2 == record[:1000])
 

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -461,10 +461,10 @@ class TestMark4(object):
 
         with mark4.open(SAMPLE_FILE, 'rs', ntrack=64, decade=2010,
                         sample_rate=32*u.MHz) as fh:
-            start_time = fh.current_time
+            start_time = fh.time
             record = fh.read()
             fh_raw_tell1 = fh.fh_raw.tell()
-            stop_time = fh.current_time
+            stop_time = fh.time
 
         rewritten_file = str(tmpdir.join('rewritten.m4'))
         with mark4.open(rewritten_file, 'ws', sample_rate=32*u.MHz,
@@ -477,10 +477,10 @@ class TestMark4(object):
 
         with mark4.open(rewritten_file, 'rs', ntrack=64, decade=2010,
                         sample_rate=32*u.MHz, thread_ids=[3, 4]) as fh:
-            assert fh.current_time == start_time
-            assert fh.current_time == fh.tell(unit='time')
+            assert fh.time == start_time
+            assert fh.time == fh.tell(unit='time')
             record2 = fh.read(160000)
-            assert fh.current_time == stop_time
+            assert fh.time == stop_time
             assert np.all(record2[:80000] == record[:80000, 3:5])
             assert np.all(record2[80000:] == 0.)
 
@@ -561,7 +561,7 @@ class TestMark4(object):
                             sample_rate=32*u.MHz) as f2:
                 assert f2.header0 == frame.header
                 with pytest.raises(ValueError):
-                    f2._header_last
+                    f2._last_header
 
     def test_stream_invalid(self):
         with pytest.raises(ValueError):

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -192,7 +192,7 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
     @property
     def size(self):
         n_frames = int(round(
-            (self.header1.time - self.header0.time).to(u.s).value *
+            (self._header1.time - self.header0.time).to(u.s).value *
             self.frames_per_second)) + 1
         return n_frames * self.samples_per_frame
 

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -192,7 +192,7 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
     @property
     def size(self):
         n_frames = int(round(
-            (self._header1.time - self.header0.time).to(u.s).value *
+            (self._header_last.time - self.header0.time).to(u.s).value *
             self.frames_per_second)) + 1
         return n_frames * self.samples_per_frame
 

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -192,7 +192,7 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
     @property
     def size(self):
         n_frames = int(round(
-            (self._header_last.time - self.header0.time).to(u.s).value *
+            (self._last_header.time - self.header0.time).to(u.s).value *
             self.frames_per_second)) + 1
         return n_frames * self.samples_per_frame
 

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -217,7 +217,7 @@ class TestMark5B(object):
     def test_header_times(self):
         with mark5b.open(SAMPLE_FILE, 'rb') as fh:
             header0 = mark5b.Mark5BHeader.fromfile(fh, ref_mjd=57000.)
-            time0 = header0.time
+            time_start = header0.time
             samples_per_frame = header0.payloadsize * 8 // 2 // 8
             frame_rate = 32. * u.MHz / samples_per_frame
             frame_duration = 1. / frame_rate
@@ -228,7 +228,7 @@ class TestMark5B(object):
                 except EOFError:
                     break
                 header_time = frame.header.time
-                expected = time0 + frame.header['frame_nr'] * frame_duration
+                expected = time_start + frame.header['frame_nr'] * frame_duration
                 assert abs(header_time - expected) < 1. * u.ns
 
         # On the last frame, also check one can recover the time if 'frac_sec'
@@ -307,7 +307,7 @@ class TestMark5B(object):
             assert fh.fh_raw.tell() == header.framesize
             assert fh.samples_per_frame == 5000
             assert fh.frames_per_second == 6400
-            header1 = fh._header1
+            header_last = fh._header_last
             assert fh.size == 20000
             record = fh.read(12)
             assert fh.tell() == 12
@@ -316,20 +316,20 @@ class TestMark5B(object):
             assert fh.tell() == 10002
             assert fh.fh_raw.tell() == 3. * header.framesize
             assert np.abs(fh.tell(unit='time') -
-                          (fh.time0 + 10002 / (32*u.MHz))) < 1. * u.ns
-            fh.seek(fh.time0 + 1000 / (32*u.MHz))
+                          (fh.time_start + 10002 / (32*u.MHz))) < 1. * u.ns
+            fh.seek(fh.time_start + 1000 / (32*u.MHz))
             assert fh.tell() == 1000
             fh.seek(-10, 2)
             assert fh.tell() == fh.size - 10
             record3 = fh.read()
 
-        assert header1['frame_nr'] == 3
-        assert header1['user'] == header['user']
-        assert header1['bcd_jday'] == header['bcd_jday']
-        assert header1['bcd_seconds'] == header['bcd_seconds']
-        assert header1['bcd_fraction'] == 4
-        assert (round((1./((header1.time-header.time)/3.)).to(u.Hz).value) ==
-                6400)
+        assert header_last['frame_nr'] == 3
+        assert header_last['user'] == header['user']
+        assert header_last['bcd_jday'] == header['bcd_jday']
+        assert header_last['bcd_seconds'] == header['bcd_seconds']
+        assert header_last['bcd_fraction'] == 4
+        frate = (1. / ((header_last.time - header.time) / 3.)).to(u.Hz).value
+        assert round(frate) == 6400
         assert record.shape == (12, 8)
         assert np.all(record.astype(int)[:3] ==
                       np.array([[-3, -1, +1, -1, +3, -3, -3, +3],
@@ -348,12 +348,12 @@ class TestMark5B(object):
         # Read all data and check that it can be written out.
         with mark5b.open(SAMPLE_FILE, 'rs', nchan=8, bps=2,
                          sample_rate=32*u.MHz, ref_mjd=57000) as fh:
-            time0 = fh.tell(unit='time')
+            time_start = fh.tell(unit='time')
             record = fh.read(20000)
-            time1 = fh.tell(unit='time')
+            time_end = fh.tell(unit='time')
 
         m5_test = str(tmpdir.join('test.m5b'))
-        with mark5b.open(m5_test, 'ws', time=time0, nchan=8,
+        with mark5b.open(m5_test, 'ws', time=time_start, nchan=8,
                          bps=2, sample_rate=32*u.MHz) as fw:
             # Write in pieces to ensure squeezed data can be handled,
             # And add in an invalid frame for good measure.
@@ -361,19 +361,19 @@ class TestMark5B(object):
             fw.write(record[11:5000])
             fw.write(record[5000:10000], invalid_data=True)
             fw.write(record[10000:])
-            assert fw.tell(unit='time') == time1
+            assert fw.tell(unit='time') == time_end
 
         with mark5b.open(m5_test, 'rs', nchan=8, bps=2, sample_rate=32*u.MHz,
                          ref_mjd=57000) as fh:
-            assert fh.tell(unit='time') == time0
+            assert fh.tell(unit='time') == time_start
             record2 = fh.read(20000)
-            assert fh.tell(unit='time') == time1
+            assert fh.tell(unit='time') == time_end
             assert np.all(record2[:5000] == record[:5000])
             assert np.all(record2[5000:10000] == 0.)
             assert np.all(record2[10000:] == record[10000:])
 
         # Check files can be made byte-for-byte identical.
-        with mark5b.open(m5_test, 'ws', time=time0, nchan=8, bps=2,
+        with mark5b.open(m5_test, 'ws', time=time_start, nchan=8, bps=2,
                          sample_rate=32*u.MHz, user=header['user'],
                          internal_tvg=header['internal_tvg'],
                          frame_nr=header['frame_nr']) as fw:
@@ -422,7 +422,7 @@ class TestMark5B(object):
             assert fh.tell() == 12
             assert np.all(out.squeeze() == record[:12, 0])
 
-        with mark5b.open(m5_test, 'ws', time=time0, nchan=1, bps=2,
+        with mark5b.open(m5_test, 'ws', time=time_start, nchan=1, bps=2,
                          sample_rate=32*u.MHz) as fw:
             assert fw.sample_shape == ()
             fw.write(record[:10000, 0])

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -307,7 +307,7 @@ class TestMark5B(object):
             assert fh.fh_raw.tell() == header.framesize
             assert fh.samples_per_frame == 5000
             assert fh.frames_per_second == 6400
-            header1 = fh.header1
+            header1 = fh._header1
             assert fh.size == 20000
             record = fh.read(12)
             assert fh.tell() == 12

--- a/baseband/tests/test_conversion.py
+++ b/baseband/tests/test_conversion.py
@@ -258,12 +258,12 @@ class TestMark4ToVDIF1(object):
         with mark4.open(SAMPLE_M4, 'rs', ntrack=64, decade=2010,
                         sample_rate=32.*u.MHz) as fr:
             m4header0 = fr.header0
-            time_start = fr.time_start
+            start_time = fr.start_time
             vheader0 = vdif.VDIFHeader.fromvalues(
                 edv=1, bps=m4header0.bps, nchan=1, station='Ar',
-                time=time_start, bandwidth=16.*u.MHz,
+                time=start_time, bandwidth=16.*u.MHz,
                 payloadsize=640*2//8, complex_data=False)
-            assert abs(vheader0.time - time_start) < 2. * u.ns
+            assert abs(vheader0.time - start_time) < 2. * u.ns
             data = fr.read(80000)  # full Mark 4 frame
             offset1 = fr.tell()
             time1 = fr.tell(unit='time')
@@ -275,7 +275,7 @@ class TestMark4ToVDIF1(object):
 
         fl = str(tmpdir.join('test.vdif'))
         with vdif.open(fl, 'ws', nthread=data.shape[1], header=vheader0) as fw:
-            assert (fw.tell(unit='time') - time_start) < 2. * u.ns
+            assert (fw.tell(unit='time') - start_time) < 2. * u.ns
             # Write first VDIF frame, matching Mark 4 Header, hence invalid.
             fw.write(data[:160], invalid_data=True)
             # Write remaining VDIF frames, with valid data.
@@ -286,7 +286,7 @@ class TestMark4ToVDIF1(object):
             expected = vheader0.copy()
             expected['invalid_data'] = True
             assert fv.header0 == expected
-            assert abs(fv.header0.time - time_start) < 2. * u.ns
+            assert abs(fv.header0.time - start_time) < 2. * u.ns
             dv = fv.read(80000)
             assert np.all(dv == data)
             assert fv.offset == offset1
@@ -361,7 +361,7 @@ class TestDADAToVDIF1(object):
             ddh = fr.header0
             dada_data = fr.read()
             offset1 = fr.tell()
-            time_end = fr.tell(unit='time')
+            stop_time = fr.tell(unit='time')
 
         header = self.get_vdif_header(ddh)
         data = self.get_vdif_data(dada_data)
@@ -372,14 +372,14 @@ class TestDADAToVDIF1(object):
             assert (fw.tell(unit='time') - header.time) < 2. * u.ns
             # Write all data in since frameset, made of two frames.
             fw.write(data)
-            assert (fw.tell(unit='time') - time_end) < 2. * u.ns
+            assert (fw.tell(unit='time') - stop_time) < 2. * u.ns
             assert fw.offset == offset1
 
         with vdif.open(vdif_file, 'rs') as fv:
             assert abs(fv.header0.time - ddh.time) < 2. * u.ns
             dv = fv.read()
             assert fv.offset == offset1
-            assert np.abs(fv.tell(unit='time') - time_end) < 2.*u.ns
+            assert np.abs(fv.tell(unit='time') - stop_time) < 2.*u.ns
             vh = fv.header0
             vnthread = fv.sample_shape.nthread
         assert np.allclose(dv, data)

--- a/baseband/tests/test_conversion.py
+++ b/baseband/tests/test_conversion.py
@@ -258,11 +258,12 @@ class TestMark4ToVDIF1(object):
         with mark4.open(SAMPLE_M4, 'rs', ntrack=64, decade=2010,
                         sample_rate=32.*u.MHz) as fr:
             m4header0 = fr.header0
-            time0 = fr.time0
+            time_start = fr.time_start
             vheader0 = vdif.VDIFHeader.fromvalues(
-                edv=1, bps=m4header0.bps, nchan=1, station='Ar', time=time0,
-                bandwidth=16.*u.MHz, payloadsize=640*2//8, complex_data=False)
-            assert abs(vheader0.time - time0) < 2. * u.ns
+                edv=1, bps=m4header0.bps, nchan=1, station='Ar',
+                time=time_start, bandwidth=16.*u.MHz,
+                payloadsize=640*2//8, complex_data=False)
+            assert abs(vheader0.time - time_start) < 2. * u.ns
             data = fr.read(80000)  # full Mark 4 frame
             offset1 = fr.tell()
             time1 = fr.tell(unit='time')
@@ -274,7 +275,7 @@ class TestMark4ToVDIF1(object):
 
         fl = str(tmpdir.join('test.vdif'))
         with vdif.open(fl, 'ws', nthread=data.shape[1], header=vheader0) as fw:
-            assert (fw.tell(unit='time') - time0) < 2. * u.ns
+            assert (fw.tell(unit='time') - time_start) < 2. * u.ns
             # Write first VDIF frame, matching Mark 4 Header, hence invalid.
             fw.write(data[:160], invalid_data=True)
             # Write remaining VDIF frames, with valid data.
@@ -285,7 +286,7 @@ class TestMark4ToVDIF1(object):
             expected = vheader0.copy()
             expected['invalid_data'] = True
             assert fv.header0 == expected
-            assert abs(fv.header0.time - time0) < 2. * u.ns
+            assert abs(fv.header0.time - time_start) < 2. * u.ns
             dv = fv.read(80000)
             assert np.all(dv == data)
             assert fv.offset == offset1

--- a/baseband/tests/test_conversion.py
+++ b/baseband/tests/test_conversion.py
@@ -360,7 +360,7 @@ class TestDADAToVDIF1(object):
             ddh = fr.header0
             dada_data = fr.read()
             offset1 = fr.tell()
-            time1 = fr.tell(unit='time')
+            time_end = fr.tell(unit='time')
 
         header = self.get_vdif_header(ddh)
         data = self.get_vdif_data(dada_data)
@@ -371,14 +371,14 @@ class TestDADAToVDIF1(object):
             assert (fw.tell(unit='time') - header.time) < 2. * u.ns
             # Write all data in since frameset, made of two frames.
             fw.write(data)
-            assert (fw.tell(unit='time') - time1) < 2. * u.ns
+            assert (fw.tell(unit='time') - time_end) < 2. * u.ns
             assert fw.offset == offset1
 
         with vdif.open(vdif_file, 'rs') as fv:
             assert abs(fv.header0.time - ddh.time) < 2. * u.ns
             dv = fv.read()
             assert fv.offset == offset1
-            assert np.abs(fv.tell(unit='time') - time1) < 2.*u.ns
+            assert np.abs(fv.tell(unit='time') - time_end) < 2.*u.ns
             vh = fv.header0
             vnthread = fv.sample_shape.nthread
         assert np.allclose(dv, data)

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -321,7 +321,7 @@ class VDIFStreamReader(VDIFStreamBase, VLBIStreamReaderBase, VDIFFileReader):
                                                squeeze)
 
     @lazyproperty
-    def _header_last(self):
+    def _last_header(self):
         """Last header of the file."""
         raw_offset = self.fh_raw.tell()
         # Go to end of file.
@@ -333,18 +333,18 @@ class VDIFStreamReader(VDIFStreamBase, VLBIStreamReaderBase, VDIFFileReader):
         maximum = 2 * self._sample_shape.nthread * self.header0.framesize
         while not found:
             self.fh_raw.seek(-self.header0.framesize, 1)
-            header_last = self.find_header(
+            last_header = self.find_header(
                 template_header=self.header0,
                 maximum=maximum, forward=False)
-            if header_last is None or raw_size - self.fh_raw.tell() > maximum:
+            if last_header is None or raw_size - self.fh_raw.tell() > maximum:
                 raise ValueError("Corrupt VDIF? No thread_id={0} frame in "
                                  "last {1} bytes."
                                  .format(self.header0['thread_id'], maximum))
 
-            found = header_last['thread_id'] == self.header0['thread_id']
+            found = last_header['thread_id'] == self.header0['thread_id']
 
         self.fh_raw.seek(raw_offset)
-        return header_last
+        return last_header
 
     def read(self, count=None, fill_value=0., out=None):
         """Read count samples.

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -273,7 +273,7 @@ class VDIFStreamBase(VLBIStreamBase):
                 "    sample_shape={s.sample_shape},\n"
                 "    complex_data={s.complex_data},"
                 " bps={h.bps}, edv={h.edv}, station={h.station},\n"
-                "    time_start={s.time_start}>"
+                "    start_time={s.start_time}>"
                 .format(s=self, h=self.header0))
 
 

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -273,7 +273,7 @@ class VDIFStreamBase(VLBIStreamBase):
                 "    sample_shape={s.sample_shape},\n"
                 "    complex_data={s.complex_data},"
                 " bps={h.bps}, edv={h.edv}, station={h.station},\n"
-                "    (start) time={s.time0}>"
+                "    time_start={s.time_start}>"
                 .format(s=self, h=self.header0))
 
 
@@ -321,7 +321,7 @@ class VDIFStreamReader(VDIFStreamBase, VLBIStreamReaderBase, VDIFFileReader):
                                                squeeze)
 
     @lazyproperty
-    def _header1(self):
+    def _header_last(self):
         """Last header of the file."""
         raw_offset = self.fh_raw.tell()
         # Go to end of file.
@@ -333,18 +333,18 @@ class VDIFStreamReader(VDIFStreamBase, VLBIStreamReaderBase, VDIFFileReader):
         maximum = 2 * self._sample_shape.nthread * self.header0.framesize
         while not found:
             self.fh_raw.seek(-self.header0.framesize, 1)
-            header1 = self.find_header(
+            header_last = self.find_header(
                 template_header=self.header0,
                 maximum=maximum, forward=False)
-            if header1 is None or raw_size - self.fh_raw.tell() > maximum:
+            if header_last is None or raw_size - self.fh_raw.tell() > maximum:
                 raise ValueError("Corrupt VDIF? No thread_id={0} frame in "
                                  "last {1} bytes."
                                  .format(self.header0['thread_id'], maximum))
 
-            found = header1['thread_id'] == self.header0['thread_id']
+            found = header_last['thread_id'] == self.header0['thread_id']
 
         self.fh_raw.seek(raw_offset)
-        return header1
+        return header_last
 
     def read(self, count=None, fill_value=0., out=None):
         """Read count samples.

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -321,7 +321,7 @@ class VDIFStreamReader(VDIFStreamBase, VLBIStreamReaderBase, VDIFFileReader):
                                                squeeze)
 
     @lazyproperty
-    def header1(self):
+    def _header1(self):
         """Last header of the file."""
         raw_offset = self.fh_raw.tell()
         # Go to end of file.

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -496,13 +496,14 @@ class TestVDIF(object):
             assert repr(fh).startswith('<VDIFStreamReader')
             assert fh.tell() == 0
             assert header == fh.header0
-            assert fh.time_start == fh.header0.time
-            assert abs(fh.tell(unit='time') - fh.time_start) < 1. * u.ns
+            assert fh.start_time == fh.header0.time
+            assert abs(fh.current_time - fh.start_time) < 1. * u.ns
+            assert fh.current_time == fh.tell(unit='time')
             record = fh.read(12)
             assert fh.tell() == 12
-            t12 = fh.tell(unit='time')
+            t12 = fh.current_time
             s12 = 12 / fh.samples_per_frame / fh.frames_per_second * u.s
-            assert abs(t12 - fh.time_start - s12) < 1. * u.ns
+            assert abs(t12 - fh.start_time - s12) < 1. * u.ns
             fh.seek(10, 1)
             fh.tell() == 22
             fh.seek(t12)
@@ -512,9 +513,9 @@ class TestVDIF(object):
             with pytest.raises(ValueError):
                 fh.seek(0, 3)
             assert fh.size == 40000
-            assert abs(fh.time_end - fh._header_last.time - u.s /
+            assert abs(fh.stop_time - fh._header_last.time - u.s /
                        fh.frames_per_second) < 1. * u.ns
-            assert abs(fh.time_end - fh.time_start - u.s * fh.size /
+            assert abs(fh.stop_time - fh.start_time - u.s * fh.size /
                        fh.samples_per_frame / fh.frames_per_second) < 1. * u.ns
 
         assert record.shape == (12, 8)
@@ -563,8 +564,8 @@ class TestVDIF(object):
             assert fh.header0.bps == 2
             assert fh._sample_shape.nchan == 2
             assert fh._sample_shape.nthread == 2
-            assert fh.time_start == Time('2010-01-01')
-            assert fh.time_end == fh.time_start + 1.5 * u.s
+            assert fh.start_time == Time('2010-01-01')
+            assert fh.stop_time == fh.start_time + 1.5 * u.s
             fh.seek(16)
             record = fh.read(16)
         assert np.all(record == data)
@@ -637,7 +638,7 @@ def test_mwa_vdif():
     with vdif.open(SAMPLE_MWA, 'rs', sample_rate=1.28*u.MHz) as fh:
         assert fh.samples_per_frame == 128
         assert fh.frames_per_second == 10000
-        assert fh.tell(unit='time') == Time('2015-10-03T20:49:45.000')
+        assert fh.current_time == Time('2015-10-03T20:49:45.000')
         assert fh.header0.edv == 0
 
 
@@ -664,16 +665,16 @@ def test_arochime_vdif():
     # Now test the actual data stream.
     with vdif.open(SAMPLE_AROCHIME, 'rs', frames_per_second=390625) as fh:
         assert fh.samples_per_frame == 1
-        t0 = fh.tell(unit='time')
+        t0 = fh.current_time
         assert abs(t0 - Time('2016-04-22T08:45:31.788759040')) < 1. * u.ns
-        assert abs(t0 - fh.time_start) < 1. * u.ns
+        assert abs(t0 - fh.start_time) < 1. * u.ns
         assert fh.header0.edv == 0
         assert fh.size == 5
         d = fh.read()
         assert d.shape == (5, 2, 1024)
         assert d.dtype.kind == 'c'
-        t1 = fh.tell(unit='time')
-        assert abs(t1 - fh.time_end) < 1. * u.ns
+        t1 = fh.current_time
+        assert abs(t1 - fh.stop_time) < 1. * u.ns
         assert abs(t1 - t0 - u.s * (fh.size / fh.samples_per_frame /
                                     fh.frames_per_second)) < 1. * u.ns
 

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -497,11 +497,11 @@ class TestVDIF(object):
             assert fh.tell() == 0
             assert header == fh.header0
             assert fh.start_time == fh.header0.time
-            assert abs(fh.current_time - fh.start_time) < 1. * u.ns
-            assert fh.current_time == fh.tell(unit='time')
+            assert abs(fh.time - fh.start_time) < 1. * u.ns
+            assert fh.time == fh.tell(unit='time')
             record = fh.read(12)
             assert fh.tell() == 12
-            t12 = fh.current_time
+            t12 = fh.time
             s12 = 12 / fh.samples_per_frame / fh.frames_per_second * u.s
             assert abs(t12 - fh.start_time - s12) < 1. * u.ns
             fh.seek(10, 1)
@@ -513,7 +513,7 @@ class TestVDIF(object):
             with pytest.raises(ValueError):
                 fh.seek(0, 3)
             assert fh.size == 40000
-            assert abs(fh.stop_time - fh._header_last.time - u.s /
+            assert abs(fh.stop_time - fh._last_header.time - u.s /
                        fh.frames_per_second) < 1. * u.ns
             assert abs(fh.stop_time - fh.start_time - u.s * fh.size /
                        fh.samples_per_frame / fh.frames_per_second) < 1. * u.ns
@@ -622,7 +622,7 @@ class TestVDIF(object):
             with vdif.open(s, 'rs') as f2:
                 assert f2.header0 == frame.header
                 with pytest.raises(ValueError):
-                    f2._header_last
+                    f2._last_header
 
     def test_io_invalid(self):
         with pytest.raises(TypeError):
@@ -638,7 +638,7 @@ def test_mwa_vdif():
     with vdif.open(SAMPLE_MWA, 'rs', sample_rate=1.28*u.MHz) as fh:
         assert fh.samples_per_frame == 128
         assert fh.frames_per_second == 10000
-        assert fh.current_time == Time('2015-10-03T20:49:45.000')
+        assert fh.time == Time('2015-10-03T20:49:45.000')
         assert fh.header0.edv == 0
 
 
@@ -665,7 +665,7 @@ def test_arochime_vdif():
     # Now test the actual data stream.
     with vdif.open(SAMPLE_AROCHIME, 'rs', frames_per_second=390625) as fh:
         assert fh.samples_per_frame == 1
-        t0 = fh.current_time
+        t0 = fh.time
         assert abs(t0 - Time('2016-04-22T08:45:31.788759040')) < 1. * u.ns
         assert abs(t0 - fh.start_time) < 1. * u.ns
         assert fh.header0.edv == 0
@@ -673,7 +673,7 @@ def test_arochime_vdif():
         d = fh.read()
         assert d.shape == (5, 2, 1024)
         assert d.dtype.kind == 'c'
-        t1 = fh.current_time
+        t1 = fh.time
         assert abs(t1 - fh.stop_time) < 1. * u.ns
         assert abs(t1 - t0 - u.s * (fh.size / fh.samples_per_frame /
                                     fh.frames_per_second)) < 1. * u.ns

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -512,9 +512,9 @@ class TestVDIF(object):
             with pytest.raises(ValueError):
                 fh.seek(0, 3)
             assert fh.size == 40000
-            assert abs(fh.time1 - fh.header1.time - u.s /
+            assert abs(fh._time1 - fh._header1.time - u.s /
                        fh.frames_per_second) < 1. * u.ns
-            assert abs(fh.time1 - fh.time0 - u.s * fh.size /
+            assert abs(fh._time1 - fh.time0 - u.s * fh.size /
                        fh.samples_per_frame / fh.frames_per_second) < 1. * u.ns
 
         assert record.shape == (12, 8)
@@ -564,7 +564,7 @@ class TestVDIF(object):
             assert fh._sample_shape.nchan == 2
             assert fh._sample_shape.nthread == 2
             assert fh.time0 == Time('2010-01-01')
-            assert fh.time1 == fh.time0 + 1.5 * u.s
+            assert fh._time1 == fh.time0 + 1.5 * u.s
             fh.seek(16)
             record = fh.read(16)
         assert np.all(record == data)
@@ -621,7 +621,7 @@ class TestVDIF(object):
             with vdif.open(s, 'rs') as f2:
                 assert f2.header0 == frame.header
                 with pytest.raises(ValueError):
-                    f2.header1
+                    f2._header1
 
     def test_io_invalid(self):
         with pytest.raises(TypeError):
@@ -673,7 +673,7 @@ def test_arochime_vdif():
         assert d.shape == (5, 2, 1024)
         assert d.dtype.kind == 'c'
         t1 = fh.tell(unit='time')
-        assert abs(t1 - fh.time1) < 1. * u.ns
+        assert abs(t1 - fh._time1) < 1. * u.ns
         assert abs(t1 - t0 - u.s * (fh.size / fh.samples_per_frame /
                                     fh.frames_per_second)) < 1. * u.ns
 

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -120,7 +120,10 @@ class VLBIStreamBase(VLBIFileBase):
 
     @lazyproperty
     def start_time(self):
-        """Start time of file."""
+        """Start time of the file.
+
+        See also `time` for the time of the sample pointer's current offset.
+        """
         return self._get_time(self.header0)
 
     @deprecated('0.X', name='time0', alternative='start_time',
@@ -131,8 +134,11 @@ class VLBIStreamBase(VLBIFileBase):
     time0 = property(get_time0, None, None)
 
     @property
-    def current_time(self):
-        """Time of the current offset in file."""
+    def time(self):
+        """Time of the sample pointer's current offset in file.
+
+        See also `start_time` for the start time of the file.
+        """
         return self.tell(unit='time')
 
     @property
@@ -273,23 +279,27 @@ class VLBIStreamReaderBase(VLBIStreamBase):
         return max_frame + 1
 
     @lazyproperty
-    def _header_last(self):
+    def _last_header(self):
         """Last header of the file."""
         raw_offset = self.fh_raw.tell()
         self.fh_raw.seek(-self.header0.framesize, 2)
-        header_last = self.find_header(template_header=self.header0,
+        last_header = self.find_header(template_header=self.header0,
                                        maximum=10*self.header0.framesize,
                                        forward=False)
         self.fh_raw.seek(raw_offset)
-        if header_last is None:
+        if last_header is None:
             raise ValueError("Corrupt VLBI frame? No frame in last {0} bytes."
                              .format(10 * self.header0.framesize))
-        return header_last
+        return last_header
 
     @lazyproperty
     def stop_time(self):
-        """Time at the end of the file, just after the last sample."""
-        return self._get_time(self._header_last) + u.s / self.frames_per_second
+        """Time at the end of the file, just after the last sample.
+
+        See also `start_time` for the start time of the file, and `time` for
+        the time of the sample pointer's current offset.
+        """
+        return self._get_time(self._last_header) + u.s / self.frames_per_second
 
     @deprecated('0.X', name='time1', alternative='stop_time',
                 obj_type='attribute')

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -54,10 +54,10 @@ class VLBIStreamBase(VLBIFileBase):
                  thread_ids, samples_per_frame, frames_per_second=None,
                  sample_rate=None, squeeze=True):
         super(VLBIStreamBase, self).__init__(fh_raw)
-        self.header0 = header0
+        self._header0 = header0
         self._sample_shape = sample_shape
-        self.bps = bps
-        self.complex_data = complex_data
+        self._bps = bps
+        self._complex_data = complex_data
         self.thread_ids = thread_ids
         self.samples_per_frame = samples_per_frame
         if frames_per_second is None:
@@ -72,6 +72,16 @@ class VLBIStreamBase(VLBIFileBase):
         self.frames_per_second = frames_per_second
         self.offset = 0
         self.squeeze = squeeze
+
+    @property
+    def squeeze(self):
+        """If `True`, remove any dimensions of length unity from
+        arrays after decoding, and add them when encoding."""
+        return self._squeeze
+
+    @squeeze.setter
+    def squeeze(self, squeeze):
+        self._squeeze = squeeze
 
     @property
     def sample_shape(self):
@@ -108,8 +118,32 @@ class VLBIStreamBase(VLBIFileBase):
 
     @lazyproperty
     def time0(self):
-        """Start time."""
+        """Start time of file."""
         return self._get_time(self.header0)
+
+    @property
+    def header0(self):
+        """First header of file."""
+        return self._header0
+
+    @property
+    def bps(self):
+        """Bits per sample."""
+        return self._bps
+
+    @property
+    def complex_data(self):
+        """If `True`, decoded data is complex."""
+        return self._complex_data
+
+    @property
+    def thread_ids(self):
+        """Specific threads/channels to read."""
+        return self._thread_ids
+
+    @thread_ids.setter
+    def thread_ids(self, ids):
+        self._thread_ids = ids
 
     def tell(self, unit=None):
         """Current offset in file.

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -75,13 +75,15 @@ class VLBIStreamBase(VLBIFileBase):
 
     @property
     def squeeze(self):
-        """If `True`, remove any dimensions of length unity from
-        arrays after decoding, and add them when encoding."""
+        """Whether data arrays have arrays with length unity removed.
+
+        If `True`, such dimensions are removed in reading, and added back in
+        writing."""
         return self._squeeze
 
     @squeeze.setter
     def squeeze(self, squeeze):
-        self._squeeze = squeeze
+        self._squeeze = bool(squeeze)
 
     @property
     def sample_shape(self):
@@ -135,12 +137,12 @@ class VLBIStreamBase(VLBIFileBase):
 
     @property
     def bps(self):
-        """Bits per sample."""
+        """Number of bits for each part (real or imaginary) of a sample."""
         return self._bps
 
     @property
     def complex_data(self):
-        """If `True`, decoded data is complex."""
+        """Whether the decoded data is complex."""
         return self._complex_data
 
     @property

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -122,7 +122,8 @@ class VLBIStreamBase(VLBIFileBase):
     def start_time(self):
         """Start time of the file.
 
-        See also `time` for the time of the sample pointer's current offset.
+        See also `time` for the time of the sample pointer's current offset,
+        and (if available) `stop_time` for the time at the end of the file.
         """
         return self._get_time(self.header0)
 
@@ -137,7 +138,8 @@ class VLBIStreamBase(VLBIFileBase):
     def time(self):
         """Time of the sample pointer's current offset in file.
 
-        See also `start_time` for the start time of the file.
+        See also `start_time` for the start time, and (if available)
+        `stop_time` for the end time, of the file.
         """
         return self.tell(unit='time')
 

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -225,7 +225,7 @@ class VLBIStreamReaderBase(VLBIStreamBase):
         return max_frame + 1
 
     @lazyproperty
-    def header1(self):
+    def _header1(self):
         """Last header of the file."""
         raw_offset = self.fh_raw.tell()
         self.fh_raw.seek(-self.header0.framesize, 2)
@@ -239,14 +239,14 @@ class VLBIStreamReaderBase(VLBIStreamBase):
         return header1
 
     @lazyproperty
-    def time1(self):
+    def _time1(self):
         """Time of the sample just beyond the last one in the file."""
-        return self._get_time(self.header1) + u.s / self.frames_per_second
+        return self._get_time(self._header1) + u.s / self.frames_per_second
 
     @property
     def size(self):
         """Number of samples in the file."""
-        return int(round((self.time1 - self.time0).to(u.s).value *
+        return int(round((self._time1 - self.time0).to(u.s).value *
                          self.frames_per_second * self.samples_per_frame))
 
     def seek(self, offset, whence=0):

--- a/baseband/vlbi_base/header.py
+++ b/baseband/vlbi_base/header.py
@@ -314,6 +314,7 @@ class VLBIHeaderBase(object):
 
     @property
     def mutable(self):
+        """If `True`, header can be modified."""
         if isinstance(self.words, tuple):
             return False
         word0 = self.words[0]

--- a/baseband/vlbi_base/header.py
+++ b/baseband/vlbi_base/header.py
@@ -314,7 +314,7 @@ class VLBIHeaderBase(object):
 
     @property
     def mutable(self):
-        """If `True`, header can be modified."""
+        """Whether the header can be modified."""
         if isinstance(self.words, tuple):
             return False
         word0 = self.words[0]

--- a/docs/baseband/dada/index.rst
+++ b/docs/baseband/dada/index.rst
@@ -51,7 +51,7 @@ writing is in units of samples, and provides access to header information.
     <DADAStreamReader name=... offset=0
         frames_per_second=1000.0, samples_per_frame=16000,
         sample_shape=SampleShape(npol=2), bps=8,
-        thread_ids=[0, 1], time_start=2013-07-02T01:39:20.000>
+        thread_ids=[0, 1], start_time=2013-07-02T01:39:20.000>
     >>> d = fh.read(10000)
     >>> d.shape
     (10000, 2)

--- a/docs/baseband/dada/index.rst
+++ b/docs/baseband/dada/index.rst
@@ -51,7 +51,7 @@ writing is in units of samples, and provides access to header information.
     <DADAStreamReader name=... offset=0
         frames_per_second=1000.0, samples_per_frame=16000,
         sample_shape=SampleShape(npol=2), bps=8,
-        thread_ids=[0, 1], (start) time=2013-07-02T01:39:20.000>
+        thread_ids=[0, 1], time_start=2013-07-02T01:39:20.000>
     >>> d = fh.read(10000)
     >>> d.shape
     (10000, 2)

--- a/docs/baseband/mark4/index.rst
+++ b/docs/baseband/mark4/index.rst
@@ -47,7 +47,7 @@ also provides access to header information.::
     <Mark4StreamReader name=... offset=0
         frames_per_second=400, samples_per_frame=80000,
         sample_shape=SampleShape(nchan=8), bps=2,
-        time_start=2014-06-16T07:38:12.47500>
+        start_time=2014-06-16T07:38:12.47500>
     >>> d = fh.read(6400)
     >>> d.shape
     (6400, 8)

--- a/docs/baseband/mark4/index.rst
+++ b/docs/baseband/mark4/index.rst
@@ -47,7 +47,7 @@ also provides access to header information.::
     <Mark4StreamReader name=... offset=0
         frames_per_second=400, samples_per_frame=80000,
         sample_shape=SampleShape(nchan=8), bps=2,
-        (start) time=2014-06-16T07:38:12.47500>
+        time_start=2014-06-16T07:38:12.47500>
     >>> d = fh.read(6400)
     >>> d.shape
     (6400, 8)

--- a/docs/baseband/tutorials/getting_started.rst
+++ b/docs/baseband/tutorials/getting_started.rst
@@ -190,13 +190,13 @@ ignored.
 We can retrieve the time of the first sample in the file using ``start_time``,
 the time immediately after the last sample using ``stop_time``, and the time
 of the pointer's current location (equivalent to ``fh.tell(unit='time')``)
-using ``current_time``::
+using ``time``::
 
     >>> fh.start_time
     <Time object: scale='utc' format='isot' value=2014-06-16T05:56:07.000000000>
     >>> fh.stop_time
     <Time object: scale='utc' format='isot' value=2014-06-16T05:56:07.001250000>
-    >>> fh.current_time
+    >>> fh.time
     <Time object: scale='utc' format='isot' value=2014-06-16T05:56:07.001125000>
     >>> fh.close()
 

--- a/docs/baseband/tutorials/getting_started.rst
+++ b/docs/baseband/tutorials/getting_started.rst
@@ -111,7 +111,7 @@ We can access information about the file by printing ``fh``::
         frames_per_second=1600, samples_per_frame=20000,
         sample_shape=SampleShape(nthread=8),
         complex_data=False, bps=2, edv=3, station=65532,
-        (start) time=2014-06-16T05:56:07.000000000>
+        time_start=2014-06-16T05:56:07.000000000>
 
 The ``offset`` gives the current location of the sample file pointer - it's at
 ``24`` since we have just read in 24 (complete) samples.  If we called
@@ -188,10 +188,13 @@ ignored.
     36000
     >>> fh.close()
 
-We can retrieve the time of the first sample in the file using ``time0``::
+We can retrieve the time of the first sample in the file using ``time_start``,
+and the time immediately after the last sample using ``time_end``::
 
-    >>> fh.time0
+    >>> fh.time_start
     <Time object: scale='utc' format='isot' value=2014-06-16T05:56:07.000000000>
+    >>> fh.time_end
+    <Time object: scale='utc' format='isot' value=2014-06-16T05:56:07.001250000>
 
 Extracting Header Information
 -----------------------------
@@ -293,9 +296,9 @@ be necessary for compatibility with `DSPSR
     ...                nthread=1, nchan=fr.sample_shape.nthread,
     ...                frames_per_second=fr.frames_per_second,
     ...                samples_per_frame=fr.samples_per_frame // 8,
-    ...                complex_data=fr.complex_data,
-    ...                bps=fr.bps, edv=fr.header0.edv,
-    ...                station=fr.header0.station, time=fr.time0)
+    ...                complex_data=fr.complex_data, bps=fr.bps,
+    ...                edv=fr.header0.edv, station=fr.header0.station,
+    ...                time=fr.time_start)
 
 The minimal parameters needed to generate a file are listed under the
 documentation for each format's ``open``, though comprehensive lists can be
@@ -363,7 +366,7 @@ values into `vdif.open <baseband.vdif.open>` to create one.
     >>> fw = vdif.open('m4convert.vdif', 'ws', edv=1, nthread=1,
     ...                samples_per_frame=spf, nchan=fr.sample_shape.nchan,
     ...                frames_per_second=fps, complex_data=fr.complex_data, 
-    ...                bps=fr.bps, time=fr.time0)
+    ...                bps=fr.bps, time=fr.time_start)
 
 We choose ``edv = 1`` since it's the simplest VDIF EDV whose header includes a
 frame rate. The concept of threads does not exist in Mark 4, so the file

--- a/docs/baseband/tutorials/getting_started.rst
+++ b/docs/baseband/tutorials/getting_started.rst
@@ -188,6 +188,11 @@ ignored.
     36000
     >>> fh.close()
 
+We can retrieve the time of the first sample in the file using ``time0``::
+
+    >>> fh.time0
+    <Time object: scale='utc' format='isot' value=2014-06-16T05:56:07.000000000>
+
 Extracting Header Information
 -----------------------------
 

--- a/docs/baseband/tutorials/getting_started.rst
+++ b/docs/baseband/tutorials/getting_started.rst
@@ -111,7 +111,7 @@ We can access information about the file by printing ``fh``::
         frames_per_second=1600, samples_per_frame=20000,
         sample_shape=SampleShape(nthread=8),
         complex_data=False, bps=2, edv=3, station=65532,
-        time_start=2014-06-16T05:56:07.000000000>
+        start_time=2014-06-16T05:56:07.000000000>
 
 The ``offset`` gives the current location of the sample file pointer - it's at
 ``24`` since we have just read in 24 (complete) samples.  If we called
@@ -186,15 +186,19 @@ ignored.
     >>> # Seek to specific time.
     >>> fh.seek(Time('2014-06-16T05:56:07.001125'))
     36000
-    >>> fh.close()
 
-We can retrieve the time of the first sample in the file using ``time_start``,
-and the time immediately after the last sample using ``time_end``::
+We can retrieve the time of the first sample in the file using ``start_time``,
+the time immediately after the last sample using ``stop_time``, and the time
+of the pointer's current location (equivalent to ``fh.tell(unit='time')``)
+using ``current_time``::
 
-    >>> fh.time_start
+    >>> fh.start_time
     <Time object: scale='utc' format='isot' value=2014-06-16T05:56:07.000000000>
-    >>> fh.time_end
+    >>> fh.stop_time
     <Time object: scale='utc' format='isot' value=2014-06-16T05:56:07.001250000>
+    >>> fh.current_time
+    <Time object: scale='utc' format='isot' value=2014-06-16T05:56:07.001125000>
+    >>> fh.close()
 
 Extracting Header Information
 -----------------------------
@@ -298,7 +302,7 @@ be necessary for compatibility with `DSPSR
     ...                samples_per_frame=fr.samples_per_frame // 8,
     ...                complex_data=fr.complex_data, bps=fr.bps,
     ...                edv=fr.header0.edv, station=fr.header0.station,
-    ...                time=fr.time_start)
+    ...                time=fr.start_time)
 
 The minimal parameters needed to generate a file are listed under the
 documentation for each format's ``open``, though comprehensive lists can be
@@ -366,7 +370,7 @@ values into `vdif.open <baseband.vdif.open>` to create one.
     >>> fw = vdif.open('m4convert.vdif', 'ws', edv=1, nthread=1,
     ...                samples_per_frame=spf, nchan=fr.sample_shape.nchan,
     ...                frames_per_second=fps, complex_data=fr.complex_data, 
-    ...                bps=fr.bps, time=fr.time_start)
+    ...                bps=fr.bps, time=fr.start_time)
 
 We choose ``edv = 1`` since it's the simplest VDIF EDV whose header includes a
 frame rate. The concept of threads does not exist in Mark 4, so the file

--- a/docs/baseband/vdif/index.rst
+++ b/docs/baseband/vdif/index.rst
@@ -80,7 +80,7 @@ information::
         frames_per_second=1600, samples_per_frame=20000,
         sample_shape=SampleShape(nthread=8),
         complex_data=False, bps=2, edv=3, station=65532,
-        time_start=2014-06-16T05:56:07.000000000>
+        start_time=2014-06-16T05:56:07.000000000>
     >>> d = fh.read(12)
     >>> d.shape
     (12, 8)

--- a/docs/baseband/vdif/index.rst
+++ b/docs/baseband/vdif/index.rst
@@ -80,7 +80,7 @@ information::
         frames_per_second=1600, samples_per_frame=20000,
         sample_shape=SampleShape(nthread=8),
         complex_data=False, bps=2, edv=3, station=65532,
-        (start) time=2014-06-16T05:56:07.000000000>
+        time_start=2014-06-16T05:56:07.000000000>
     >>> d = fh.read(12)
     >>> d.shape
     (12, 8)


### PR DESCRIPTION
Properties are `header0`, `complex_data`, `bps`, `thread_ids` and `squeeze`.  Also updated a few docstrings for clarity.

Switching `frames_per_second` to framerate won't be done in time for the meeting, so I thought it might be useful to have this in the pipeline as a very small update.