### PR TITLE
Mark 4, 5B accept `astropy.time.Time` objects as reference times; both now able to read across large time divisions

### DIFF
--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -519,8 +519,9 @@ class Mark4StreamWriter(VLBIStreamWriterBase, Mark4FileWriter):
 open = make_opener('Mark4', globals(), doc="""
 --- For reading a stream : (see `~baseband.mark4.base.Mark4StreamReader`)
 
-ntrack : int
-    Number of tracks used to store the data.
+ntrack : int, optional
+    Number of tracks used to store the data. Will be inferred from file
+    if not given.
 decade : int, or None, optional
     Decade of the observation start time (eg. ``2010`` for 2018), needed to
     remove ambiguity in the Mark 4 time stamp.  Can instead pass an approximate

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -333,10 +333,10 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
         """
         oldpos = fh.tell()
         header0 = header_template.fromfile(fh, header_template.ntrack,
-                                           decade=header_template.decade)
+                                           ref_time=header_template.time)
         fh.seek(header0.payloadsize, 1)
         header1 = header_template.fromfile(fh, header_template.ntrack,
-                                           decade=header_template.decade)
+                                           ref_time=header_template.time)
         fh.seek(oldpos)
         # Mark 4 specification states frames-lengths range from 1.25 ms
         # to 160 ms.
@@ -347,10 +347,9 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
     def _last_header(self):
         """Last header of the file."""
         last_header = super(Mark4StreamReader, self)._last_header
-        # decade correction.
-        header_unit_year = last_header['bcd_unit_year'][0]
-        last_header.decade = Mark4Header.infer_decade(self.header0.time,
-                                                      header_unit_year)
+        # Infer the decade, assuming the end of the file is no more than
+        # 4 years away from the start.
+        last_header.infer_decade(self.header0.time)
         return last_header
 
     def read(self, count=None, fill_value=0., out=None):

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -252,8 +252,8 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
         Number of tracks used to store the data.  If ``None``, will attempt to
         automatically detect it by scanning the file.
     decade : int, or `~astropy.time.Time`
-        Year rounded to decade, to remove ambiguities in the time stamps.
-        By default, it will be inferred from the file creation date.
+        Decade the observations were taken (needed to remove ambiguity in the
+        Mark 4 time stamp).
     thread_ids: list of int, optional
         Specific threads/channels to read.  By default, all are read.
     frames_per_second : int, optional
@@ -285,6 +285,11 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
             assert self.offset0 is not None, (
                 "Could not find a first frame using ntrack={}. Perhaps "
                 "try ntrack=None for auto-determination.".format(ntrack))
+        # If decade is an astropy.time.Time object, extract decade.
+        try:
+            decade = decade.__index__()
+        except AttributeError:
+            decade = 10 * (decade.datetime.year // 10)
         self._frame = self.read_frame(ntrack, decade)
         self._frame_data = None
         self._frame_nr = None

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -1,5 +1,6 @@
 # Licensed under the GPLv3 - see LICENSE.rst
 import numpy as np
+from astropy.utils import lazyproperty
 
 from ..vlbi_base.base import (make_opener, VLBIFileBase, VLBIStreamReaderBase,
                               VLBIStreamWriterBase)
@@ -22,7 +23,7 @@ class Mark4FileReader(VLBIFileBase):
     Adds ``read_frame`` and ``find_frame`` methods to the VLBI file wrapper.
     """
 
-    def read_frame(self, ntrack, decade):
+    def read_frame(self, ntrack, decade=None, ref_time=None):
         """Read a single frame (header plus payload).
 
         Parameters
@@ -30,8 +31,11 @@ class Mark4FileReader(VLBIFileBase):
         ntrack : int
             Number of Mark 4 bitstreams.
         decade : int
-            Decade the observations were taken (needed to remove ambiguity in
-            the Mark 4 time stamp).
+            Decade the observations were taken in, needed to remove ambiguity
+            in the Mark 4 time stamp.  Used only if `ref_time` is ``None``.
+        ref_time : `~astropy.time.Time`, optional
+            Reference time within 4 years of the start time of the
+            observations.  Can instead pass `decade`.
 
         Returns
         -------
@@ -40,7 +44,13 @@ class Mark4FileReader(VLBIFileBase):
             :class:`~baseband.mark4.Mark4Header` and data encoded in the frame,
             respectively.
         """
-        return Mark4Frame.fromfile(self.fh_raw, ntrack=ntrack, decade=decade)
+        frame = Mark4Frame.fromfile(self.fh_raw, ntrack=ntrack, decade=decade)
+        if ref_time:
+            # Unnecessary to decode BCD for single digit.
+            header_unit_year = frame.header['bcd_unit_year'][0]
+            frame.header.decade = self.ref_time_to_decade(ref_time,
+                                                          header_unit_year)
+        return frame
 
     def find_frame(self, ntrack, maximum=None, forward=True):
         """Look for the first occurrence of a frame, from the current position.
@@ -186,8 +196,8 @@ class Mark4FileReader(VLBIFileBase):
             Number of tracks used to store the data.  Required if
             ``template_header`` is ``None``.
         decade : int, optional
-            Decade the observations were taken (needed to remove ambiguity in
-            the Mark 4 time stamp).  Required if ``template_header`` is
+            Decade the observations were taken in, needed to remove ambiguity
+            in the Mark 4 time stamp.  Required if ``template_header`` is
             ``None``.
         maximum : int, optional
             Maximum number of bytes to search through.  Default is twice the
@@ -210,6 +220,22 @@ class Mark4FileReader(VLBIFileBase):
                                       decade=decade)
         self.fh_raw.seek(offset)
         return header
+
+    @staticmethod
+    def ref_time_to_decade(ref_time, header_unit_year):
+        """Uses a reference time to determine a header's ``decade``.
+
+        Parameters
+        ----------
+        ref_time : `~astropy.time.Time`
+            Reference time within 4 years of the start time of the
+            observations.
+        header_unit_year : int
+            Unit digit of the year the observations, from the header.
+        """
+        ref_decade, ref_year = divmod(ref_time.datetime.year, 10)
+        return 10 * int(ref_decade +
+                        np.round((ref_year - header_unit_year) / 10.))
 
 
 class Mark4FileWriter(VLBIFileBase):
@@ -251,9 +277,12 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
     ntrack : int, or None
         Number of tracks used to store the data.  If ``None``, will attempt to
         automatically detect it by scanning the file.
-    decade : int, or `~astropy.time.Time`
-        Decade the observations were taken (needed to remove ambiguity in the
-        Mark 4 time stamp).
+    decade : int, optional
+        Decade the observations were taken in, needed to remove ambiguity in
+        the Mark 4 time stamp.  Used only if `ref_time` is ``None``.
+    ref_time : `~astropy.time.Time`, optional
+        Reference time within 4 years of the start time of the observations.
+        Can instead pass `decade`.
     thread_ids: list of int, optional
         Specific threads/channels to read.  By default, all are read.
     frames_per_second : int, optional
@@ -268,8 +297,9 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
 
     _frame_class = Mark4Frame
 
-    def __init__(self, fh_raw, ntrack=None, decade=None, thread_ids=None,
-                 frames_per_second=None, sample_rate=None, squeeze=True):
+    def __init__(self, fh_raw, ntrack=None, decade=None, ref_time=None,
+                 thread_ids=None, frames_per_second=None, sample_rate=None,
+                 squeeze=True):
         # Pre-set fh_raw, so FileReader methods work
         # TODO: move this to StreamReaderBase?
         self.fh_raw = fh_raw
@@ -285,12 +315,7 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
             assert self.offset0 is not None, (
                 "Could not find a first frame using ntrack={}. Perhaps "
                 "try ntrack=None for auto-determination.".format(ntrack))
-        # If decade is an astropy.time.Time object, extract decade.
-        try:
-            decade = decade.__index__()
-        except AttributeError:
-            decade = 10 * (decade.datetime.year // 10)
-        self._frame = self.read_frame(ntrack, decade)
+        self._frame = self.read_frame(ntrack, decade=decade, ref_time=ref_time)
         self._frame_data = None
         self._frame_nr = None
         header = self._frame.header
@@ -325,7 +350,7 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
         Unlike VLBIStreamReaderBase._get_frame_rate, this function reads
         only two consecutive frames, extracting their timestamps to determine
         how much time has elapsed.  It will return an EOFError if there is
-        only one frame.
+        only one frame.  It cannot seek past decade increments.
         """
         oldpos = fh.tell()
         header0 = header_template.fromfile(fh, header_template.ntrack,
@@ -338,6 +363,16 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
         # to 160 ms.
         tdelta = header1.ms[0] - header0.ms[0]
         return int(np.round(1000. / tdelta))
+
+    @lazyproperty
+    def _last_header(self):
+        """Last header of the file."""
+        last_header = super(Mark4StreamReader, self)._last_header
+        # decade correction.
+        header_unit_year = last_header['bcd_unit_year'][0]
+        last_header.decade = self.ref_time_to_decade(self.header0.time,
+                                                     header_unit_year)
+        return last_header
 
     def read(self, count=None, fill_value=0., out=None):
         """Read count samples.
@@ -401,7 +436,8 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
         frame_nr = self.offset // self.samples_per_frame
         self.fh_raw.seek(self.offset0 + frame_nr * self.header0.framesize)
         self._frame = self.read_frame(ntrack=self.header0.ntrack,
-                                      decade=self.header0.decade)
+                                      ref_time=self.header0.time)
+        # Convert payloads to data array.
         self._frame_nr = frame_nr
 
 
@@ -506,6 +542,12 @@ open = make_opener('Mark4', globals(), doc="""
 
 ntrack : int
     Number of tracks used to store the data.
+decade : int, optional
+    Decade the observations were taken in, needed to remove ambiguity in the
+    Mark 4 time stamp.  Used only if `ref_time` is ``None``.
+ref_time : `~astropy.time.Time`, optional
+    Reference time within 4 years of the start time of the observations.  Can
+    instead pass `decade`.
 thread_ids: list of int, optional
     Specific threads/channels to read.  By default, all are read.
 frames_per_second : int, optional

--- a/baseband/mark4/frame.py
+++ b/baseband/mark4/frame.py
@@ -100,7 +100,7 @@ class Mark4Frame(VLBIFrameBase):
             self.header['communication_error'] = True
 
     @classmethod
-    def fromfile(cls, fh, ntrack, decade=None, verify=True):
+    def fromfile(cls, fh, ntrack, decade=None, ref_time=None, verify=True):
         """Read a frame from a filehandle.
 
         Parameters
@@ -109,13 +109,18 @@ class Mark4Frame(VLBIFrameBase):
             To read header from.
         ntrack : int
             Number of Mark 4 bitstreams.
-        decade : int, or None
-            Decade the observations were taken (needed to remove ambiguity in
-            the Mark 4 time stamp).
+        decade : int, or None, optional
+            Decade in which the observations were taken.  Can instead pass an
+            approximate `ref_time`.
+        ref_time : `~astropy.time.Time`, or None, optional
+            Reference time within 4 years of the observation time.  Used only
+            if `decade` is ``None``.
+
         verify : bool
             Whether to do basic verification of integrity.  Default: `True`.
         """
-        header = cls._header_class.fromfile(fh, ntrack, decade, verify)
+        header = cls._header_class.fromfile(fh, ntrack, decade=decade,
+                                            ref_time=ref_time, verify=verify)
         payload = cls._payload_class.fromfile(fh, header=header)
         return cls(header, payload, verify=verify)
 

--- a/baseband/mark4/header.py
+++ b/baseband/mark4/header.py
@@ -157,7 +157,8 @@ class Mark4TrackHeader(VLBIHeaderBase):
         assert np.all(self['sync_pattern'] ==
                       self._header_parser.defaults['sync_pattern'])
         assert np.all((self['bcd_fraction'] & 0xf) % 5 != 4)
-        assert self.decade is not None and (1950 < self.decade < 3000)
+        if self.decade is not None:
+            assert (1950 < self.decade < 3000)
 
     @property
     def track_id(self):

--- a/baseband/mark4/header.py
+++ b/baseband/mark4/header.py
@@ -164,7 +164,7 @@ class Mark4TrackHeader(VLBIHeaderBase):
             assert self.decade % 10 == 0, "decade must be end in zero"
 
     def infer_decade(self, ref_time):
-        """Uses a reference time to determine a header's ``decade``.
+        """Uses a reference time to set a header's ``decade``.
 
         Parameters
         ----------

--- a/baseband/mark4/header.py
+++ b/baseband/mark4/header.py
@@ -161,7 +161,7 @@ class Mark4TrackHeader(VLBIHeaderBase):
         assert np.all((self['bcd_fraction'] & 0xf) % 5 != 4)
         if self.decade is not None:
             assert (1950 < self.decade < 3000)
-            assert self.decade % 10 == 0, "decade must be end in zero"
+            assert self.decade % 10 == 0, "decade must end in zero"
 
     def infer_decade(self, ref_time):
         """Uses a reference time to set a header's ``decade``.

--- a/baseband/mark4/header.py
+++ b/baseband/mark4/header.py
@@ -141,13 +141,15 @@ class Mark4TrackHeader(VLBIHeaderBase):
 
     decade = None
 
-    def __init__(self, words, decade=None, verify=True):
+    def __init__(self, words, decade=None, ref_time=None, verify=True):
         if words is None:
             self.words = [0, 0, 0, 0, 0]
         else:
             self.words = words
         if decade is not None:
             self.decade = decade
+        elif ref_time is not None:
+            self.infer_decade(ref_time)
         if verify:
             self.verify()
 
@@ -159,8 +161,18 @@ class Mark4TrackHeader(VLBIHeaderBase):
         assert np.all((self['bcd_fraction'] & 0xf) % 5 != 4)
         if self.decade is not None:
             assert (1950 < self.decade < 3000)
-            assert self.decade % 10 == 0, ("decade must be explicit "
-                                           "decades.")
+            assert self.decade % 10 == 0, "decade must be end in zero"
+
+    def infer_decade(self, ref_time):
+        """Uses a reference time to determine a header's ``decade``.
+
+        Parameters
+        ----------
+        ref_time : `~astropy.time.Time`
+            Reference time within 5 years of the observation time.
+        """
+        self.decade = np.round(ref_time.decimalyear - self['bcd_unit_year'],
+                               decimals=-1).astype(int)
 
     @property
     def track_id(self):
@@ -293,16 +305,9 @@ class Mark4Header(Mark4TrackHeader):
     def __init__(self, words, ntrack=None, decade=None, ref_time=None,
                  verify=True):
         if words is None:
-            self.words = np.zeros((5, ntrack), dtype=np.uint32)
-        else:
-            self.words = words
-        if decade is not None:
-            self.decade = decade
-        elif ref_time is not None:
-            self.decade = self.infer_decade(ref_time,
-                                            self['bcd_unit_year'][0])
-        if verify:
-            self.verify()
+            words = np.zeros((5, ntrack), dtype=np.uint32)
+        super(Mark4Header, self).__init__(words, decade=decade,
+                                          ref_time=ref_time, verify=verify)
 
     def verify(self):
         super(Mark4Header, self).verify()
@@ -311,20 +316,11 @@ class Mark4Header(Mark4TrackHeader):
                                                  self['lsb_output']))) ==
                 self.nchan)
 
-    @staticmethod
-    def infer_decade(ref_time, header_unit_year):
-        """Uses a reference time to determine a header's ``decade``.
-
-        Parameters
-        ----------
-        ref_time : `~astropy.time.Time`
-            Reference time within 4 years of the observation time.
-        header_unit_year : int
-            Unit digit of the year the observations, from the header.
-        """
-        ref_decade, ref_year = divmod(ref_time.datetime.year, 10)
-        return 10 * int(ref_decade + np.round((ref_year -
-                                               header_unit_year) / 10.))
+    def infer_decade(self, ref_time):
+        super(Mark4Header, self).infer_decade(ref_time)
+        if getattr(self.decade, 'size', 1) > 1:
+            assert np.all(self.decade == self.decade[0])
+            self.decade = self.decade[0]
 
     @classmethod
     def _stream_dtype(cls, ntrack):
@@ -420,11 +416,11 @@ class Mark4Header(Mark4TrackHeader):
         ntrack : int
             Number of Mark 4 bitstreams.
         decade : int, or None, optional
-            Decade in which the observations were taken.  Can instead pass an
-            approximate `ref_time`.
+            Decade in which the observations were taken.  Not needed if
+            ``time`` is given.  Can instead pass an approximate `ref_time`.
         ref_time : `~astropy.time.Time`, or None, optional
-            Reference time within 4 years of the observation time.  Used only
-            if `decade` is ``None``.
+            Reference time within 4 years of the observation time.  Not needed
+            if ``time`` is given, and used only if `decade` is ``None``.
         **kwargs :
             Values used to initialize header keys or methods.
 
@@ -452,8 +448,8 @@ class Mark4Header(Mark4TrackHeader):
         if not any(key in kwargs for key in ('lsb_output', 'converter_id',
                                              'converter')):
             kwargs.setdefault('nsb', 1)
-        return super(Mark4Header, cls).fromvalues(ntrack, decade=decade,
-                                                  ref_time=ref_time, **kwargs)
+        return super(Mark4Header, cls).fromvalues(ntrack, decade, ref_time,
+                                                  **kwargs)
 
     def update(self, crc=None, verify=True, **kwargs):
         """Update the header by setting keywords or properties.

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -187,24 +187,19 @@ class TestMark4(object):
         assert header13.ntrack == 53
         assert abs(header13.time - header.time) < 1. * u.ns
 
-    def test_infer_decade(self):
+    @pytest.mark.parametrize(('unit_year', 'ref_time', 'decade'),
+                             [(5, Time('2014:1:12:00:00'), 2010),
+                              (5, Time('2009:362:19:27:33'), 2000),
+                              (3, Time('2009:362:19:27:33'), 2010),
+                              (2, Time('2018:117:6:42:15'), 2020),
+                              (4, Time('2018:117:6:42:15'), 2010)])
+    def test_infer_decade(self, unit_year, ref_time, decade):
         # Check that infer_decade returns proper decade for
         # ref_time.year - 5 < year <= ref_time.year + 5.
-        decade = mark4.header.Mark4Header.infer_decade(
-            Time('2014:1:12:00:00'), 5)
-        assert decade == 2010
-        decade = mark4.header.Mark4Header.infer_decade(
-            Time('2009:362:19:27:33'), 5)
-        assert decade == 2000
-        decade = mark4.header.Mark4Header.infer_decade(
-            Time('2009:362:19:27:33'), 3)
-        assert decade == 2010
-        decade = mark4.header.Mark4Header.infer_decade(
-            Time('2018:117:6:42:15'), 2)
-        assert decade == 2020
-        decade = mark4.header.Mark4Header.infer_decade(
-            Time('2018:117:6:42:15'), 4)
-        assert decade == 2010
+        header = mark4.header.Mark4Header(None, ntrack=16, verify=False)
+        header['bcd_unit_year'] = unit_year
+        header.infer_decade(ref_time)
+        assert header.decade == decade
 
     def test_decoding(self):
         """Check that look-up levels are consistent with mark5access."""

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import pytest
 import numpy as np
 from astropy import units as u
+from astropy.time import Time
 from astropy.tests.helper import catch_warnings
 from ... import mark4
 from ...vlbi_base.encoding import OPTIMAL_2BIT_HIGH
@@ -353,12 +354,14 @@ class TestMark4(object):
                                             forward=True)
             assert fh.tell() == 0xa88 + header0.framesize
             fh.seek(0xa87)
-            header_0xa87b = fh.find_header(template_header=header0,
+            header_0xa87b = fh.find_header(ntrack=header0.ntrack,
+                                           decade=header0.decade,
                                            forward=False)
             assert header_0xa87b is None
             assert fh.tell() == 0xa87
             fh.seek(0xa88)
-            header_0xa88f = fh.find_header(template_header=header0)
+            header_0xa88f = fh.find_header(ntrack=header0.ntrack,
+                                           decade=header0.decade)
             assert fh.tell() == 0xa88
             fh.seek(0xa88)
             header_0xa88b = fh.find_header(template_header=header0,
@@ -486,6 +489,14 @@ class TestMark4(object):
         assert record2.shape == (2, 8)
         assert np.all(record2[0] == 0.)
         assert not np.any(record2[1] == 0.)
+
+        # Check passing a time object into decade.
+        with mark4.open(SAMPLE_FILE, 'rs', ntrack=64,
+                        decade=Time('2018:364:23:59:59')) as fh:
+            assert header == fh.header0
+        with mark4.open(SAMPLE_FILE, 'rs', ntrack=64,
+                        decade=Time(56039.5, format='mjd')) as fh:
+            assert header == fh.header0
 
         # Test if _get_frame_rate automatic frame rate calculator works,
         # returns same header and payload info.

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -190,12 +190,13 @@ class TestMark4(object):
     @pytest.mark.parametrize(('unit_year', 'ref_time', 'decade'),
                              [(5, Time('2014:1:12:00:00'), 2010),
                               (5, Time('2009:362:19:27:33'), 2000),
-                              (3, Time('2009:362:19:27:33'), 2010),
-                              (2, Time('2018:117:6:42:15'), 2020),
+                              (4, Time('2009:001:19:27:33'), 2010),
+                              (3, Time('2018:117:6:42:15'), 2020),
                               (4, Time('2018:117:6:42:15'), 2010)])
     def test_infer_decade(self, unit_year, ref_time, decade):
         # Check that infer_decade returns proper decade for
-        # ref_time.year - 5 < year <= ref_time.year + 5.
+        # ref_time.year - 5 < year < ref_time.year + 5, and uses bankers'
+        # rounding at the boundaries.
         header = mark4.header.Mark4Header(None, ntrack=16, verify=False)
         header['bcd_unit_year'] = unit_year
         header.infer_decade(ref_time)

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -23,9 +23,9 @@ class Mark5BFileReader(VLBIFileBase):
 
         Parameters
         ----------
-        ref_time : int
-            Used to determine the thousands in the Mark 5B header time.
-            Thus, should be within 500 days of the actual observing time.
+        ref_mjd : int
+            Reference MJD within 500 days of the observation time, used to
+            infer the full MJD from the time information in the header.
         nchan : int
             Number of channels encoded in the payload.
         bps : int
@@ -46,6 +46,28 @@ class Mark5BFileReader(VLBIFileBase):
 
         Search is from the current position.  If given, a template_header
         is used to initialize the framesize, as well as kday in the header.
+
+        Parameters
+        ----------
+        template_header : :class:`~baseband.mark5b.Mark5BHeader`, optional
+            Template Mark 5B header, from which `kday` and `framesize`
+            are extracted.
+        kday : int, optional
+            Explicit thousands of MJD of the observation time.  Required if
+            `template_header` is ``None``.
+        framesize : int, optional
+            Size of a frame, in bytes.  Required if `template_header` is
+            ``None``.
+        maximum : int, optional
+            Maximum number of bytes to search through.  Default is twice the
+            framesize.
+        forward : bool, optional
+            Seek forward if ``True`` (default), backward if ``False``.
+
+        Returns
+        -------
+        header : :class:`~baseband.mark5b.Mark5BHeader`, or None
+            Retrieved Mark 5B header, or ``None`` if nothing found.
         """
         fh = self.fh_raw
         if template_header:
@@ -113,6 +135,7 @@ class Mark5BFileWriter(VLBIFileBase):
 
     Adds ``write_frame`` method to the VLBI binary file wrapper.
     """
+
     def write_frame(self, data, header=None, bps=2, valid=True, **kwargs):
         """Write a single frame (header plus payload).
 
@@ -156,8 +179,8 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
     bps : int, optional
         Bits per sample.  Default: 2.
     ref_mjd : int, or `~astropy.time.Time` instance
-        Reference MJD (rounded to thousands), to remove ambiguities in the
-        time stamps.  By default, will be inferred from the file creation date.
+        Reference MJD within 500 days of the observation time, used to infer
+        the full MJD from the time information in the header.
     thread_ids: list of int, optional
         Specific channels to read.  By default, all channels are read.
     frames_per_second : int, optional
@@ -177,6 +200,11 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
         # Pre-set fh_raw, so FileReader methods work
         # TODO: move this to StreamReaderBase?
         self.fh_raw = fh_raw
+        # If ref_mjd is astropy.time.Time object, extract mjd.
+        try:
+            ref_mjd = ref_mjd.__index__()
+        except AttributeError:
+            ref_mjd = int(ref_mjd.mjd)
         self._frame = self.read_frame(ref_mjd=ref_mjd, nchan=nchan, bps=bps)
         self._frame_data = None
         header = self._frame.header
@@ -264,7 +292,7 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
     def _read_frame(self, fill_value=0.):
         self.fh_raw.seek(self.offset // self.samples_per_frame *
                          self._frame.size)
-        self._frame = self.read_frame(ref_mjd=self.header0.kday,
+        self._frame = self.read_frame(ref_mjd=int(self.header0.time.mjd),
                                       nchan=self._sample_shape.nchan,
                                       bps=self.bps)
 
@@ -377,8 +405,8 @@ nchan : int
 bps : int, optional
     Bits per sample.  Default: 2.
 ref_mjd : int, or `~astropy.time.Time` instance
-    Reference MJD (rounded to thousands), to remove ambiguities in the
-    time stamps.  By default, will be inferred from the file creation date.
+    Reference MJD within 500 days of the observation time, used to infer
+    the full MJD from the time information in the header.
 thread_ids: list of int, optional
     Specific threads to read.  By default, all threads are read.
 frames_per_second : int, optional

--- a/baseband/mark5b/frame.py
+++ b/baseband/mark5b/frame.py
@@ -69,16 +69,17 @@ class Mark5BFrame(VLBIFrameBase):
         super(Mark5BFrame, self).__init__(header, payload, valid, verify)
 
     @classmethod
-    def fromfile(cls, fh, ref_mjd, nchan, bps=2, valid=None, verify=True):
+    def fromfile(cls, fh, kday, nchan, bps=2, valid=None, verify=True):
         """Read a frame from a filehandle.
 
         Parameters
         ----------
         fh : filehandle
             To read the header and payload from.
-        ref_mjd : int
-            Reference MJD within 500 days of the observation time, used to
-            infer the full MJD from the time information in the header.
+        kday : int, optional
+            Explicit thousands of MJD of the observation start time (eg.
+            ``57000`` for MJD 57999), used to infer the full MJD from header's
+            time information.
         nchan : int
             Number of channels encoded in the payload.
         bps : int
@@ -86,7 +87,7 @@ class Mark5BFrame(VLBIFrameBase):
         verify : bool
             Whether to do basic checks of frame integrity (default: `True`).
         """
-        header = cls._header_class.fromfile(fh, ref_mjd, verify=verify)
+        header = cls._header_class.fromfile(fh, kday, verify=verify)
         payload = cls._payload_class.fromfile(fh, nchan, bps)
         return cls(header, payload, valid, verify)
 

--- a/baseband/mark5b/frame.py
+++ b/baseband/mark5b/frame.py
@@ -76,9 +76,9 @@ class Mark5BFrame(VLBIFrameBase):
         ----------
         fh : filehandle
             To read the header and payload from.
-        ref_mjd : float
-            MJD within 500 days of the actual observation, to resolve 1000-day
-            ambiguities in the Mark 5B timestamp.
+        ref_mjd : int
+            Reference MJD within 500 days of the observation time, used to
+            infer the full MJD from the time information in the header.
         nchan : int
             Number of channels encoded in the payload.
         bps : int

--- a/baseband/mark5b/frame.py
+++ b/baseband/mark5b/frame.py
@@ -69,26 +69,30 @@ class Mark5BFrame(VLBIFrameBase):
         super(Mark5BFrame, self).__init__(header, payload, valid, verify)
 
     @classmethod
-    def fromfile(cls, fh, kday, nchan, bps=2, valid=None, verify=True):
+    def fromfile(cls, fh, nchan, kday=None, ref_time=None, bps=2, valid=None,
+                 verify=True):
         """Read a frame from a filehandle.
 
         Parameters
         ----------
         fh : filehandle
             To read the header and payload from.
-        kday : int, optional
-            Explicit thousands of MJD of the observation start time (eg.
-            ``57000`` for MJD 57999), used to infer the full MJD from header's
-            time information.
         nchan : int
             Number of channels encoded in the payload.
+        kday : int, or None, optional
+            Explicit thousands of MJD of the observation time.  Can instead
+            pass an approximate `ref_time`.
+        ref_time : `~astropy.time.Time`, or None, optional
+            Reference time within 500 days of the observation time, used to
+            infer the full MJD.  Used only if `kday` is ``None``.
         bps : int
             Number of bits per sample used in payload encoding (default: 2).
         verify : bool
             Whether to do basic checks of frame integrity (default: `True`).
         """
-        header = cls._header_class.fromfile(fh, kday, verify=verify)
-        payload = cls._payload_class.fromfile(fh, nchan, bps)
+        header = cls._header_class.fromfile(fh, kday=kday, ref_time=ref_time,
+                                            verify=verify)
+        payload = cls._payload_class.fromfile(fh, nchan=nchan, bps=bps)
         return cls(header, payload, valid, verify)
 
     @classmethod

--- a/baseband/mark5b/frame.py
+++ b/baseband/mark5b/frame.py
@@ -69,7 +69,7 @@ class Mark5BFrame(VLBIFrameBase):
         super(Mark5BFrame, self).__init__(header, payload, valid, verify)
 
     @classmethod
-    def fromfile(cls, fh, nchan, kday=None, ref_time=None, bps=2, valid=None,
+    def fromfile(cls, fh, nchan, bps=3, kday=None, ref_time=None, valid=None,
                  verify=True):
         """Read a frame from a filehandle.
 
@@ -79,14 +79,14 @@ class Mark5BFrame(VLBIFrameBase):
             To read the header and payload from.
         nchan : int
             Number of channels encoded in the payload.
+        bps : int
+            Number of bits per sample used in payload encoding (default: 2).
         kday : int, or None, optional
             Explicit thousands of MJD of the observation time.  Can instead
             pass an approximate `ref_time`.
         ref_time : `~astropy.time.Time`, or None, optional
             Reference time within 500 days of the observation time, used to
             infer the full MJD.  Used only if `kday` is ``None``.
-        bps : int
-            Number of bits per sample used in payload encoding (default: 2).
         verify : bool
             Whether to do basic checks of frame integrity (default: `True`).
         """

--- a/baseband/mark5b/header.py
+++ b/baseband/mark5b/header.py
@@ -82,7 +82,7 @@ class Mark5BHeader(VLBIHeaderBase):
         if kday is not None:
             self.kday = kday
         elif ref_time is not None:
-            self.kday = self.infer_kday(ref_time, self.jday)
+            self.infer_kday(ref_time)
         if verify:
             self.verify()
 
@@ -93,8 +93,7 @@ class Mark5BHeader(VLBIHeaderBase):
                 self._header_parser.defaults['sync_pattern'])
         assert self.kday is None or (33000 < self.kday < 400000)
         if self.kday is not None:
-            assert self.kday % 1000 == 0, ("kday must be explicit "
-                                           "thousands of MJD.")
+            assert self.kday % 1000 == 0, "kday must be thousands of MJD."
 
     def copy(self, **kwargs):
         return super(Mark5BHeader, self).copy(kday=self.kday, **kwargs)
@@ -135,25 +134,15 @@ class Mark5BHeader(VLBIHeaderBase):
             if verify:
                 self.verify()
 
-    @staticmethod
-    def infer_kday(ref_time, header_jday):
-        """Uses a reference time to determine a header's ``kday``.
+    def infer_kday(self, ref_time):
+        """Uses a reference time to set a header's ``kday``.
 
         Parameters
         ----------
         ref_time : `~astropy.time.Time`
             Reference time within 500 days of the observation time.
-        header_jday : int
-            Correct jday from the header.
-
-        Returns
-        -------
-        kday : int
-            Explicit thousands of MJD of the observation time.
         """
-        ref_kday, ref_jday = divmod(ref_time.mjd, 1000)
-        return 1000 * int(ref_kday + np.round((ref_jday -
-                                               header_jday) / 1000.))
+        self.kday = np.round(ref_time.mjd - self.jday, decimals=-3).astype(int)
 
     @property
     def payloadsize(self):

--- a/baseband/mark5b/header.py
+++ b/baseband/mark5b/header.py
@@ -44,9 +44,9 @@ class Mark5BHeader(VLBIHeaderBase):
     words : tuple of int, or None
         Eight (or four for legacy VDIF) 32-bit unsigned int header words.
         If ``None``, set to a tuple of zeros for later initialisation.
-    ref_mjd : float, or None
-        MJD within 500 days of the observation time, used to infer the
-        full MJD from the time information in the header (which only has
+    ref_mjd : int, or None
+        Reference MJD within 500 days of the observation time, used to infer
+        the full MJD from the time information in the header (which only has
         last 3 digits of the MJD).
     kday : int, or None
         Explicit thousands of MJD.
@@ -82,12 +82,12 @@ class Mark5BHeader(VLBIHeaderBase):
         elif ref_mjd is not None:
             ref_kday, ref_jday = divmod(ref_mjd, 1000)
             if words is None:
-                jday = 0.
+                jday = 0
             else:
                 # self is not yet initialised, so get jday from words directly
                 jday = bcd_decode(
                     self._header_parser.parsers['bcd_jday'](words))
-            self.kday = int(ref_kday + round((ref_jday - jday)/1000)) * 1000
+            self.kday = int(ref_kday + round((ref_jday - jday) / 1000)) * 1000
         super(Mark5BHeader, self).__init__(words, verify=verify, **kwargs)
 
     def verify(self):

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -124,7 +124,8 @@ class TestMark5B(object):
                               (261, Time(57762, format='mjd'), 58000)])
     def test_infer_kday(self, jday, ref_time, kday):
         # Check that infer_kday returns proper kday for
-        # ref_time - 500 <= MJD < ref_time + 500
+        # ref_time - 500 < MJD < ref_time + 500, and uses bankers' rounding
+        # at the boundaries.
         header = mark5b.header.Mark5BHeader(None, verify=False)
         header.jday = jday
         header.infer_kday(ref_time)

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -115,27 +115,20 @@ class TestMark5B(object):
             header8.kday = 56000
             assert header8 == header
 
-    def test_infer_kday(self):
+    @pytest.mark.parametrize(('jday', 'ref_time', 'kday'),
+                             [(882, Time(57500, format='mjd'), 57000),
+                              (120, Time(57500, format='mjd'), 57000),
+                              (882, Time(57113, format='mjd'), 56000),
+                              (120, Time(57762, format='mjd'), 58000),
+                              (263, Time(57762, format='mjd'), 57000),
+                              (261, Time(57762, format='mjd'), 58000)])
+    def test_infer_kday(self, jday, ref_time, kday):
         # Check that infer_kday returns proper kday for
         # ref_time - 500 <= MJD < ref_time + 500
-        kday = mark5b.header.Mark5BHeader.infer_kday(
-            Time(57500, format='mjd'), 882)
-        assert kday == 57000
-        kday = mark5b.header.Mark5BHeader.infer_kday(
-            Time(57500, format='mjd'), 120)
-        assert kday == 57000
-        kday = mark5b.header.Mark5BHeader.infer_kday(
-            Time(57113, format='mjd'), 882)
-        assert kday == 56000
-        kday = mark5b.header.Mark5BHeader.infer_kday(
-            Time(57762, format='mjd'), 120)
-        assert kday == 58000
-        kday = mark5b.header.Mark5BHeader.infer_kday(
-            Time(57762, format='mjd'), 262)
-        assert kday == 57000
-        kday = mark5b.header.Mark5BHeader.infer_kday(
-            Time(57762, format='mjd'), 261)
-        assert kday == 58000
+        header = mark5b.header.Mark5BHeader(None, verify=False)
+        header.jday = jday
+        header.infer_kday(ref_time)
+        assert header.kday == kday
 
     def test_decoding(self):
         """Check that look-up levels are consistent with mark5access."""

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -178,10 +178,10 @@ class TestMark5B(object):
 
     def test_frame(self, tmpdir):
         with mark5b.open(SAMPLE_FILE, 'rb') as fh:
-            header = mark5b.Mark5BHeader.fromfile(fh, ref_mjd=57000.)
+            header = mark5b.Mark5BHeader.fromfile(fh, ref_mjd=57000)
             payload = mark5b.Mark5BPayload.fromfile(fh, nchan=8, bps=2)
             fh.seek(0)
-            frame = fh.read_frame(nchan=8, bps=2, ref_mjd=57000.)
+            frame = fh.read_frame(nchan=8, bps=2, ref_mjd=57000)
 
         assert frame.header == header
         assert frame.payload == payload
@@ -193,7 +193,7 @@ class TestMark5B(object):
         with open(str(tmpdir.join('test.m5b')), 'w+b') as s:
             frame.tofile(s)
             s.seek(0)
-            frame2 = mark5b.Mark5BFrame.fromfile(s, ref_mjd=57000.,
+            frame2 = mark5b.Mark5BFrame.fromfile(s, ref_mjd=57000,
                                                  nchan=frame.shape[1],
                                                  bps=frame.payload.bps)
         assert frame2 == frame
@@ -216,7 +216,7 @@ class TestMark5B(object):
 
     def test_header_times(self):
         with mark5b.open(SAMPLE_FILE, 'rb') as fh:
-            header0 = mark5b.Mark5BHeader.fromfile(fh, ref_mjd=57000.)
+            header0 = mark5b.Mark5BHeader.fromfile(fh, ref_mjd=57000)
             start_time = header0.time
             samples_per_frame = header0.payloadsize * 8 // 2 // 8
             frame_rate = 32. * u.MHz / samples_per_frame
@@ -224,7 +224,7 @@ class TestMark5B(object):
             fh.seek(0)
             while True:
                 try:
-                    frame = fh.read_frame(nchan=8, bps=2, ref_mjd=57000.)
+                    frame = fh.read_frame(nchan=8, bps=2, ref_mjd=57000)
                 except EOFError:
                     break
                 header_time = frame.header.time
@@ -254,7 +254,7 @@ class TestMark5B(object):
         # since otherwise they run *very* slow.  This is somehow related to
         # pytest, since speed is not a big issue running stuff on its own.
         with mark5b.open(SAMPLE_FILE, 'rb') as fh:
-            header0 = mark5b.Mark5BHeader.fromfile(fh, ref_mjd=57000.)
+            header0 = mark5b.Mark5BHeader.fromfile(fh, ref_mjd=57000)
             fh.seek(0)
             header_0 = fh.find_header(template_header=header0)
             assert fh.tell() == 0
@@ -266,7 +266,8 @@ class TestMark5B(object):
             header_16b = fh.find_header(template_header=header0, forward=False)
             assert fh.tell() == 0
             fh.seek(-10000, 2)
-            header_m10000b = fh.find_header(template_header=header0,
+            header_m10000b = fh.find_header(kday=header0.kday,
+                                            framesize=header0.framesize,
                                             forward=False)
             assert fh.tell() == 3 * header0.framesize
             fh.seek(-30, 2)
@@ -282,7 +283,8 @@ class TestMark5B(object):
             s.write(f.read())
         with mark5b.open(m5_test, 'rb') as fh:
             fh.seek(0)
-            header_0 = fh.find_header(template_header=header0)
+            header_0 = fh.find_header(kday=header0.kday,
+                                      framesize=header0.framesize)
             assert fh.tell() == 0
             fh.seek(10000)
             header_10000f = fh.find_header(template_header=header0,
@@ -317,9 +319,9 @@ class TestMark5B(object):
             assert fh.tell() == 10002
             assert fh.fh_raw.tell() == 3. * header.framesize
             assert fh.time == fh.tell(unit='time')
-            assert np.abs(fh.time -
-                          (fh.start_time + 10002 / (32*u.MHz))) < 1. * u.ns
-            fh.seek(fh.start_time + 1000 / (32*u.MHz))
+            assert (np.abs(fh.time - (fh.start_time + 10002 / (32 * u.MHz))) <
+                    1. * u.ns)
+            fh.seek(fh.start_time + 1000 / (32 * u.MHz))
             assert fh.tell() == 1000
             fh.seek(-10, 2)
             assert fh.tell() == fh.size - 10
@@ -351,6 +353,19 @@ class TestMark5B(object):
                       np.array([[-1, -1, -1, +3, +3, -3, +3, -1],
                                 [-1, +1, -3, +3, -3, +1, +3, +1]]))
         assert record3.shape == (10, 8)
+
+        # Check passing a time object into ref_mjd.
+        with mark5b.open(SAMPLE_FILE, 'rs', nchan=8, bps=2,
+                         sample_rate=32*u.MHz,
+                         ref_mjd=Time('2015-01-01')) as fh:
+            assert fh.header0 == header
+            assert fh._header_last == header_last
+        with mark5b.open(SAMPLE_FILE, 'rs', nchan=8, bps=2,
+                         sample_rate=32*u.MHz,
+                         ref_mjd=Time('2013-01-01')) as fh:
+            assert fh.header0 == header
+            assert fh._header_last == header_last
+
         # Read only some selected threads.
         with mark5b.open(SAMPLE_FILE, 'rs', nchan=8, bps=2, thread_ids=[4, 5],
                          sample_rate=32*u.MHz, ref_mjd=57000) as fh:

--- a/docs/baseband/mark4/index.rst
+++ b/docs/baseband/mark4/index.rst
@@ -41,7 +41,7 @@ the data themselves::
 Opening in stream mode automatically seeks for the first frame, and wraps the
 low-level routines such that reading and writing is in units of samples.  It
 also provides access to header information.  In lieu of ``decade``, one may
-also provide a reference time within 5 years of the observation start time::
+also provide a reference time within 4 years of the observation start time::
 
     >>> from astropy.time import Time
     >>> fh = mark4.open(SAMPLE_MARK4, 'rs', ntrack=64,

--- a/docs/baseband/mark4/index.rst
+++ b/docs/baseband/mark4/index.rst
@@ -41,7 +41,7 @@ the data themselves::
 Opening in stream mode automatically seeks for the first frame, and wraps the
 low-level routines such that reading and writing is in units of samples.  It
 also provides access to header information.  In lieu of ``decade``, one may
-also provide a reference time within 4 years of the observation start time::
+also provide a reference time within 5 years of the observation start time::
 
     >>> from astropy.time import Time
     >>> fh = mark4.open(SAMPLE_MARK4, 'rs', ntrack=64,

--- a/docs/baseband/mark4/index.rst
+++ b/docs/baseband/mark4/index.rst
@@ -40,9 +40,12 @@ the data themselves::
 
 Opening in stream mode automatically seeks for the first frame, and wraps the
 low-level routines such that reading and writing is in units of samples.  It
-also provides access to header information.::
+also provides access to header information.  In lieu of ``decade``, one may
+also provide a reference time within 4 years of the observation start time::
 
-    >>> fh = mark4.open(SAMPLE_MARK4, 'rs', ntrack=64, decade=2010)
+    >>> from astropy.time import Time
+    >>> fh = mark4.open(SAMPLE_MARK4, 'rs', ntrack=64,
+    ...                 ref_time=Time('2013:100:23:00:00'))
     >>> fh
     <Mark4StreamReader name=... offset=0
         frames_per_second=400, samples_per_frame=80000,


### PR DESCRIPTION
Mark4 and 5B file and readers now can accept either a reference time within 4 years (Mark 4) or 1 kiloday (5B; 1 kday = 1000 MJD) of the observation start time, or an explicit kday or decade.  Mark 4 now reads across decade increments; 5B across kiloday ones, due to some slight reworking of `_last_header` and `_read_frame` within stream readers.  Functions in `frame.py` and `header.py` now only accept an explicit kday/decade.

Standardized the reference time name to `ref_time`, replacing `ref_mjd` in Mark 5B.

Note the slightly odd argument ordering of `ref_time` after `kday` or `decade` is to enable legacy Mark 4 codes to continue implicitly passing `decade` as the second argument to `Mark4FileReader.read_frame`.  Mark 5B codes that pass `ref_mjd` implicitly, however, will **give incorrect times** (by 1000 days).