### PR TITLE
Mark4 ntrack auto guessing

### DIFF
--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -58,10 +58,10 @@ class Mark4FileReader(VLBIFileBase):
         Parameters
         ----------
         ntrack : int
-            Number of "tape tracks".
+            Number of tracks used to store the data.
         maximum : int, optional
             Maximum number of bytes forward to search through.
-            Default is the framesize (20000 * ntrack // 8).
+            Default is twice the framesize (20000 * ntrack // 8).
         forward : bool, optional
             Whether to search forwards or backwards.  Default is forwards.
 
@@ -177,6 +177,28 @@ class Mark4FileReader(VLBIFileBase):
 
         Read the header at that location and return it.
         The file pointer is left at the start of the header.
+
+        Parameters
+        ----------
+        template_header : `~baseband.mark4.Mark4Header`, optional
+            Template Mark 4 header, from which `ntrack` and `decade` are read.
+        ntrack : int, optional
+            Number of tracks used to store the data.  Required if
+            ``template_header`` is ``None``.
+        decade : int, optional
+            Decade the observations were taken (needed to remove ambiguity in
+            the Mark 4 time stamp).  Required if ``template_header`` is
+            ``None``.
+        maximum : int, optional
+            Maximum number of bytes to search through.  Default is twice the
+            framesize.
+        forward : bool, optional
+            Seek forward if ``True`` (default), backward if ``False``.
+
+        Returns
+        -------
+        header : :class:`~baseband.mark4.Mark4Header`, or None
+            Retrieved Mark 4 header, or ``None`` if nothing found.
         """
         if template_header is not None:
             ntrack = template_header.ntrack

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -149,7 +149,9 @@ class Mark4FileReader(VLBIFileBase):
 
         Uses ``find_frame`` to look for the first occurrence of a frame from
         the current position while cycling through all supported ``ntrack``
-        values.
+        values.  Returns the value of ``ntrack`` for which ``find_frame`` is
+        successful (it will fail for incorrect values), alongside the
+        found frame offset.
 
         Parameters
         ----------
@@ -234,7 +236,7 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
         file handle to the raw Mark 4 data stream.
     ntrack : int, or None
         Number of tracks used to store the data.  If ``None``, will attempt to
-        determine it by scanning the file.
+        automatically detect it by scanning the file.
     decade : int, or `~astropy.time.Time`
         Year rounded to decade, to remove ambiguities in the time stamps.
         By default, it will be inferred from the file creation date.
@@ -262,10 +264,9 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
             self.offset0, ntrack = self.find_frame_and_ntrack()
         else:
             self.offset0 = self.find_frame(ntrack=ntrack)
-        if self.offset0 is None:
-            raise Exception('Could not find the first occurrence of a header.'
-                            'If automatic ntrack detection was used, try'
-                            'passing in an explicit ntrack.')
+        assert self.offset0 is not None, (
+            "Could not find the first occurrence of a header.  If automatic "
+            "ntrack detection was used, try passing in an explicit ntrack.")
         self._frame = self.read_frame(ntrack, decade)
         self._frame_data = None
         self._frame_nr = None

--- a/baseband/mark4/header.py
+++ b/baseband/mark4/header.py
@@ -325,7 +325,7 @@ class Mark4Header(Mark4TrackHeader):
         elif ntrack == 32:
             return ta
         else:
-            raise ValueError("Have mark 4 track assignments only for "
+            raise ValueError("Have Mark 4 track assignments only for "
                              "ntrack=32 or 64, not {0}".format(ntrack))
 
     @property

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -419,6 +419,33 @@ class TestMark4(object):
             assert header_100f == header0
             assert header_m1000b == header0
 
+    def test_find_frame_and_ntrack(self):
+        with mark4.open(SAMPLE_FILE, 'rb') as fh:
+            offset0 = fh.find_frame(ntrack=64)
+            assert offset0 == 2696
+            fh.seek(0)
+            offset0_auto, ntrack_auto = fh.find_frame_and_ntrack()
+            assert offset0_auto == offset0
+            assert ntrack_auto == 64
+
+        with mark4.open(SAMPLE_32TRACK, 'rb') as fh:
+            # Seek past first frame header; find second frame.
+            fh.seek(10000)
+            offset0 = fh.find_frame(ntrack=32)
+            assert offset0 == 89656
+            fh.seek(10000)
+            offset0_auto, ntrack_auto = fh.find_frame_and_ntrack()
+            assert offset0_auto == offset0
+            assert ntrack_auto == 32
+
+        with mark4.open(SAMPLE_32TRACK_FANOUT2, 'rb') as fh:
+            offset0 = fh.find_frame(ntrack=32)
+            assert offset0 == 17436
+            fh.seek(0)
+            offset0_auto, ntrack_auto = fh.find_frame_and_ntrack()
+            assert offset0_auto == offset0
+            assert ntrack_auto == 32
+
     def test_filestreamer(self, tmpdir):
         with mark4.open(SAMPLE_FILE, 'rb') as fh:
             fh.seek(0xa88)
@@ -467,6 +494,15 @@ class TestMark4(object):
             record3 = fh.read(642)
 
         assert np.all(record3 == record)
+
+        # Test if automatic ntrack and frame rate detectors work together.
+        with mark4.open(SAMPLE_FILE, 'rs', decade=2010) as fh:
+            assert header == fh.header0
+            assert fh.frames_per_second * fh.samples_per_frame == 32000000
+            fh.seek(80000 + 639)
+            record4 = fh.read(2)
+
+        assert np.all(record4 == record2)
 
         with mark4.open(SAMPLE_FILE, 'rs', ntrack=64, decade=2010,
                         sample_rate=32*u.MHz) as fh:
@@ -561,14 +597,32 @@ class TestMark4(object):
                 open(str(tmpdir.join('test.m4')), 'w+b') as s:
             fh.seek(0xa88)
             frame = fh.read_frame(ntrack=64, decade=2010)
+            # Write single frame to file.
             frame.tofile(s)
+            # Now add lots of data without headers.
+            for i in range(5):
+                frame.payload.tofile(s)
+            s.seek(0)
+            # With too many payload samples for one frame, f2.find_frame
+            # will fail.
+            with pytest.raises(AssertionError):
+                f2 = mark4.open(s, 'rs', ntrack=64, decade=2010,
+                                sample_rate=32*u.MHz)
+
+        with mark4.open(SAMPLE_FILE, 'rb') as fh, \
+                open(str(tmpdir.join('test.m4')), 'w+b') as s:
+            fh.seek(0xa88)
+            frame0 = fh.read_frame(ntrack=64, decade=2010)
+            frame1 = fh.read_frame(ntrack=64, decade=2010)
+            frame0.tofile(s)
+            frame1.tofile(s)
             # now add lots of data without headers.
             for i in range(15):
-                frame.payload.tofile(s)
+                frame1.payload.tofile(s)
             s.seek(0)
             with mark4.open(s, 'rs', ntrack=64, decade=2010,
                             sample_rate=32*u.MHz) as f2:
-                assert f2.header0 == frame.header
+                assert f2.header0 == frame0.header
                 with pytest.raises(ValueError):
                     f2._last_header
 

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -419,14 +419,14 @@ class TestMark4(object):
             assert header_100f == header0
             assert header_m1000b == header0
 
-    def test_find_frame_and_ntrack(self):
+    def test_determine_ntrack(self):
         with mark4.open(SAMPLE_FILE, 'rb') as fh:
             offset0 = fh.find_frame(ntrack=64)
             assert offset0 == 2696
             fh.seek(0)
-            offset0_auto, ntrack_auto = fh.find_frame_and_ntrack()
-            assert offset0_auto == offset0
-            assert ntrack_auto == 64
+            ntrack = fh.determine_ntrack()
+            assert ntrack == 64
+            assert fh.fh_raw.tell() == offset0
 
         with mark4.open(SAMPLE_32TRACK, 'rb') as fh:
             # Seek past first frame header; find second frame.
@@ -434,17 +434,17 @@ class TestMark4(object):
             offset0 = fh.find_frame(ntrack=32)
             assert offset0 == 89656
             fh.seek(10000)
-            offset0_auto, ntrack_auto = fh.find_frame_and_ntrack()
-            assert offset0_auto == offset0
-            assert ntrack_auto == 32
+            ntrack = fh.determine_ntrack()
+            assert fh.fh_raw.tell() == offset0
+            assert ntrack == 32
 
         with mark4.open(SAMPLE_32TRACK_FANOUT2, 'rb') as fh:
             offset0 = fh.find_frame(ntrack=32)
             assert offset0 == 17436
             fh.seek(0)
-            offset0_auto, ntrack_auto = fh.find_frame_and_ntrack()
-            assert offset0_auto == offset0
-            assert ntrack_auto == 32
+            ntrack = fh.determine_ntrack()
+            assert fh.fh_raw.tell() == offset0
+            assert ntrack == 32
 
     def test_filestreamer(self, tmpdir):
         with mark4.open(SAMPLE_FILE, 'rb') as fh:


### PR DESCRIPTION
@cczhu - this is just your PR, but with the `ref_mjd` commit removed, and an additional one added that simplifies the routine to just be `determine_ntrack`, which returns ntrack and leaves the filepointer in the right place. I think this is a bit cleaner. What do you think?