### PR TITLE
Filestreamers' seek method can now use 'start', 'end', and 'current' in place of 0, 2 and 1.

### DIFF
--- a/baseband/dada/tests/test_dada.py
+++ b/baseband/dada/tests/test_dada.py
@@ -279,6 +279,15 @@ class TestDADA(object):
             assert fh._last_header == fh.header0
             assert np.abs(fh.stop_time -
                           (start_time + 16000 / (16.*u.MHz))) < 1.*u.ns
+            # Test seeker works with both int and str values for whence
+            assert fh.seek(13, 0) == fh.seek(13, 'start')
+            assert fh.seek(-13, 2) == fh.seek(-13, 'end')
+            fhseek_int = fh.seek(17, 1)
+            fh.seek(-17, 'current')
+            fhseek_str = fh.seek(17, 'current')
+            assert fhseek_int == fhseek_str
+            with pytest.raises(ValueError):
+                fh.seek(0, 'last')
 
         assert record1.shape == (12, 2)
         assert np.all(record1[:3] == np.array(

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -439,6 +439,15 @@ class TestMark4(object):
             assert fh.tell() == 80641
             # Raw file should be just after frame 1.
             assert fh.fh_raw.tell() == 0xa88 + 2 * fh.header0.framesize
+            # Test seeker works with both int and str values for whence
+            assert fh.seek(13, 0) == fh.seek(13, 'start')
+            assert fh.seek(-13, 2) == fh.seek(-13, 'end')
+            fhseek_int = fh.seek(17, 1)
+            fh.seek(-17, 'current')
+            fhseek_str = fh.seek(17, 'current')
+            assert fhseek_int == fhseek_str
+            with pytest.raises(ValueError):
+                fh.seek(0, 'last')
 
         assert record.shape == (642, 8)
         assert np.all(record[:640] == 0.)

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -228,7 +228,8 @@ class TestMark5B(object):
                 except EOFError:
                     break
                 header_time = frame.header.time
-                expected = start_time + frame.header['frame_nr'] * frame_duration
+                expected = (start_time +
+                            frame.header['frame_nr'] * frame_duration)
                 assert abs(header_time - expected) < 1. * u.ns
 
         # On the last frame, also check one can recover the time if 'frac_sec'
@@ -323,6 +324,15 @@ class TestMark5B(object):
             fh.seek(-10, 2)
             assert fh.tell() == fh.size - 10
             record3 = fh.read()
+            # Test seeker works with both int and str values for whence
+            assert fh.seek(13, 0) == fh.seek(13, 'start')
+            assert fh.seek(-13, 2) == fh.seek(-13, 'end')
+            fhseek_int = fh.seek(17, 1)
+            fh.seek(-17, 'current')
+            fhseek_str = fh.seek(17, 'current')
+            assert fhseek_int == fhseek_str
+            with pytest.raises(ValueError):
+                fh.seek(0, 'last')
 
         assert last_header['frame_nr'] == 3
         assert last_header['user'] == header['user']

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -512,6 +512,15 @@ class TestVDIF(object):
             assert fh.tell() == 0
             with pytest.raises(ValueError):
                 fh.seek(0, 3)
+            # Test seeker works with both int and str values for whence
+            assert fh.seek(13, 0) == fh.seek(13, 'start')
+            assert fh.seek(-13, 2) == fh.seek(-13, 'end')
+            fhseek_int = fh.seek(17, 1)
+            fh.seek(-17, 'current')
+            fhseek_str = fh.seek(17, 'current')
+            assert fhseek_int == fhseek_str
+            with pytest.raises(ValueError):
+                fh.seek(0, 'last')
             assert fh.size == 40000
             assert abs(fh.stop_time - fh._last_header.time - u.s /
                        fh.frames_per_second) < 1. * u.ns

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -330,7 +330,9 @@ class VLBIStreamReaderBase(VLBIStreamBase):
         whence : int
             Like regular seek, the offset is taken to be from the start if
             ``whence=0`` (default), from the current position if ``1``,
-            and from the end if ``2``.  Ignored if ``offset`` is a time.`
+            and from the end if ``2``.  One can use ``'start'``, ``'current'``,
+            or ``'end'`` for ``0``, ``1``, or ``2``, respectively.  Ignored if
+            ``offset`` is a time.`
         """
         try:
             offset = offset.__index__()
@@ -346,14 +348,15 @@ class VLBIStreamReaderBase(VLBIStreamBase):
                 self.samples_per_frame * self.frames_per_second * u_sample))])
             offset = int(round(offset.value))
 
-        if whence == 0:
+        if whence == 0 or whence == 'start':
             self.offset = offset
-        elif whence == 1:
+        elif whence == 1 or whence == 'current':
             self.offset += offset
-        elif whence == 2:
+        elif whence == 2 or whence == 'end':
             self.offset = self.size + offset
         else:
-            raise ValueError("invalid 'whence'; should be 0, 1, or 2.")
+            raise ValueError("invalid 'whence'; should be 0 or 'start', 1 or"
+                             "'current', or 2 or 'end'.")
 
         return self.offset
 


### PR DESCRIPTION
If approved, should be merged after #91, since its based off of that branch.