### PR TITLE
Mark 4, 5B stream reader's read method now can set invalid data `fill_value`

### DIFF
--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -374,8 +374,11 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
             frame_nr, sample_offset = divmod(self.offset,
                                              self.samples_per_frame)
             if frame_nr != self._frame_nr:
-                self._read_frame(fill_value)
+                self._read_frame()
 
+            # Set decoded value for invalid data.
+            self._frame.invalid_data_value = fill_value
+            # Decode data into array.
             data = self._frame.data
             if self.thread_ids:
                 data = data[:, self.thread_ids]
@@ -389,15 +392,12 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
 
         return out
 
-    def _read_frame(self, fill_value=0.):
+    def _read_frame(self):
         frame_nr = self.offset // self.samples_per_frame
         self.fh_raw.seek(self.offset0 + frame_nr * self.header0.framesize)
         self._frame = self.read_frame(ntrack=self.header0.ntrack,
                                       decade=self.header0.decade)
-        # Convert payloads to data array.
-        self._frame_data = self._frame.data
         self._frame_nr = frame_nr
-        self._frame.invalid_data_value = fill_value
 
 
 class Mark4StreamWriter(VLBIStreamWriterBase, Mark4FileWriter):

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -374,7 +374,7 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
             frame_nr, sample_offset = divmod(self.offset,
                                              self.samples_per_frame)
             if frame_nr != self._frame_nr:
-                self._read_frame()
+                self._read_frame(fill_value)
 
             data = self._frame.data
             if self.thread_ids:
@@ -389,7 +389,7 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
 
         return out
 
-    def _read_frame(self):
+    def _read_frame(self, fill_value=0.):
         frame_nr = self.offset // self.samples_per_frame
         self.fh_raw.seek(self.offset0 + frame_nr * self.header0.framesize)
         self._frame = self.read_frame(ntrack=self.header0.ntrack,
@@ -397,6 +397,7 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
         # Convert payloads to data array.
         self._frame_data = self._frame.data
         self._frame_nr = frame_nr
+        self._frame.invalid_data_value = fill_value
 
 
 class Mark4StreamWriter(VLBIStreamWriterBase, Mark4FileWriter):

--- a/baseband/mark4/frame.py
+++ b/baseband/mark4/frame.py
@@ -69,7 +69,6 @@ class Mark4Frame(VLBIFrameBase):
 
     _header_class = Mark4Header
     _payload_class = Mark4Payload
-    invalid_data_value = 0.
 
     def __init__(self, header, payload, valid=None, verify=True):
         self.header = header

--- a/baseband/mark4/frame.py
+++ b/baseband/mark4/frame.py
@@ -69,6 +69,7 @@ class Mark4Frame(VLBIFrameBase):
 
     _header_class = Mark4Header
     _payload_class = Mark4Payload
+    invalid_data_value = 0.
 
     def __init__(self, header, payload, valid=None, verify=True):
         self.header = header

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -581,7 +581,7 @@ class TestMark4(object):
         m4_incomplete = str(tmpdir.join('incomplete.m4'))
         with catch_warnings(UserWarning) as w:
             with mark4.open(SAMPLE_FILE, 'rs', ntrack=64, decade=2010) as fr:
-                record = fr.read(80010)
+                record = fr.read(10)
                 with mark4.open(m4_incomplete, 'ws', header=fr.header0,
                                 ntrack=64, decade=2010,
                                 sample_rate=32*u.MHz) as fw:
@@ -590,13 +590,10 @@ class TestMark4(object):
         assert 'partial buffer' in str(w[0].message)
         with mark4.open(m4_incomplete, 'rs', ntrack=64, decade=2010,
                         frames_per_second=400) as fwr:
-            # First frame is fine.
-            assert np.all(fwr.read(80000) == record[:80000])
-            bad_data = fwr.read(fill_value=fill_value)
             assert not fwr._frame.valid
-            assert np.all(bad_data ==
+            assert np.all(fwr.read(fill_value=fill_value) ==
                           fwr._frame.invalid_data_value)
-            assert np.all(bad_data == fill_value)
+            assert fwr._frame.invalid_data_value == fill_value
 
     def test_corrupt_stream(self, tmpdir):
         with mark4.open(SAMPLE_FILE, 'rb') as fh, \

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -576,11 +576,12 @@ class TestMark4(object):
 
     # Test that writing an incomplete stream is possible, and that frame set is
     # appropriately marked as invalid.
-    def test_incomplete_stream(self, tmpdir):
+    @pytest.mark.parametrize('fill_value', (0., -999.))
+    def test_incomplete_stream(self, tmpdir, fill_value):
         m4_incomplete = str(tmpdir.join('incomplete.m4'))
         with catch_warnings(UserWarning) as w:
             with mark4.open(SAMPLE_FILE, 'rs', ntrack=64, decade=2010) as fr:
-                record = fr.read(10)
+                record = fr.read(80010)
                 with mark4.open(m4_incomplete, 'ws', header=fr.header0,
                                 ntrack=64, decade=2010,
                                 sample_rate=32*u.MHz) as fw:
@@ -589,9 +590,13 @@ class TestMark4(object):
         assert 'partial buffer' in str(w[0].message)
         with mark4.open(m4_incomplete, 'rs', ntrack=64, decade=2010,
                         frames_per_second=400) as fwr:
+            # First frame is fine.
+            assert np.all(fwr.read(80000) == record[:80000])
+            bad_data = fwr.read(fill_value=fill_value)
             assert not fwr._frame.valid
-            assert np.all(fwr.read() ==
+            assert np.all(bad_data ==
                           fwr._frame.invalid_data_value)
+            assert np.all(bad_data == fill_value)
 
     def test_corrupt_stream(self, tmpdir):
         with mark4.open(SAMPLE_FILE, 'rb') as fh, \

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -239,7 +239,7 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
             if(dt != dt_expected or
                frame_nr != self._frame['frame_nr']):
                 # Read relevant frame, reusing data array from previous frame.
-                self._read_frame()
+                self._read_frame(fill_value)
                 dt_expected = (self._frame.seconds - self.header0.seconds +
                                86400 * (self._frame.jday - self.header0.jday))
                 assert dt == dt_expected
@@ -258,7 +258,7 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
 
         return out
 
-    def _read_frame(self):
+    def _read_frame(self, fill_value=0.):
         self.fh_raw.seek(self.offset // self.samples_per_frame *
                          self._frame.size)
         self._frame = self.read_frame(ref_mjd=self.header0.kday,
@@ -266,6 +266,7 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
                                       bps=self.bps)
         # Convert payloads to data array.
         self._frame_data = self._frame.data
+        self._frame.invalid_data_value = fill_value
 
 
 class Mark5BStreamWriter(VLBIStreamWriterBase, Mark5BFileWriter):

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -239,12 +239,15 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
             if(dt != dt_expected or
                frame_nr != self._frame['frame_nr']):
                 # Read relevant frame, reusing data array from previous frame.
-                self._read_frame(fill_value)
+                self._read_frame()
                 dt_expected = (self._frame.seconds - self.header0.seconds +
                                86400 * (self._frame.jday - self.header0.jday))
                 assert dt == dt_expected
                 assert frame_nr == self._frame['frame_nr']
 
+            # Set decoded value for invalid data.
+            self._frame.invalid_data_value = fill_value
+            # Decode data into array.
             data = self._frame.data
             if self.thread_ids:
                 data = data[:, self.thread_ids]
@@ -264,9 +267,6 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
         self._frame = self.read_frame(ref_mjd=self.header0.kday,
                                       nchan=self._sample_shape.nchan,
                                       bps=self.bps)
-        # Convert payloads to data array.
-        self._frame_data = self._frame.data
-        self._frame.invalid_data_value = fill_value
 
 
 class Mark5BStreamWriter(VLBIStreamWriterBase, Mark5BFileWriter):

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -460,7 +460,7 @@ class TestMark5B(object):
         with catch_warnings(UserWarning) as w:
             with mark5b.open(SAMPLE_FILE, 'rs', nchan=8, bps=2,
                              sample_rate=32*u.MHz, ref_mjd=57000) as fr:
-                record = fr.read(5010)
+                record = fr.read(10)
                 with mark5b.open(m5_incomplete, 'ws', header=fr.header0,
                                  nchan=8, sample_rate=32*u.MHz) as fw:
                     fw.write(record)
@@ -468,9 +468,7 @@ class TestMark5B(object):
         assert 'partial buffer' in str(w[0].message)
         with mark5b.open(m5_incomplete, 'rs', nchan=8, bps=2,
                          sample_rate=32*u.MHz, ref_mjd=57000) as fwr:
-            assert np.all(fwr.read(5000) == record[:5000])
-            bad_data = fwr.read(fill_value=fill_value)
             assert not fwr._frame.valid
-            assert np.all(fwr.read() ==
+            assert np.all(fwr.read(fill_value=fill_value) ==
                           fwr._frame.invalid_data_value)
-            assert np.all(bad_data == fill_value)
+            assert fwr._frame.invalid_data_value == fill_value

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -389,11 +389,14 @@ class VDIFStreamReader(VDIFStreamBase, VLBIStreamReaderBase, VDIFFileReader):
                frame_nr != self._frameset['frame_nr']):
                 # Read relevant frame (possibly reusing data array from
                 # previous frame set).
-                self._read_frame_set(fill_value)
+                self._read_frame_set()
                 assert dt == (self._frameset['seconds'] -
                               self.header0['seconds'])
                 assert frame_nr == self._frameset['frame_nr']
 
+            # Set decoded value for invalid data.
+            self._frameset.invalid_data_value = fill_value
+            # Decode data into array.
             data = self._frameset.data.transpose(1, 0, 2)
             # Copy relevant data from frame into output.
             nsample = min(count, self.samples_per_frame - sample_offset)
@@ -405,12 +408,11 @@ class VDIFStreamReader(VDIFStreamBase, VLBIStreamReaderBase, VDIFFileReader):
 
         return out
 
-    def _read_frame_set(self, fill_value=0.):
+    def _read_frame_set(self):
         self.fh_raw.seek(self.offset // self.samples_per_frame *
                          self._framesetsize)
         self._frameset = self.read_frameset(self.thread_ids,
                                             edv=self.header0.edv)
-        self._frameset.invalid_data_value = fill_value
 
 
 class VDIFStreamWriter(VDIFStreamBase, VLBIStreamWriterBase, VDIFFileWriter):

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -601,7 +601,8 @@ class TestVDIF(object):
 
     # Test that writing an incomplete stream is possible, and that frame set is
     # appropriately marked as invalid.
-    def test_incomplete_stream(self, tmpdir):
+    @pytest.mark.parametrize('fill_value', (0., -999.))
+    def test_incomplete_stream(self, tmpdir, fill_value):
         vdif_incomplete = str(tmpdir.join('incomplete.vdif'))
         with catch_warnings(UserWarning) as w:
             with vdif.open(SAMPLE_FILE, 'rs') as fr:
@@ -613,8 +614,9 @@ class TestVDIF(object):
         assert 'partial buffer' in str(w[0].message)
         with vdif.open(vdif_incomplete, 'rs') as fwr:
             assert all([not frame.valid for frame in fwr._frameset.frames])
-            assert np.all(fwr.read() ==
+            assert np.all(fwr.read(fill_value=fill_value) ==
                           fwr._frameset.invalid_data_value)
+            assert fwr._frameset.invalid_data_value == fill_value
 
     def test_corrupt_stream(self, tmpdir):
         with vdif.open(SAMPLE_FILE, 'rb') as fh, \


### PR DESCRIPTION
Small bugfix (to #101) to allow the user to set the `fill_value` for invalid data in Mark 4 and 5B stream readers.  Implemented associated tests (which write multiple frames because the user currently cannot set `fill_value` upon reader initialization).