### PR TITLE
Unify passing sampling rate information

### DIFF
--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -191,7 +191,6 @@ class DADAStreamBase(VLBIStreamBase):
     """
 
     def __init__(self, fh_raw, header0, thread_ids=None, squeeze=True):
-        sample_rate = (1. / (header0['TSAMP'] * 1e-6)) * u.Hz
         if thread_ids is None:
             thread_ids = list(range(header0['NPOL']))
         sample_shape = DADAPayload._sample_shape_maker(len(thread_ids),
@@ -201,7 +200,7 @@ class DADAStreamBase(VLBIStreamBase):
             bps=header0.bps, complex_data=header0.complex_data,
             thread_ids=thread_ids,
             samples_per_frame=header0.samples_per_frame,
-            sample_rate=sample_rate, squeeze=squeeze)
+            sample_rate=header0.sample_rate, squeeze=squeeze)
 
     def _frame_info(self):
         """Convert offset to file number and offset into that file."""

--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -4,6 +4,7 @@ import os
 import re
 
 import numpy as np
+import astropy.units as u
 from astropy.extern import six
 from astropy.utils import lazyproperty
 
@@ -190,8 +191,7 @@ class DADAStreamBase(VLBIStreamBase):
     """
 
     def __init__(self, fh_raw, header0, thread_ids=None, squeeze=True):
-        frames_per_second = (1. / (header0['TSAMP'] * 1e-6) /
-                             header0.samples_per_frame)
+        sample_rate = (1. / (header0['TSAMP'] * 1e-6)) * u.Hz
         if thread_ids is None:
             thread_ids = list(range(header0['NPOL']))
         sample_shape = DADAPayload._sample_shape_maker(len(thread_ids),
@@ -201,7 +201,7 @@ class DADAStreamBase(VLBIStreamBase):
             bps=header0.bps, complex_data=header0.complex_data,
             thread_ids=thread_ids,
             samples_per_frame=header0.samples_per_frame,
-            frames_per_second=frames_per_second, squeeze=squeeze)
+            sample_rate=sample_rate, squeeze=squeeze)
 
     def _frame_info(self):
         """Convert offset to file number and offset into that file."""

--- a/baseband/dada/header.py
+++ b/baseband/dada/header.py
@@ -338,13 +338,16 @@ class DADAHeader(OrderedDict):
 
     @property
     def sample_rate(self):
-        """Number of complete samples per second."""
+        """Number of complete samples per second.
+
+        Can be set with a negative quantity to set `sideband`.
+        """
         return (1. / self['TSAMP']) * u.MHz
 
     @sample_rate.setter
     def sample_rate(self, sample_rate):
         sample_rate = sample_rate.to_value(u.MHz)
-        self['TSAMP'] = 1. / sample_rate
+        self['TSAMP'] = 1. / abs(sample_rate)
         bw = sample_rate * self['NCHAN'] / (1 if self.complex_data else 2)
         self['BW'] = (-1 if self.get('BW', bw) < 0 else 1) * bw
 

--- a/baseband/dada/header.py
+++ b/baseband/dada/header.py
@@ -349,17 +349,6 @@ class DADAHeader(OrderedDict):
         self['BW'] = (-1 if self.get('BW', bw) < 0 else 1) * bw
 
     @property
-    def bandwidth(self):
-        """Bandwidth covered by the data."""
-        return abs(self['BW']) * u.MHz
-
-    @bandwidth.setter
-    def bandwidth(self, bw):
-        bw = bw.to(u.MHz).value
-        self['BW'] = (-1 if self.get('BW', bw) < 0 else 1) * bw
-        self['TSAMP'] = self['NCHAN'] / (1 if self.complex_data else 2) / bw
-
-    @property
     def sideband(self):
         """True if upper sideband."""
         return self['BW'] > 0

--- a/baseband/dada/header.py
+++ b/baseband/dada/header.py
@@ -54,8 +54,9 @@ class DADAHeader(OrderedDict):
     """
 
     _properties = ('payloadsize', 'framesize', 'bps', 'complex_data',
-                   'sample_shape', 'bandwidth', 'sideband', 'tsamp',
-                   'samples_per_frame', 'offset', 'start_time', 'time')
+                   'sample_shape', 'sample_rate', 'bandwidth', 'sideband',
+                   'tsamp', 'samples_per_frame', 'offset', 'start_time',
+                   'time')
     """Properties accessible/usable in initialisation for all headers."""
 
     _defaults = [('HEADER', 'DADA'),
@@ -334,6 +335,18 @@ class DADAHeader(OrderedDict):
     @sample_shape.setter
     def sample_shape(self, sample_shape):
         self['NPOL'], self['NCHAN'] = sample_shape
+
+    @property
+    def sample_rate(self):
+        """Number of complete samples per second."""
+        return (1. / self['TSAMP']) * u.MHz
+
+    @sample_rate.setter
+    def sample_rate(self, sample_rate):
+        sample_rate = sample_rate.to_value(u.MHz)
+        self['TSAMP'] = 1. / sample_rate
+        bw = sample_rate * self['NCHAN'] / (1 if self.complex_data else 2)
+        self['BW'] = (-1 if self.get('BW', bw) < 0 else 1) * bw
 
     @property
     def bandwidth(self):

--- a/baseband/dada/tests/test_dada.py
+++ b/baseband/dada/tests/test_dada.py
@@ -88,7 +88,7 @@ class TestDADA(object):
             start_time=header.start_time,
             offset=header.time-header.start_time,
             bps=header.bps, complex_data=header.complex_data,
-            bandwidth=header.bandwidth, sideband=header.sideband,
+            sample_rate=header.sample_rate, sideband=header.sideband,
             samples_per_frame=header.samples_per_frame,
             sample_shape=header.sample_shape,
             source=header['SOURCE'], ra=header['RA'], dec=header['DEC'],
@@ -101,7 +101,7 @@ class TestDADA(object):
         header5 = dada.DADAHeader.fromvalues(
             offset=header.offset, time=header.time,
             bps=header.bps, complex_data=header.complex_data,
-            bandwidth=header.bandwidth, sideband=header.sideband,
+            sample_rate=header.sample_rate, sideband=header.sideband,
             samples_per_frame=header.samples_per_frame,
             sample_shape=header.sample_shape,
             source=header['SOURCE'], ra=header['RA'], dec=header['DEC'],
@@ -320,7 +320,7 @@ class TestDADA(object):
         # Try single polarisation, and check initialisation by header keywords.
         h = self.header
         with dada.open(filename, 'ws', time=h.time, bps=h.bps,
-                       complex_data=h.complex_data, bandwidth=h.bandwidth,
+                       complex_data=h.complex_data, sample_rate=h.sample_rate,
                        payloadsize=32000, nthread=1, nchan=1) as fw:
             fw.write(self.payload.data[:, 0, 0])
             assert np.abs(fw.start_time - start_time) < 1.*u.ns

--- a/baseband/dada/tests/test_dada.py
+++ b/baseband/dada/tests/test_dada.py
@@ -265,8 +265,7 @@ class TestDADA(object):
             assert fh.header0 == self.header
             assert fh.size == 16000
             assert fh.start_time == start_time
-            assert np.all(fh.sample_rate == 16 * u.MHz)
-            assert fh._sample_rate == 16000000.0
+            assert fh.sample_rate == 16 * u.MHz
             record1 = fh.read(12)
             assert fh.tell() == 12
             fh.seek(10000)
@@ -304,7 +303,7 @@ class TestDADA(object):
         filename = str(tmpdir.join('a.dada'))
         with dada.open(filename, 'ws', header=self.header,
                        squeeze=False) as fw:
-            assert np.all(fw.sample_rate == 16 * u.MHz)
+            assert fw.sample_rate == 16 * u.MHz
             fw.write(self.payload.data)
             assert fw.start_time == start_time
             assert (np.abs(fw.time - (start_time + 16000 / (16. * u.MHz))) <
@@ -316,7 +315,7 @@ class TestDADA(object):
             assert (np.abs(fh.time - (start_time + 16000 / (16. * u.MHz))) <
                     1. * u.ns)
             assert fh.stop_time == fh.time
-            assert np.all(fh.sample_rate == 16 * u.MHz)
+            assert fh.sample_rate == 16 * u.MHz
         assert np.all(data == self.payload.data.squeeze())
         # Try single polarisation, and check initialisation by header keywords.
         h = self.header

--- a/baseband/dada/tests/test_dada.py
+++ b/baseband/dada/tests/test_dada.py
@@ -265,6 +265,8 @@ class TestDADA(object):
             assert fh.header0 == self.header
             assert fh.size == 16000
             assert fh.start_time == start_time
+            assert np.all(fh.sample_rate == 16 * u.MHz)
+            assert fh._sample_rate == 16000000.0
             record1 = fh.read(12)
             assert fh.tell() == 12
             fh.seek(10000)
@@ -302,6 +304,7 @@ class TestDADA(object):
         filename = str(tmpdir.join('a.dada'))
         with dada.open(filename, 'ws', header=self.header,
                        squeeze=False) as fw:
+            assert np.all(fw.sample_rate == 16 * u.MHz)
             fw.write(self.payload.data)
             assert fw.start_time == start_time
             assert (np.abs(fw.time - (start_time + 16000 / (16. * u.MHz))) <
@@ -313,6 +316,7 @@ class TestDADA(object):
             assert (np.abs(fh.time - (start_time + 16000 / (16. * u.MHz))) <
                     1. * u.ns)
             assert fh.stop_time == fh.time
+            assert np.all(fh.sample_rate == 16 * u.MHz)
         assert np.all(data == self.payload.data.squeeze())
         # Try single polarisation, and check initialisation by header keywords.
         h = self.header

--- a/baseband/gsb/base.py
+++ b/baseband/gsb/base.py
@@ -358,6 +358,8 @@ class GSBStreamWriter(GSBStreamBase, VLBIStreamWriterBase):
     sample_rate : `~astropy.units.Quantity`
         Number of complete samples per second (ie. the rate at which each
         channel of each polarization is sampled).
+    header : `~baseband.gsb.GSBHeader`, optional
+        Header for the first frame, holding time information, etc.
     nchan : int, optional
         Number of channels. Default is `None`, which sets it to 1 for rawdump,
         512 for phased.
@@ -373,8 +375,6 @@ class GSBStreamWriter(GSBStreamBase, VLBIStreamWriterBase):
     payloadsize : int, optional
         Number of bytes per payload, divided by the number of raw files.
         Must be set if ``samples_per_frame`` is `None`.
-    header : `~baseband.gsb.GSBHeader`, optional
-        Header for the first frame, holding time information, etc.
     squeeze : bool, optional
         If `True` (default), ``write`` accepts squeezed arrays as input, and
         adds any dimensions of length unity.
@@ -402,9 +402,9 @@ class GSBStreamWriter(GSBStreamBase, VLBIStreamWriterBase):
         Redundant modulo-8 shared memory block number; not used by Baseband.
     """
 
-    def __init__(self, fh_ts, fh_raw, sample_rate, nchan=None, bps=None,
-                 complex_data=None, samples_per_frame=None, payloadsize=None,
-                 header=None, squeeze=True, **kwargs):
+    def __init__(self, fh_ts, fh_raw, sample_rate, header=None, nchan=None,
+                 bps=None, complex_data=None, samples_per_frame=None,
+                 payloadsize=None, squeeze=True, **kwargs):
         if header is None:
             mode = kwargs.pop('header_mode',
                               'rawdump' if hasattr(fh_raw, 'read') else

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -318,8 +318,8 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
 
         Returns
         -------
-        framerate : int
-            Frames per second.
+        framerate : `~astropy.units.Quantity`
+            Frames per second, in Hz.
 
         Notes
         -----
@@ -339,7 +339,7 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
         # Mark 4 specification states frames-lengths range from 1.25 ms
         # to 160 ms.
         tdelta = header1.ms[0] - header0.ms[0]
-        return int(np.round(1000. / tdelta))
+        return np.round(1000. / tdelta) * u.Hz
 
     @lazyproperty
     def _last_header(self):

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -1,6 +1,7 @@
 # Licensed under the GPLv3 - see LICENSE.rst
 import numpy as np
 from astropy.utils import lazyproperty
+import astropy.units as u
 
 from ..vlbi_base.base import (make_opener, VLBIFileBase, VLBIStreamReaderBase,
                               VLBIStreamWriterBase)
@@ -264,11 +265,10 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
         Used only if `decade` is ``None``.
     thread_ids: list of int, optional
         Specific threads/channels to read.  By default, all are read.
-    frames_per_second : int, optional
-        Needed to calculate timestamps. If not given, will be inferred from
-        ``sample_rate``, or by scanning the file.
     sample_rate : `~astropy.units.Quantity`, optional
-        Rate at which each thread is sampled (bandwidth * 2; frequency units).
+        Number of complete samples per second (ie. the rate at which each
+        channel is sampled).  If not given, will be inferred from scanning two
+        frames of the file.
     squeeze : bool, optional
         If `True` (default), remove any dimensions of length unity from
         decoded data.
@@ -277,8 +277,7 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
     _frame_class = Mark4Frame
 
     def __init__(self, fh_raw, ntrack=None, decade=None, ref_time=None,
-                 thread_ids=None, frames_per_second=None, sample_rate=None,
-                 squeeze=True):
+                 thread_ids=None, sample_rate=None, squeeze=True):
         # Pre-set fh_raw, so FileReader methods work
         # TODO: move this to StreamReaderBase?
         self.fh_raw = fh_raw
@@ -304,12 +303,11 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
             fh_raw, header0=header, sample_shape=sample_shape,
             bps=header.bps, complex_data=False, thread_ids=thread_ids,
             samples_per_frame=header.samples_per_frame,
-            frames_per_second=frames_per_second, sample_rate=sample_rate,
-            squeeze=squeeze)
+            sample_rate=sample_rate, squeeze=squeeze)
 
     @staticmethod
-    def _get_frame_rate(fh, header_template):
-        """Returns the number of frames in one second of data.
+    def _get_sample_rate(fh, header_template, samples_per_frame):
+        """Returns the number of complete samples in one second of data.
 
         Parameters
         ----------
@@ -317,19 +315,21 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
             Binary file handle.
         header_template : header class or instance
             Definition or instance of file format's header class.
+        samples_per_frame : int
+            Number of complete samples per frame.
 
         Returns
         -------
-        fps : int
-            Frames per second.
+        sample_rate : `~astropy.units.Quantity`
+            Number of complete samples per second.
 
         Notes
         -----
 
-        Unlike VLBIStreamReaderBase._get_frame_rate, this function reads
+        Unlike `VLBIStreamReaderBase._get_sample_rate`, this function reads
         only two consecutive frames, extracting their timestamps to determine
         how much time has elapsed.  It will return an EOFError if there is
-        only one frame.  It cannot seek past decade increments.
+        only one frame.
         """
         oldpos = fh.tell()
         header0 = header_template.fromfile(fh, header_template.ntrack,
@@ -341,7 +341,7 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
         # Mark 4 specification states frames-lengths range from 1.25 ms
         # to 160 ms.
         tdelta = header1.ms[0] - header0.ms[0]
-        return int(np.round(1000. / tdelta))
+        return int(np.round(1000. / tdelta)) * samples_per_frame * u.Hz
 
     @lazyproperty
     def _last_header(self):
@@ -426,11 +426,9 @@ class Mark4StreamWriter(VLBIStreamWriterBase, Mark4FileWriter):
     ----------
     raw : `~baseband.mark4.Mark4FileWriter`
         Which will write filled sets of frames to storage.
-    frames_per_second : int, optional
-        Needed to calculate timestamps. If not given, inferred from
-        ``sample_rate``.
-    sample_rate : `~astropy.units.Quantity`, optional
-        Rate at which each thread is sampled (bandwidth * 2; frequency units).
+    sample_rate : `~astropy.units.Quantity`
+        Number of complete samples per second (ie. the rate at which each
+        channel is sampled), needed to calculate header timestamps.
     header : `~baseband.mark4.Mark4Header`
         Header for the first frame, holding start time information, etc.
     squeeze : bool, optional
@@ -455,8 +453,7 @@ class Mark4StreamWriter(VLBIStreamWriterBase, Mark4FileWriter):
 
     _frame_class = Mark4Frame
 
-    def __init__(self, raw, frames_per_second=None, sample_rate=None,
-                 header=None, squeeze=True, **kwargs):
+    def __init__(self, raw, sample_rate, header=None, squeeze=True, **kwargs):
         if header is None:
             header = Mark4Header.fromvalues(**kwargs)
         sample_shape = Mark4Payload._sample_shape_maker(header.nchan)
@@ -465,8 +462,7 @@ class Mark4StreamWriter(VLBIStreamWriterBase, Mark4FileWriter):
             thread_ids=range(header.nchan), bps=header.bps, complex_data=False,
             samples_per_frame=(header.framesize * 8 // header.bps //
                                header.nchan),
-            frames_per_second=frames_per_second, sample_rate=sample_rate,
-            squeeze=squeeze)
+            sample_rate=sample_rate, squeeze=squeeze)
 
         self._data = np.zeros((self.samples_per_frame,
                                self._sample_shape.nchan), np.float32)
@@ -530,22 +526,19 @@ ref_time : `~astropy.time.Time`, or None, optional
     only if `decade` is ``None``.
 thread_ids: list of int, optional
     Specific threads/channels to read.  By default, all are read.
-frames_per_second : int, optional
-    Needed to calculate timestamps. If not given, will be inferred from
-    ``sample_rate``, or by scanning the file.
 sample_rate : `~astropy.units.Quantity`, optional
-    Rate at which each thread is sampled (bandwidth * 2; frequency units).
+    Number of complete samples per second (ie. the rate at which each channel
+    is sampled).  If not given, will be inferred from scanning two frames of
+    the file.
 squeeze : bool, optional
     If `True` (default), remove any dimensions of length unity from
     decoded data.
 
 --- For writing a stream : (see `~baseband.mark4.base.Mark4StreamWriter`)
 
-frames_per_second : int, optional
-    Needed to calculate timestamps. If not given, inferred from
-    ``sample_rate``.
-sample_rate : `~astropy.units.Quantity`, optional
-    Rate at which each thread is sampled (bandwidth * 2; frequency units).
+sample_rate : `~astropy.units.Quantity`
+    Number of complete samples per second (ie. the rate at which each channel
+    is sampled), needed to calculate header timestamps.
 header : `~baseband.mark4.Mark4Header`
     Header for the first frame, holding time information, etc.
 squeeze : bool, optional

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -306,8 +306,8 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
             sample_rate=sample_rate, squeeze=squeeze)
 
     @staticmethod
-    def _get_sample_rate(fh, header_template, samples_per_frame):
-        """Returns the number of complete samples in one second of data.
+    def _get_frame_rate(fh, header_template):
+        """Returns the number of frames per second in a Mark 4 file.
 
         Parameters
         ----------
@@ -315,18 +315,16 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
             Binary file handle.
         header_template : header class or instance
             Definition or instance of file format's header class.
-        samples_per_frame : int
-            Number of complete samples per frame.
 
         Returns
         -------
-        sample_rate : `~astropy.units.Quantity`
-            Number of complete samples per second.
+        framerate : int
+            Frames per second.
 
         Notes
         -----
 
-        Unlike `VLBIStreamReaderBase._get_sample_rate`, this function reads
+        Unlike `VLBIStreamReaderBase._get_frame_rate`, this function reads
         only two consecutive frames, extracting their timestamps to determine
         how much time has elapsed.  It will return an EOFError if there is
         only one frame.
@@ -341,7 +339,7 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
         # Mark 4 specification states frames-lengths range from 1.25 ms
         # to 160 ms.
         tdelta = header1.ms[0] - header0.ms[0]
-        return int(np.round(1000. / tdelta)) * samples_per_frame * u.Hz
+        return int(np.round(1000. / tdelta))
 
     @lazyproperty
     def _last_header(self):

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -505,8 +505,7 @@ class TestMark4(object):
             assert fh.fh_raw.tell() == 0xa88 + fh.header0.framesize
             assert fh.samples_per_frame == 80000
             assert fh.size == 2 * fh.samples_per_frame
-            assert np.all(fh.sample_rate == 32 * u.MHz)
-            assert fh._sample_rate == 32000000.0
+            assert fh.sample_rate == 32 * u.MHz
             record = fh.read(642)
             assert fh.tell() == 642
             # regression test against #4, of incorrect frame offsets.
@@ -548,7 +547,7 @@ class TestMark4(object):
         with mark4.open(SAMPLE_FILE, 'rs', ntrack=64, decade=2010) as fh:
             assert header == fh.header0
             assert fh.samples_per_frame == 80000
-            assert np.all(fh.sample_rate == 32 * u.MHz)
+            assert fh.sample_rate == 32 * u.MHz
             record3 = fh.read(642)
 
         assert np.all(record3 == record)
@@ -556,7 +555,7 @@ class TestMark4(object):
         # Test if automatic ntrack and frame rate detectors work together.
         with mark4.open(SAMPLE_FILE, 'rs', decade=2010) as fh:
             assert header == fh.header0
-            assert np.all(fh.sample_rate == 32 * u.MHz)
+            assert fh.sample_rate == 32 * u.MHz
             fh.seek(80000 + 639)
             record4 = fh.read(2)
 
@@ -572,7 +571,7 @@ class TestMark4(object):
         rewritten_file = str(tmpdir.join('rewritten.m4'))
         with mark4.open(rewritten_file, 'ws', sample_rate=32*u.MHz,
                         time=start_time, ntrack=64, bps=2, fanout=4) as fw:
-            assert np.all(fw.sample_rate == 32 * u.MHz)
+            assert fw.sample_rate == 32 * u.MHz
             # write in bits and pieces and with some invalid data as well.
             fw.write(record[:11])
             fw.write(record[11:80000])
@@ -583,7 +582,7 @@ class TestMark4(object):
                         sample_rate=32*u.MHz, thread_ids=[3, 4]) as fh:
             assert fh.time == start_time
             assert fh.time == fh.tell(unit='time')
-            assert np.all(fh.sample_rate == 32 * u.MHz)
+            assert fh.sample_rate == 32 * u.MHz
             record5 = fh.read(160000)
             assert fh.time == stop_time
             assert np.all(record5[:80000] == record[:80000, 3:5])
@@ -738,7 +737,7 @@ class Test32TrackFanout4():
                         sample_rate=32*u.MHz) as fh:
             header0 = fh.header0
             assert fh.samples_per_frame == 80000
-            assert np.all(fh.sample_rate == 32 * u.MHz)
+            assert fh.sample_rate == 32 * u.MHz
             start_time = fh.start_time
             assert start_time.yday == '2015:011:01:23:10.48500'
             record = fh.read(160000)
@@ -800,7 +799,7 @@ class Test32TrackFanout2():
                         sample_rate=16*u.MHz) as fh:
             header0 = fh.header0
             assert fh.samples_per_frame == 40000
-            assert np.all(fh.sample_rate == 16 * u.MHz)
+            assert fh.sample_rate == 16 * u.MHz
             start_time = fh.start_time
             assert start_time.yday == '2017:063:04:42:26.02500'
             record = fh.read(80000)
@@ -861,7 +860,7 @@ class Test16TrackFanout4():
                         sample_rate=32*u.MHz) as fh:
             header0 = fh.header0
             assert fh.samples_per_frame == 80000
-            assert np.all(fh.sample_rate == 32 * u.MHz)
+            assert fh.sample_rate == 32 * u.MHz
             start_time = fh.start_time
             assert start_time.yday == '2013:307:06:00:00.77000'
             record = fh.read(160000)

--- a/baseband/mark5b/header.py
+++ b/baseband/mark5b/header.py
@@ -11,7 +11,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import numpy as np
-from astropy import units as u
+import astropy.units as u
 from astropy.time import Time
 
 from ..vlbi_base.header import HeaderParser, VLBIHeaderBase, four_word_struct

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -345,8 +345,7 @@ class TestMark5B(object):
             assert header == fh.header0
             assert fh.fh_raw.tell() == header.framesize
             assert fh.samples_per_frame == 5000
-            assert np.all(fh.sample_rate == 32 * u.MHz)
-            assert fh._sample_rate == 32000000.0
+            assert fh.sample_rate == 32 * u.MHz
             last_header = fh._last_header
             assert fh.size == 20000
             record = fh.read(12)
@@ -419,7 +418,7 @@ class TestMark5B(object):
         m5_test = str(tmpdir.join('test.m5b'))
         with mark5b.open(m5_test, 'ws', time=start_time, nchan=8,
                          bps=2, sample_rate=32*u.MHz) as fw:
-            assert np.all(fw.sample_rate == 32 * u.MHz)
+            assert fw.sample_rate == 32 * u.MHz
             # Write in pieces to ensure squeezed data can be handled,
             # And add in an invalid frame for good measure.
             fw.write(record[:11])
@@ -431,7 +430,7 @@ class TestMark5B(object):
         with mark5b.open(m5_test, 'rs', nchan=8, bps=2, sample_rate=32*u.MHz,
                          ref_time=Time(57000, format='mjd')) as fh:
             assert fh.time == start_time
-            assert np.all(fh.sample_rate == 32 * u.MHz)
+            assert fh.sample_rate == 32 * u.MHz
             record2 = fh.read(20000)
             assert fh.time == stop_time
             assert np.all(record2[:5000] == record[:5000])

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import pytest
 import numpy as np
-from astropy import units as u
+import astropy.units as u
 from astropy.time import Time
 from astropy.tests.helper import catch_warnings
 from ... import mark5b
@@ -345,7 +345,8 @@ class TestMark5B(object):
             assert header == fh.header0
             assert fh.fh_raw.tell() == header.framesize
             assert fh.samples_per_frame == 5000
-            assert fh.frames_per_second == 6400
+            assert np.all(fh.sample_rate == 32 * u.MHz)
+            assert fh._sample_rate == 32000000.0
             last_header = fh._last_header
             assert fh.size == 20000
             record = fh.read(12)
@@ -418,6 +419,7 @@ class TestMark5B(object):
         m5_test = str(tmpdir.join('test.m5b'))
         with mark5b.open(m5_test, 'ws', time=start_time, nchan=8,
                          bps=2, sample_rate=32*u.MHz) as fw:
+            assert np.all(fw.sample_rate == 32 * u.MHz)
             # Write in pieces to ensure squeezed data can be handled,
             # And add in an invalid frame for good measure.
             fw.write(record[:11])
@@ -429,6 +431,7 @@ class TestMark5B(object):
         with mark5b.open(m5_test, 'rs', nchan=8, bps=2, sample_rate=32*u.MHz,
                          ref_time=Time(57000, format='mjd')) as fh:
             assert fh.time == start_time
+            assert np.all(fh.sample_rate == 32 * u.MHz)
             record2 = fh.read(20000)
             assert fh.time == stop_time
             assert np.all(record2[:5000] == record[:5000])

--- a/baseband/tests/test_conversion.py
+++ b/baseband/tests/test_conversion.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import pytest
 import numpy as np
-from astropy import units as u
+import astropy.units as u
 from astropy.time import Time
 from .. import vdif
 from .. import mark4
@@ -123,7 +123,7 @@ class TestVDIF0VDIF1(object):
             kwargs = dict(h0)
             kwargs['edv'] = 1
             fl = str(tmpdir.join('test1.vdif'))
-            with vdif.open(fl, 'ws', frames_per_second=10000, **kwargs) as f1w:
+            with vdif.open(fl, 'ws', sample_rate=1.28*u.MHz, **kwargs) as f1w:
                 h1w = f1w.header0
                 assert list(h1w.words[:4]) == list(h0.words[:4])
                 assert h1w.framerate == 10. * u.kHz

--- a/baseband/tests/test_conversion.py
+++ b/baseband/tests/test_conversion.py
@@ -311,9 +311,8 @@ class TestDADAToVDIF1(object):
     """
 
     def get_vdif_header(self, header):
-        sample_rate = header.bandwidth * (1 if header.complex_data else 2)
         return vdif.VDIFHeader.fromvalues(
-            edv=1, time=header.time, sample_rate=sample_rate,
+            edv=1, time=header.time, sample_rate=header.sample_rate,
             bps=header.bps, nchan=header['NCHAN'],
             complex_data=header.complex_data,
             payloadsize=header.payloadsize // 2,
@@ -388,8 +387,7 @@ class TestDADAToVDIF1(object):
         dada_file = str(tmpdir.join('reconverted.dada'))
         dv_data = self.get_dada_data(dv)
         assert np.allclose(dv_data, dada_data)
-        bandwidth = vh.sample_rate / (1 if vh.complex_data else 2)
-        with dada.open(dada_file, 'ws', bandwidth=bandwidth,
+        with dada.open(dada_file, 'ws', sample_rate=vh.sample_rate,
                        time=vh.time, npol=vnthread, bps=vh.bps,
                        payloadsize=vh.payloadsize*2, nchan=vh.nchan,
                        telescope=vh.station,

--- a/baseband/tests/test_conversion.py
+++ b/baseband/tests/test_conversion.py
@@ -63,7 +63,7 @@ class TestVDIFMark5B(object):
         # This is common enough that we should not fail verification.
         header_copy.verify()
         assert abs(header_copy.time - m5h2.time) > 1.*u.ns
-        assert abs(header_copy.get_time(framerate=32*u.MHz/m5pl.nsample) -
+        assert abs(header_copy.get_time(sample_rate=32*u.MHz) -
                    m5h2.time) < 1.*u.ns
         # Also check two special cases:
         assert abs(header_copy.get_time(frame_nr=0) == m5h1.time)
@@ -126,16 +126,14 @@ class TestVDIF0VDIF1(object):
             with vdif.open(fl, 'ws', sample_rate=1.28*u.MHz, **kwargs) as f1w:
                 h1w = f1w.header0
                 assert list(h1w.words[:4]) == list(h0.words[:4])
-                assert h1w.framerate == 10. * u.kHz
-                assert h1w.bandwidth == 1.28 * f0.sample_shape.nchan * u.MHz
+                assert h1w.sample_rate == 1.28*u.MHz
                 f1w.write(d0)
 
             with vdif.open(fl, 'rs') as f1r:
                 h1r = f1r.header0
                 d1r = f1r.read(1024)
                 assert h1r.words[:4] == h0.words[:4]
-                assert h1r.framerate == 10. * u.kHz
-                assert h1r.bandwidth == 1.28 * f0.sample_shape.nchan * u.MHz
+                assert h1w.sample_rate == 1.28*u.MHz
                 assert np.all(d1r == d0)
 
 
@@ -149,7 +147,7 @@ class TestMark5BToVDIF3(object):
         # check that we have enough information to create VDIF EDV 3 header.
         header = vdif.VDIFHeader.fromvalues(
             edv=3, bps=m5pl.bps, nchan=1, station='WB', time=m5h.time,
-            bandwidth=16.*u.MHz, complex_data=False)
+            sample_rate=32.*u.MHz, complex_data=False)
         assert header.time == m5h.time
 
     def test_stream(self, tmpdir):
@@ -164,7 +162,7 @@ class TestMark5BToVDIF3(object):
             # create VDIF header from Mark 5B stream information.
             header = vdif.VDIFHeader.fromvalues(
                 edv=3, bps=fr.bps, nchan=1, station='WB', time=m5h.time,
-                bandwidth=16.*u.MHz, complex_data=False)
+                sample_rate=32.*u.MHz, complex_data=False)
             data = fr.read(20000)  # enough to fill one EDV3 frame.
             time1 = fr.tell(unit='time')
 
@@ -196,7 +194,7 @@ class TestMark5BToVDIF3(object):
             # hand, so we can compare byte-for-byte.
             with mark5b.open(mark5b_new_file, 'ws', nchan=dv.shape[1],
                              bps=hv.bps, time=hv.time,
-                             sample_rate=hv.bandwidth*2, user=hm['user'],
+                             sample_rate=hv.sample_rate, user=hm['user'],
                              internal_tvg=hm['internal_tvg']) as fw:
                 fw.write(dv)
 
@@ -222,7 +220,7 @@ class TestVDIF3ToMark5B(object):
 
         fl = str(tmpdir.join('test.m5b'))
         with mark5b.open(fl, 'ws', nchan=data.shape[1], bps=vh.bps,
-                         time=vh.time, sample_rate=vh.bandwidth*2) as fw:
+                         time=vh.time, sample_rate=vh.sample_rate) as fw:
             fw.write(data)
 
         with vdif.open(SAMPLE_VDIF, 'rs') as fv, mark5b.open(
@@ -251,7 +249,7 @@ class TestMark4ToVDIF1(object):
         # check that we have enough information to create VDIF EDV 1 header.
         header = vdif.VDIFHeader.fromvalues(
             edv=1, bps=m4h.bps, nchan=1, station='Ar', time=m4h.time,
-            bandwidth=16.*u.MHz, payloadsize=640*2//8, complex_data=False)
+            sample_rate=32.*u.MHz, payloadsize=640*2//8, complex_data=False)
         assert abs(header.time - m4h.time) < 2. * u.ns
 
     def test_stream(self, tmpdir):
@@ -261,7 +259,7 @@ class TestMark4ToVDIF1(object):
             start_time = fr.start_time
             vheader0 = vdif.VDIFHeader.fromvalues(
                 edv=1, bps=m4header0.bps, nchan=1, station='Ar',
-                time=start_time, bandwidth=16.*u.MHz,
+                time=start_time, sample_rate=32.*u.MHz,
                 payloadsize=640*2//8, complex_data=False)
             assert abs(vheader0.time - start_time) < 2. * u.ns
             data = fr.read(80000)  # full Mark 4 frame
@@ -294,7 +292,7 @@ class TestMark4ToVDIF1(object):
 
         # Convert VDIF file back to Mark 4, and check byte-for-byte.
         fl2 = str(tmpdir.join('test.m4'))
-        with mark4.open(fl2, 'ws', sample_rate=vheader0.bandwidth*2,
+        with mark4.open(fl2, 'ws', sample_rate=vheader0.sample_rate,
                         time=vheader0.time, ntrack=64, bps=2, fanout=4,
                         system_id=108) as fw:
             fw.write(dv)
@@ -311,9 +309,11 @@ class TestDADAToVDIF1(object):
     Here, we use a VDIF format with a flexible size so it is easier to fit
     the dada file inside the VDIF one.
     """
+
     def get_vdif_header(self, header):
+        sample_rate = header.bandwidth * (1 if header.complex_data else 2)
         return vdif.VDIFHeader.fromvalues(
-            edv=1, time=header.time, bandwidth=header.bandwidth,
+            edv=1, time=header.time, sample_rate=sample_rate,
             bps=header.bps, nchan=header['NCHAN'],
             complex_data=header.complex_data,
             payloadsize=header.payloadsize // 2,
@@ -388,7 +388,8 @@ class TestDADAToVDIF1(object):
         dada_file = str(tmpdir.join('reconverted.dada'))
         dv_data = self.get_dada_data(dv)
         assert np.allclose(dv_data, dada_data)
-        with dada.open(dada_file, 'ws', bandwidth=vh.bandwidth,
+        bandwidth = vh.sample_rate / (1 if vh.complex_data else 2)
+        with dada.open(dada_file, 'ws', bandwidth=bandwidth,
                        time=vh.time, npol=vnthread, bps=vh.bps,
                        payloadsize=vh.payloadsize*2, nchan=vh.nchan,
                        telescope=vh.station,

--- a/baseband/tests/test_sequential_baseband.py
+++ b/baseband/tests/test_sequential_baseband.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import os
 import numpy as np
+import astropy.units as u
 from astropy.time import Time
 from .. import vdif
 from ..helpers import sequentialfile
@@ -24,7 +25,7 @@ def test_sequentialfile_vdif_stream(tmpdir):
         station='me')
     with sequentialfile.open(vdif_sequencer, 'wb',
                              file_size=4*header.framesize) as sfh, vdif.open(
-            sfh, 'ws', header=header, nthread=2, frames_per_second=16) as fw:
+            sfh, 'ws', header=header, nthread=2, sample_rate=256*u.Hz) as fw:
         fw.write(data)
     # check that this wrote 8 frames
     files = [vdif_sequencer[i] for i in range(8)]
@@ -33,7 +34,7 @@ def test_sequentialfile_vdif_stream(tmpdir):
     assert not os.path.isfile(vdif_sequencer[8])
 
     with sequentialfile.open(vdif_sequencer, 'rb') as sfh, vdif.open(
-            sfh, 'rs', frames_per_second=16) as fr:
+            sfh, 'rs', sample_rate=256*u.Hz) as fr:
         record1 = fr.read(21)
         assert np.all(record1 == data[:21])
         fr.seek(7*16)
@@ -42,6 +43,6 @@ def test_sequentialfile_vdif_stream(tmpdir):
         assert fr.tell() == 7*16+61
     # Might as well check file list too.
     with sequentialfile.open(files, 'rb') as sfh, vdif.open(
-            sfh, 'rs', frames_per_second=16) as fr:
+            sfh, 'rs', sample_rate=256*u.Hz) as fr:
         record1 = fr.read()
         assert np.all(record1 == data)

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -259,9 +259,10 @@ class VDIFStreamBase(VLBIStreamBase):
             sample_rate=sample_rate, squeeze=squeeze)
 
     def _get_time(self, header):
-        """Calculate time for given header.
+        """Get time from a header.
 
-        This passes on frame rate, since not all VDIF headers can calculate it.
+        This passes on sample rate, since not all VDIF headers can calculate
+        it.
         """
         return header.get_time(sample_rate=self.sample_rate)
 

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -267,7 +267,7 @@ class VDIFStreamBase(VLBIStreamBase):
 
     def __repr__(self):
         return ("<{s.__class__.__name__} name={s.name} offset={s.offset}\n"
-                "    sample_rate={s.sample_rate:.6g},"
+                "    sample_rate={s.sample_rate},"
                 " samples_per_frame={s.samples_per_frame},\n"
                 "    sample_shape={s.sample_shape},\n"
                 "    complex_data={s.complex_data},"
@@ -456,7 +456,7 @@ class VDIFStreamWriter(VDIFStreamBase, VLBIStreamWriterBase, VDIFFileWriter):
     edv : {`False`, 0, 1, 2, 3, 4, 0xab}
         Extended Data Version.
     """
-    def __init__(self, raw, nthread=1, header=None, sample_rate=None,
+    def __init__(self, raw, nthread=1, sample_rate=None, header=None,
                  squeeze=True, **kwargs):
         if header is None:
             header = VDIFHeader.fromvalues(**kwargs)

--- a/baseband/vdif/header.py
+++ b/baseband/vdif/header.py
@@ -514,22 +514,20 @@ class VDIFSampleRateHeader(VDIFBaseHeader):
     def sample_rate(self):
         """Number of complete samples per second."""
         return u.Quantity(self['sampling_rate'] *
-                          (1 if self['complex_data'] else 2) / self.nchan,
+                          (1 if self['complex_data'] else 2),
                           u.MHz if self['sampling_unit'] else u.kHz)
 
     @sample_rate.setter
     def sample_rate(self, sample_rate):
-        sample_rate = sample_rate.to(u.Hz)
-        assert sample_rate.value % 1 == 0
-        bandwidth = (sample_rate * self.nchan /
-                     (1 if self['complex_data'] else 2))
+        assert sample_rate.to_value(u.Hz) % 1 == 0
+        bandwidth = sample_rate / (1 if self['complex_data'] else 2)
         self['sampling_unit'] = not (bandwidth.unit == u.kHz or
-                                     bandwidth.to(u.MHz).value % 1 != 0)
+                                     bandwidth.to_value(u.MHz) % 1 != 0)
         if self['sampling_unit']:
-            self['sampling_rate'] = int(bandwidth.to(u.MHz).value)
+            self['sampling_rate'] = int(bandwidth.to_value(u.MHz))
         else:
             assert bandwidth.to(u.kHz).value % 1 == 0
-            self['sampling_rate'] = int(bandwidth.to(u.kHz).value)
+            self['sampling_rate'] = int(bandwidth.to_value(u.kHz))
 
 
 class VDIFHeader1(VDIFSampleRateHeader):

--- a/baseband/vdif/header.py
+++ b/baseband/vdif/header.py
@@ -374,8 +374,9 @@ class VDIFHeader(VLBIHeaderBase):
                 except AttributeError:
                     raise ValueError("Cannot calculate sample rate for this "
                                      "header. Pass it in explicitly.")
-            framerate = sample_rate / self.samples_per_frame
-            offset = (frame_nr / framerate).to(u.s).value
+            offset = (frame_nr * self.samples_per_frame /
+                      sample_rate).to_value(u.s)
+
         return (ref_epochs[self['ref_epoch']] +
                 TimeDelta(self['seconds'], offset, format='sec', scale='tai'))
 
@@ -513,9 +514,8 @@ class VDIFSampleRateHeader(VDIFBaseHeader):
     def sample_rate(self):
         """Number of complete samples per second."""
         return u.Quantity(self['sampling_rate'] *
-                          (1000000 if self['sampling_unit'] else 1000) *
-                          (1 if self['complex_data'] else 2) /
-                          self.nchan, u.Hz)
+                          (1 if self['complex_data'] else 2) / self.nchan,
+                          u.MHz if self['sampling_unit'] else u.kHz)
 
     @sample_rate.setter
     def sample_rate(self, sample_rate):
@@ -669,8 +669,8 @@ class VDIFMark5BHeader(VDIFBaseHeader, Mark5BHeader):
                     raise ValueError("Calculating the time for a non-zero "
                                      "frame number requires a sample rate. "
                                      "Pass it in explicitly.")
-                framerate = sample_rate / self.samples_per_frame
-                offset = (frame_nr / framerate).to(u.s).value
+                offset = (frame_nr * self.samples_per_frame /
+                          sample_rate).to_value(u.s)
 
         return (ref_epochs[self['ref_epoch']] +
                 TimeDelta(self['seconds'], offset, format='sec', scale='tai'))

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -504,7 +504,7 @@ class TestVDIF(object):
             record = fh.read(12)
             assert fh.tell() == 12
             t12 = fh.time
-            s12 = (12 / fh.sample_rate).to(u.s)
+            s12 = 12 / fh.sample_rate
             assert abs(t12 - fh.start_time - s12) < 1. * u.ns
             fh.seek(10, 1)
             fh.tell() == 22
@@ -525,9 +525,9 @@ class TestVDIF(object):
                 fh.seek(0, 'last')
             assert fh.size == 40000
             assert abs(fh.stop_time - fh._last_header.time - (
-                fh.samples_per_frame / fh.sample_rate).to(u.s)) < 1. * u.ns
+                fh.samples_per_frame / fh.sample_rate)) < 1. * u.ns
             assert abs(fh.stop_time - fh.start_time -
-                       (fh.size / fh.sample_rate).to(u.s)) < 1. * u.ns
+                       (fh.size / fh.sample_rate)) < 1. * u.ns
 
         assert record.shape == (12, 8)
         assert np.all(record.astype(int)[:, 0] ==
@@ -658,7 +658,7 @@ def test_mwa_vdif():
 
 def test_arochime_vdif():
     """Test ARO CHIME format (uses EDV=0)"""
-    sample_rate = 5**8*u.Hz   # 390625 frames/second * 1 samples/frame.
+    sample_rate = 800*u.MHz / 1024. / 2.   # File has 1 sample/frame.
     with open(SAMPLE_AROCHIME, 'rb') as fh:
         header0 = vdif.VDIFHeader.fromfile(fh)
     assert header0.edv == 0
@@ -690,7 +690,7 @@ def test_arochime_vdif():
         assert d.dtype.kind == 'c'
         t1 = fh.time
         assert abs(t1 - fh.stop_time) < 1. * u.ns
-        assert abs(t1 - t0 - (fh.size / fh.sample_rate).to(u.s)) < 1. * u.ns
+        assert abs(t1 - t0 - fh.size / fh.sample_rate) < 1. * u.ns
 
     # For this file, we cannot find a frame rate, so opening it without
     # should fail.

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -496,13 +496,15 @@ class TestVDIF(object):
             assert repr(fh).startswith('<VDIFStreamReader')
             assert fh.tell() == 0
             assert header == fh.header0
+            assert np.all(fh.sample_rate == 32 * u.MHz)
+            assert fh._sample_rate == 32000000.0
             assert fh.start_time == fh.header0.time
             assert abs(fh.time - fh.start_time) < 1. * u.ns
             assert fh.time == fh.tell(unit='time')
             record = fh.read(12)
             assert fh.tell() == 12
             t12 = fh.time
-            s12 = 12 / fh.samples_per_frame / fh.frames_per_second * u.s
+            s12 = (12 / fh.sample_rate).to(u.s)
             assert abs(t12 - fh.start_time - s12) < 1. * u.ns
             fh.seek(10, 1)
             fh.tell() == 22
@@ -522,10 +524,10 @@ class TestVDIF(object):
             with pytest.raises(ValueError):
                 fh.seek(0, 'last')
             assert fh.size == 40000
-            assert abs(fh.stop_time - fh._last_header.time - u.s /
-                       fh.frames_per_second) < 1. * u.ns
-            assert abs(fh.stop_time - fh.start_time - u.s * fh.size /
-                       fh.samples_per_frame / fh.frames_per_second) < 1. * u.ns
+            assert abs(fh.stop_time - fh._last_header.time - (
+                fh.samples_per_frame / fh.sample_rate).to(u.s)) < 1. * u.ns
+            assert abs(fh.stop_time - fh.start_time -
+                       (fh.size / fh.sample_rate).to(u.s)) < 1. * u.ns
 
         assert record.shape == (12, 8)
         assert np.all(record.astype(int)[:, 0] ==
@@ -561,14 +563,15 @@ class TestVDIF(object):
             complex_data=False, frame_nr=0, thread_id=0, samples_per_frame=16,
             station='me')
         with vdif.open(vdif_file, 'ws', header=header,
-                       nthread=2, frames_per_second=20) as fw:
+                       nthread=2, sample_rate=320*u.Hz) as fw:
+            assert np.all(fw.sample_rate == 320 * u.Hz)
             for i in range(30):
                 fw.write(data)
 
         with vdif.open(vdif_file, 'rs') as fh:
             assert fh.header0.station == 'me'
-            assert fh.frames_per_second == 20
             assert fh.samples_per_frame == 16
+            assert np.all(fh.sample_rate == 320 * u.Hz)
             assert not fh.complex_data
             assert fh.header0.bps == 2
             assert fh._sample_shape.nchan == 2
@@ -599,6 +602,37 @@ class TestVDIF(object):
         with vdif.open(test_file, 'rs') as fh:
             assert np.all(fh.read() == record)
 
+        # Test writing a file using header keywords (in particular
+        # ``bandwidth`` and ``framerate`` to set the sample rate).
+        with vdif.open(test_file, 'ws', nthread=8, nchan=1, complex_data=False,
+                       time=header.time, bps=2, edv=3,
+                       framerate=1600*u.Hz) as fw:
+            fw.write(record)
+        with vdif.open(test_file, 'rs') as fh:
+            assert fh.header0.time == header.time
+            assert fh.header0.edv == header.edv
+            assert fh.header0.framerate == header.framerate
+            assert fh.header0.bandwidth == header.bandwidth
+            assert fh.header0.samples_per_frame == header.samples_per_frame
+            assert fh.sample_shape == (8,)
+            assert np.all(fh.sample_rate == 32 * u.MHz)
+            assert np.all(fh.read() == record)
+        # Test writing a file using header keywords (in particular
+        # ``bandwidth`` and ``framerate`` to set the sample rate).
+        with vdif.open(test_file, 'ws', nthread=8, nchan=1, complex_data=False,
+                       time=header.time, bps=2, station=2, edv=3,
+                       bandwidth=16*u.MHz) as fw:
+            fw.write(record)
+        with vdif.open(test_file, 'rs') as fh:
+            assert fh.header0.time == header.time
+            assert fh.header0.edv == header.edv
+            assert fh.header0.framerate == header.framerate
+            assert fh.header0.bandwidth == header.bandwidth
+            assert fh.header0.samples_per_frame == header.samples_per_frame
+            assert fh.sample_shape == (8,)
+            assert np.all(fh.sample_rate == 32 * u.MHz)
+            assert np.all(fh.read() == record)
+
     # Test that writing an incomplete stream is possible, and that frame set is
     # appropriately marked as invalid.
     @pytest.mark.parametrize('fill_value', (0., -999.))
@@ -608,7 +642,7 @@ class TestVDIF(object):
             with vdif.open(SAMPLE_FILE, 'rs') as fr:
                 record = fr.read(10)
                 with vdif.open(vdif_incomplete, 'ws', header=fr.header0,
-                               nthread=8, frames_per_second=1600) as fw:
+                               nthread=8, sample_rate=32*u.MHz) as fw:
                     fw.write(record)
         assert len(w) == 1
         assert 'partial buffer' in str(w[0].message)
@@ -648,7 +682,7 @@ def test_mwa_vdif():
     """Test phased VDIF format (uses EDV=0)"""
     with vdif.open(SAMPLE_MWA, 'rs', sample_rate=1.28*u.MHz) as fh:
         assert fh.samples_per_frame == 128
-        assert fh.frames_per_second == 10000
+        assert np.all(fh.sample_rate == 1.28 * u.MHz)
         assert fh.time == Time('2015-10-03T20:49:45.000')
         assert fh.header0.edv == 0
 
@@ -674,7 +708,7 @@ def test_arochime_vdif():
                header0.get_time(framerate=390625*u.Hz) - 1. * u.s) < 1.*u.ns
 
     # Now test the actual data stream.
-    with vdif.open(SAMPLE_AROCHIME, 'rs', frames_per_second=390625) as fh:
+    with vdif.open(SAMPLE_AROCHIME, 'rs', sample_rate=390625*u.Hz) as fh:
         assert fh.samples_per_frame == 1
         t0 = fh.time
         assert abs(t0 - Time('2016-04-22T08:45:31.788759040')) < 1. * u.ns
@@ -686,8 +720,7 @@ def test_arochime_vdif():
         assert d.dtype.kind == 'c'
         t1 = fh.time
         assert abs(t1 - fh.stop_time) < 1. * u.ns
-        assert abs(t1 - t0 - u.s * (fh.size / fh.samples_per_frame /
-                                    fh.frames_per_second)) < 1. * u.ns
+        assert abs(t1 - t0 - (fh.size / fh.sample_rate).to(u.s)) < 1. * u.ns
 
     # For this file, we cannot find a frame rate, so opening it without
     # should fail.

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -209,8 +209,8 @@ class VLBIStreamBase(VLBIFileBase):
     def _frame_info(self):
         offset = (self.offset +
                   self.header0['frame_nr'] * self.samples_per_frame)
-        framerate = int(np.round((
-            self.sample_rate / self.samples_per_frame).to_value(u.Hz)))
+        framerate = int(np.round(
+            (self.sample_rate / self.samples_per_frame).to_value(u.Hz)))
         full_frame_nr, extra = divmod(offset, self.samples_per_frame)
         dt, frame_nr = divmod(full_frame_nr, framerate)
         return dt, frame_nr, extra

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -48,7 +48,6 @@ class VLBIStreamBase(VLBIFileBase):
 
     _frame_class = None
     _squeezed_shape = None
-    #_samples_per_frame = None
 
     def __init__(self, fh_raw, header0, sample_shape, bps, complex_data,
                  thread_ids, samples_per_frame, sample_rate, squeeze=True):

--- a/baseband/vlbi_base/tests/test_vlbi_base.py
+++ b/baseband/vlbi_base/tests/test_vlbi_base.py
@@ -443,8 +443,11 @@ class TestVLBIBase(object):
         smp_shp_cls_s = namedtuple('SampleShape',
                                    'n1')
         sample_shape_short = smp_shp_cls_s(1)
-        sbs = VLBIStreamBase(None, None, sample_shape_short, 1, False,
-                             None, 1000, 10000*u.Hz, squeeze=False)
+        sbs = VLBIStreamBase(fh_raw=None, header0=None,
+                             sample_shape=sample_shape_short, bps=1,
+                             complex_data=False, thread_ids=None,
+                             samples_per_frame=1000, sample_rate=10000*u.Hz,
+                             squeeze=False)
         assert sbs.sample_shape == sample_shape_short
         sbs.squeeze = True
         assert sbs.sample_shape == ()

--- a/baseband/vlbi_base/tests/test_vlbi_base.py
+++ b/baseband/vlbi_base/tests/test_vlbi_base.py
@@ -5,6 +5,7 @@ from copy import copy
 import io
 import numpy as np
 import pytest
+import astropy.units as u
 from astropy.tests.helper import catch_warnings
 from collections import namedtuple
 from ..utils import bcd_encode, bcd_decode, CRC
@@ -430,7 +431,7 @@ class TestVLBIBase(object):
                                  'n1, n2, n3, n4, n5, n6, n7, n8')
         sample_shape = smp_shp_cls(1, 17, 3, 2, 1, 5, 1, 1)
         sb = VLBIStreamBase(None, None, sample_shape, 1, False,
-                            None, 1000, 1000, squeeze=False)
+                            None, 1000, 10000*u.Hz, squeeze=False)
         assert sb.sample_shape == sample_shape
         sb.squeeze = True
         assert sb.sample_shape == (17, 3, 2, 5)
@@ -440,7 +441,7 @@ class TestVLBIBase(object):
                                    'n1')
         sample_shape_short = smp_shp_cls_s(1)
         sbs = VLBIStreamBase(None, None, sample_shape_short, 1, False,
-                             None, 1000, 1000, squeeze=False)
+                             None, 1000, 10000*u.Hz, squeeze=False)
         assert sbs.sample_shape == sample_shape_short
         sbs.squeeze = True
         assert sbs.sample_shape == ()

--- a/baseband/vlbi_base/tests/test_vlbi_base.py
+++ b/baseband/vlbi_base/tests/test_vlbi_base.py
@@ -430,8 +430,11 @@ class TestVLBIBase(object):
         smp_shp_cls = namedtuple('SampleShape',
                                  'n1, n2, n3, n4, n5, n6, n7, n8')
         sample_shape = smp_shp_cls(1, 17, 3, 2, 1, 5, 1, 1)
-        sb = VLBIStreamBase(None, None, sample_shape, 1, False,
-                            None, 1000, 10000*u.Hz, squeeze=False)
+        sb = VLBIStreamBase(fh_raw=None, header0=None,
+                            sample_shape=sample_shape, bps=1,
+                            complex_data=False, thread_ids=None,
+                            samples_per_frame=1000,
+                            sample_rate=10000*u.Hz, squeeze=False)
         assert sb.sample_shape == sample_shape
         sb.squeeze = True
         assert sb.sample_shape == (17, 3, 2, 5)

--- a/docs/baseband/dada/index.rst
+++ b/docs/baseband/dada/index.rst
@@ -50,7 +50,7 @@ writing is in units of samples, and provides access to header information.
     >>> fh = dada.open(SAMPLE_DADA, 'rs')
     >>> fh
     <DADAStreamReader name=... offset=0
-        sample_rate=16000000.0 Hz, samples_per_frame=16000,
+        sample_rate=1.6e+07 Hz, samples_per_frame=16000,
         sample_shape=SampleShape(npol=2), bps=8,
         thread_ids=[0, 1], start_time=2013-07-02T01:39:20.000>
     >>> d = fh.read(10000)

--- a/docs/baseband/dada/index.rst
+++ b/docs/baseband/dada/index.rst
@@ -15,9 +15,10 @@ Usage
 This section covers DADA-specific features of Baseband.  Tutorials for general
 usage can be found under the :ref:`Using Baseband <using_baseband_toc>` section.
 The examples below use the small sample file ``baseband/data/sample.dada``,
-and assume the `baseband.dada` module has been imported::
+and assume the `astropy.units` and `baseband.dada` modules have been imported::
 
     >>> from baseband import dada
+    >>> import astropy.units as u
     >>> from baseband.data import SAMPLE_DADA
 
 Single files can be opened with :func:`~baseband.dada.open` in binary mode. 
@@ -49,7 +50,7 @@ writing is in units of samples, and provides access to header information.
     >>> fh = dada.open(SAMPLE_DADA, 'rs')
     >>> fh
     <DADAStreamReader name=... offset=0
-        frames_per_second=1000.0, samples_per_frame=16000,
+        sample_rate=16000000.0 Hz, samples_per_frame=16000,
         sample_shape=SampleShape(npol=2), bps=8,
         thread_ids=[0, 1], start_time=2013-07-02T01:39:20.000>
     >>> d = fh.read(10000)
@@ -67,7 +68,6 @@ even smaller size of the payload, to show how one can define multiple files.
 ::
 
     >>> from astropy.time import Time
-    >>> import astropy.units as u
     >>> fw = dada.open('{utc_start}.{obs_offset:016d}.000000.dada', 'ws',
     ...                npol=2, samples_per_frame=5000, nchan=1, bps=8,
     ...                bandwidth=16*u.MHz, complex_data=True,

--- a/docs/baseband/dada/index.rst
+++ b/docs/baseband/dada/index.rst
@@ -50,7 +50,7 @@ writing is in units of samples, and provides access to header information.
     >>> fh = dada.open(SAMPLE_DADA, 'rs')
     >>> fh
     <DADAStreamReader name=... offset=0
-        sample_rate=1.6e+07 Hz, samples_per_frame=16000,
+        sample_rate=16.0 MHz, samples_per_frame=16000,
         sample_shape=SampleShape(npol=2), bps=8,
         thread_ids=[0, 1], start_time=2013-07-02T01:39:20.000>
     >>> d = fh.read(10000)
@@ -70,7 +70,7 @@ even smaller size of the payload, to show how one can define multiple files.
     >>> from astropy.time import Time
     >>> fw = dada.open('{utc_start}.{obs_offset:016d}.000000.dada', 'ws',
     ...                npol=2, samples_per_frame=5000, nchan=1, bps=8,
-    ...                bandwidth=16*u.MHz, complex_data=True,
+    ...                sample_rate=16*u.MHz, complex_data=True,
     ...                time=Time('2013-07-02T01:39:20.000'))
     >>> fw.write(d)
     >>> fw.close()

--- a/docs/baseband/mark4/index.rst
+++ b/docs/baseband/mark4/index.rst
@@ -15,9 +15,11 @@ Usage
 This section covers Mark 4-specific features of Baseband.  Tutorials for general
 usage can be found under the :ref:`Using Baseband <using_baseband_toc>` section.
 The examples below use the small sample file ``baseband/data/sample.m4``,
-and assumes `numpy` and `baseband.mark4` modules have been imported::
+and assumes the `numpy`, `astropy.units`, and `baseband.mark4` modules have
+been imported::
 
     >>> import numpy as np
+    >>> import astropy.units as u
     >>> from baseband import mark4
     >>> from baseband.data import SAMPLE_MARK4
 
@@ -48,7 +50,7 @@ also provide a reference time within 4 years of the observation start time::
     ...                 ref_time=Time('2013:100:23:00:00'))
     >>> fh
     <Mark4StreamReader name=... offset=0
-        frames_per_second=400, samples_per_frame=80000,
+        sample_rate=32000000.0 Hz, samples_per_frame=80000,
         sample_shape=SampleShape(nchan=8), bps=2,
         start_time=2014-06-16T07:38:12.47500>
     >>> d = fh.read(6400)
@@ -66,12 +68,12 @@ invalid data (zeros, by default)::
     >>> np.array_equal(d[:640], np.zeros((640,) + d.shape[1:]))
     True
 
-When writing to file, we need to pass in the frame rate in addition to 
+When writing to file, we need to pass in the sample rate in addition to 
 ``ntrack`` and ``decade`` so that times for individual samples can be
 calculated.
 
     >>> fw = mark4.open('sample_mark4_segment.m4', 'ws', header=frame.header,
-    ...                 ntrack=64, decade=2010, frames_per_second=400)
+    ...                 ntrack=64, decade=2010, sample_rate=32*u.MHz)
     >>> fw.write(frame.data)
     >>> fw.close()
 

--- a/docs/baseband/mark4/index.rst
+++ b/docs/baseband/mark4/index.rst
@@ -50,7 +50,7 @@ also provide a reference time within 4 years of the observation start time::
     ...                 ref_time=Time('2013:100:23:00:00'))
     >>> fh
     <Mark4StreamReader name=... offset=0
-        sample_rate=32000000.0 Hz, samples_per_frame=80000,
+        sample_rate=3.2e+07 Hz, samples_per_frame=80000,
         sample_shape=SampleShape(nchan=8), bps=2,
         start_time=2014-06-16T07:38:12.47500>
     >>> d = fh.read(6400)

--- a/docs/baseband/mark4/index.rst
+++ b/docs/baseband/mark4/index.rst
@@ -13,7 +13,7 @@ Usage
 =====
 
 This section covers Mark 4-specific features of Baseband.  Tutorials for general
-usage can be found under the :ref:`Using Baseband <using_baseband_toc>` section.
+usage can be found under the :ref:`Using Baseband <using_baseband_tsaoc>` section.
 The examples below use the small sample file ``baseband/data/sample.m4``,
 and assumes the `numpy`, `astropy.units`, and `baseband.mark4` modules have
 been imported::
@@ -50,7 +50,7 @@ also provide a reference time within 4 years of the observation start time::
     ...                 ref_time=Time('2013:100:23:00:00'))
     >>> fh
     <Mark4StreamReader name=... offset=0
-        sample_rate=3.2e+07 Hz, samples_per_frame=80000,
+        sample_rate=32.0 MHz, samples_per_frame=80000,
         sample_shape=SampleShape(nchan=8), bps=2,
         start_time=2014-06-16T07:38:12.47500>
     >>> d = fh.read(6400)

--- a/docs/baseband/mark4/index.rst
+++ b/docs/baseband/mark4/index.rst
@@ -13,7 +13,7 @@ Usage
 =====
 
 This section covers Mark 4-specific features of Baseband.  Tutorials for general
-usage can be found under the :ref:`Using Baseband <using_baseband_tsaoc>` section.
+usage can be found under the :ref:`Using Baseband <using_baseband_toc>` section.
 The examples below use the small sample file ``baseband/data/sample.m4``,
 and assumes the `numpy`, `astropy.units`, and `baseband.mark4` modules have
 been imported::

--- a/docs/baseband/tutorials/getting_started.rst
+++ b/docs/baseband/tutorials/getting_started.rst
@@ -108,7 +108,7 @@ We can access information about the file by printing ``fh``::
 
     >>> fh
     <VDIFStreamReader name=... offset=24
-        sample_rate=32000000.0 Hz, samples_per_frame=20000,
+        sample_rate=3.2e+07 Hz, samples_per_frame=20000,
         sample_shape=SampleShape(nthread=8),
         complex_data=False, bps=2, edv=3, station=65532,
         start_time=2014-06-16T05:56:07.000000000>

--- a/docs/baseband/tutorials/getting_started.rst
+++ b/docs/baseband/tutorials/getting_started.rst
@@ -43,7 +43,7 @@ sample DADA file, for example::
 In general, file I/O and data manipulation use the same syntax across all
 file formats.  When using ``open`` for Mark 4 and Mark 5B files, however, two
 keywords - ``ntrack``, and ``decade`` - may need to be set manually.  For these
-and VDIF, ``frames_per_second`` may also need to be passed if it can't be read
+and VDIF, ``sample_rate`` may also need to be passed if it can't be read
 or inferred from the file.  Notes on such features and quirks of individual
 formats can be found in the docstrings of their ``open`` functions, and
 within the :ref:`Specific file format <specific_file_formats_toc>`
@@ -108,7 +108,7 @@ We can access information about the file by printing ``fh``::
 
     >>> fh
     <VDIFStreamReader name=... offset=24
-        frames_per_second=1600, samples_per_frame=20000,
+        sample_rate=32000000.0 Hz, samples_per_frame=20000,
         sample_shape=SampleShape(nthread=8),
         complex_data=False, bps=2, edv=3, station=65532,
         start_time=2014-06-16T05:56:07.000000000>
@@ -298,7 +298,7 @@ be necessary for compatibility with `DSPSR
     >>> fr = vdif.open(SAMPLE_VDIF, 'rs')
     >>> fw = vdif.open('test_vdif.vdif', 'ws',
     ...                nthread=1, nchan=fr.sample_shape.nthread,
-    ...                frames_per_second=fr.frames_per_second,
+    ...                sample_rate=fr.sample_rate,
     ...                samples_per_frame=fr.samples_per_frame // 8,
     ...                complex_data=fr.complex_data, bps=fr.bps,
     ...                edv=fr.header0.edv, station=fr.header0.station,
@@ -366,20 +366,18 @@ values into `vdif.open <baseband.vdif.open>` to create one.
     >>> from baseband.data import SAMPLE_MARK4
     >>> fr = mark4.open(SAMPLE_MARK4, 'rs', ntrack=64, decade=2010)
     >>> spf = 640       # fanout * 160 = 640 invalid samples per Mark 4 frame
-    >>> fps = fr.frames_per_second * fr.samples_per_frame / spf
     >>> fw = vdif.open('m4convert.vdif', 'ws', edv=1, nthread=1,
     ...                samples_per_frame=spf, nchan=fr.sample_shape.nchan,
-    ...                frames_per_second=fps, complex_data=fr.complex_data, 
+    ...                sample_rate=fr.sample_rate, complex_data=fr.complex_data,
     ...                bps=fr.bps, time=fr.start_time)
 
 We choose ``edv = 1`` since it's the simplest VDIF EDV whose header includes a
-frame rate. The concept of threads does not exist in Mark 4, so the file
+sampling rate. The concept of threads does not exist in Mark 4, so the file
 effectively has ``nthread = 1``.  As discussed in the :ref:`Mark 4
 documentation <mark4>`, the data at the start of each frame is effectively
 overwritten by the header and are represented by invalid samples in the stream
 reader.  We set ``samples_per_frame`` to ``640`` so that each section of
-invalid data is captured in a single frame.  The framerate is then set to 50
-kHz for consistency.
+invalid data is captured in a single frame.
 
 We now write the data to file, manually flagging each invalid data frame::
 

--- a/docs/baseband/tutorials/getting_started.rst
+++ b/docs/baseband/tutorials/getting_started.rst
@@ -108,7 +108,7 @@ We can access information about the file by printing ``fh``::
 
     >>> fh
     <VDIFStreamReader name=... offset=24
-        sample_rate=3.2e+07 Hz, samples_per_frame=20000,
+        sample_rate=32.0 MHz, samples_per_frame=20000,
         sample_shape=SampleShape(nthread=8),
         complex_data=False, bps=2, edv=3, station=65532,
         start_time=2014-06-16T05:56:07.000000000>

--- a/docs/baseband/tutorials/new_edv.rst
+++ b/docs/baseband/tutorials/new_edv.rst
@@ -431,7 +431,7 @@ class, and define a replacement::
 
 We can then use the stream reader without further modification::
 
-    >>> fh2 = vdif.open(SAMPLE_DRAO_CORRUPT, 'rs', sample_rate=625**3*u.Hz)
+    >>> fh2 = vdif.open(SAMPLE_DRAO_CORRUPT, 'rs', sample_rate=5**12*u.Hz)
     >>> fh2.header0['eud2'] == header0['eud2']
     True
     >>> np.array_equal(fh2.read(1), payload0[0])

--- a/docs/baseband/tutorials/new_edv.rst
+++ b/docs/baseband/tutorials/new_edv.rst
@@ -14,6 +14,7 @@ modify Baseband's source code.
 The tutorials below assumes the following modules have been imported::
 
     >>> import numpy as np
+    >>> import astropy.units as u
     >>> from baseband import vdif, vlbi_base as vlbi
 
 .. _new_edv_vdif_headers:
@@ -430,7 +431,7 @@ class, and define a replacement::
 
 We can then use the stream reader without further modification::
 
-    >>> fh2 = vdif.open(SAMPLE_DRAO_CORRUPT, 'rs', frames_per_second=390625)
+    >>> fh2 = vdif.open(SAMPLE_DRAO_CORRUPT, 'rs', sample_rate=625**3*u.Hz)
     >>> fh2.header0['eud2'] == header0['eud2']
     True
     >>> np.array_equal(fh2.read(1), payload0[0])

--- a/docs/baseband/vdif/index.rst
+++ b/docs/baseband/vdif/index.rst
@@ -79,7 +79,7 @@ information::
     >>> fh = vdif.open(SAMPLE_VDIF, 'rs')
     >>> fh
     <VDIFStreamReader name=... offset=0
-        sample_rate=3.2e+07 Hz, samples_per_frame=20000,
+        sample_rate=32.0 MHz, samples_per_frame=20000,
         sample_shape=SampleShape(nthread=8),
         complex_data=False, bps=2, edv=3, station=65532,
         start_time=2014-06-16T05:56:07.000000000>

--- a/docs/baseband/vdif/index.rst
+++ b/docs/baseband/vdif/index.rst
@@ -47,10 +47,12 @@ Usage Notes
 This section covers VDIF-specific features of Baseband.  Tutorials for general
 usage can be found under the :ref:`Using Baseband <using_baseband_toc>` section.
 The examples below use the small sample file ``baseband/data/sample.vdif``,
-and assume the `numpy` and `baseband.vdif` modules have been imported::
+and assume the `numpy`, `astropy.units`, and `baseband.vdif` modules have been
+imported::
 
     >>> import numpy as np
     >>> from baseband import vdif
+    >>> import astropy.units as u
     >>> from baseband.data import SAMPLE_VDIF
 
 Simple reading and writing of VDIF files can be done entirely using
@@ -77,7 +79,7 @@ information::
     >>> fh = vdif.open(SAMPLE_VDIF, 'rs')
     >>> fh
     <VDIFStreamReader name=... offset=0
-        frames_per_second=1600, samples_per_frame=20000,
+        sample_rate=32000000.0 Hz, samples_per_frame=20000,
         sample_shape=SampleShape(nthread=8),
         complex_data=False, bps=2, edv=3, station=65532,
         start_time=2014-06-16T05:56:07.000000000>
@@ -93,10 +95,9 @@ coincidentally, what is given by the reader above suffices::
 
 
     >>> from astropy.time import Time
-    >>> import astropy.units as u
     >>> fw = vdif.open('try.vdif', 'ws',
     ...                nthread=2, samples_per_frame=20000, nchan=1,
-    ...                frames_per_second=1600, complex_data=False, bps=2, edv=3,
+    ...                sample_rate=32*u.MHz, complex_data=False, bps=2, edv=3,
     ...                station=65532, time=Time('2014-06-16T05:56:07.000000000'))
     >>> with vdif.open(SAMPLE_VDIF, 'rs', thread_ids=[2, 3]) as fh:
     ...    d = fh.read(20000)  # Get some data to write
@@ -161,17 +162,17 @@ best solution is to create a custom header class, then override the
 subclass selector in :class:`~baseband.vdif.header.VDIFHeader`.  Tutorials
 for doing either can be found :ref:`here <new_edv>`.
 
-EOFError encountered in ``_get_frame_rate`` when reading
---------------------------------------------------------
+EOFError encountered in ``_get_sample_rate`` when reading
+---------------------------------------------------------
 
 When the number of frames per second is not input by the user and cannot be
-deduced from header information (if EDV = 1, 3 or 4, the frame rate can be
-derived from the sampling rate found in the header), Baseband tries to
-determine the frame rate using the private method ``_get_frame_rate`` in
-:class:`~baseband.vdif.base.VDIFStreamReader`.  This function raises
-`EOFError` if the file contains less than one second of data, or is corrupt.
-In either case the file can be opened still by explicitly passing in the frame
-rate to :func:`~baseband.vdif.open` via the `frames_per_second` argument.
+deduced from header information (if EDV = 1 or, the sample rate is found in
+the header), Baseband tries to determine the sample rate using the private
+method ``_get_sample_rate`` in :class:`~baseband.vdif.base.VDIFStreamReader`. 
+This function raises `EOFError` if the file contains less than one second of
+data, or is corrupt.  In either case the file can be opened still by explicitly
+passing in the sample rate to :func:`~baseband.vdif.open` via the `sample_rate`
+argument.
 
 .. _vdif_api:
 

--- a/docs/baseband/vdif/index.rst
+++ b/docs/baseband/vdif/index.rst
@@ -79,7 +79,7 @@ information::
     >>> fh = vdif.open(SAMPLE_VDIF, 'rs')
     >>> fh
     <VDIFStreamReader name=... offset=0
-        sample_rate=32000000.0 Hz, samples_per_frame=20000,
+        sample_rate=3.2e+07 Hz, samples_per_frame=20000,
         sample_shape=SampleShape(nthread=8),
         complex_data=False, bps=2, edv=3, station=65532,
         start_time=2014-06-16T05:56:07.000000000>
@@ -162,17 +162,17 @@ best solution is to create a custom header class, then override the
 subclass selector in :class:`~baseband.vdif.header.VDIFHeader`.  Tutorials
 for doing either can be found :ref:`here <new_edv>`.
 
-EOFError encountered in ``_get_sample_rate`` when reading
+EOFError encountered in ``_get_frame_rate`` when reading
 ---------------------------------------------------------
 
-When the number of frames per second is not input by the user and cannot be
-deduced from header information (if EDV = 1 or, the sample rate is found in
-the header), Baseband tries to determine the sample rate using the private
-method ``_get_sample_rate`` in :class:`~baseband.vdif.base.VDIFStreamReader`. 
-This function raises `EOFError` if the file contains less than one second of
-data, or is corrupt.  In either case the file can be opened still by explicitly
-passing in the sample rate to :func:`~baseband.vdif.open` via the `sample_rate`
-argument.
+When the sample rate is not input by the user and cannot be deduced from header
+information (if EDV = 1 or, the sample rate is found in the header), Baseband
+tries to determine the frame rate using the private method ``_get_frame_rate``
+in :class:`~baseband.vdif.base.VDIFStreamReader` (and then multiply by the
+samples per frame to obtain the sample rate).  This function raises `EOFError`
+if the file contains less than one second of data, or is corrupt.  In either
+case the file can be opened still by explicitly passing in the sample rate to
+:func:`~baseband.vdif.open` via the `sample_rate` argument.
 
 .. _vdif_api:
 


### PR DESCRIPTION
Replaced `frames_per_second` with a `sample_rate` property from all stream reader and writer classes.  Correspondingly altered time and rate calculations, interfaces to headers with sampling and framerates, and tests, docstrings and documentation examples.

(Also removed redundant size definition in Mark 5B.)

Addresses #109.