### PR TITLE
Selectively reading sample components with `subset`

### DIFF
--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -269,9 +269,6 @@ class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase, DADAFileReader):
                 "'out' should have trailing shape {}".format(self.sample_shape))
             count = out.shape[0]
 
-        # Create a properly-shaped view of the output if needed.
-        result = self._unsqueeze(out) if self.squeeze else out
-
         offset0 = self.offset
         while count > 0:
             frame_nr, sample_offset = self._frame_info()
@@ -285,8 +282,9 @@ class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase, DADAFileReader):
             data_slice = slice(sample_offset, sample_offset + nsample)
             if self.subset:
                 data_slice = (data_slice,) + self.subset
-
-            result[sample:sample + nsample] = self._frame[data_slice]
+            out[sample:sample + nsample] = (
+                self._frame[data_slice].squeeze() if self.squeeze else
+                self._frame[data_slice])
             self.offset += nsample
             count -= nsample
 

--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -276,12 +276,13 @@ class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase, DADAFileReader):
                 # Open relevant file.
                 self._get_frame(frame_nr)
 
-            # Copy relevant data from frame into output.
+            # Determine appropriate slice to decode.
             nsample = min(count, self.samples_per_frame - sample_offset)
             sample = self.offset - offset0
             data_slice = slice(sample_offset, sample_offset + nsample)
             if self.subset:
                 data_slice = (data_slice,) + self.subset
+            # Copy relevant data from frame into output.
             out[sample:sample + nsample] = (
                 self._frame[data_slice].squeeze() if self.squeeze else
                 self._frame[data_slice])

--- a/baseband/data/__init__.py
+++ b/baseband/data/__init__.py
@@ -47,6 +47,10 @@ SAMPLE_VDIF = _full_path('sample.vdif')
 """VDIF sample. 8 threads, bps=2.
 
 Created from a EVN/VLBA PSR B1957+20 observation.
+
+Frames with even thread IDs have header timestamps that are offset from the
+odd-ID ones.  Timestamps from only odd-ID frames are used in the test suite and
+documentation.
 """
 
 SAMPLE_MWA_VDIF = _full_path('sample_mwa.vdif')

--- a/baseband/gsb/base.py
+++ b/baseband/gsb/base.py
@@ -159,8 +159,8 @@ class GSBStreamBase(VLBIStreamBase):
                 "    sample_rate={s.sample_rate:.5g},"
                 " samples_per_frame={s.samples_per_frame},\n"
                 "    sample_shape={s.sample_shape}, bps={s.bps},\n"
-                "    {t}start_time={s.start_time.isot}>"
-                .format(s=self, dn=data_name, t=(
+                "    {sub}start_time={s.start_time.isot}>"
+                .format(s=self, dn=data_name, sub=(
                     'subset={0}, '.format(self.subset) if
                     self.subset else '')))
 
@@ -306,12 +306,13 @@ class GSBStreamReader(GSBStreamBase, VLBIStreamReaderBase):
                                   ((self._frame.header.time -
                                     self.start_time) * framerate).to(u.one))
 
-            # Copy relevant data from frame into output.
+            # Determine appropriate slice to decode.
             nsample = min(count, self.samples_per_frame - sample_offset)
             sample = self.offset - offset0
             data_slice = slice(sample_offset, sample_offset + nsample)
             if self.subset:
                 data_slice = (data_slice,) + self.subset
+            # Copy relevant data from frame into output.
             out[sample:sample + nsample] = (
                 self._frame[data_slice].squeeze() if self.squeeze else
                 self._frame[data_slice])

--- a/baseband/gsb/tests/test_gsb.py
+++ b/baseband/gsb/tests/test_gsb.py
@@ -477,10 +477,12 @@ class TestGSB(object):
             out1 = np.empty_like(data1)
             fh_r.read(out=out1)
             assert np.all(out1 == data1)
-            fh_r.seek(0)
-            fh_r.squeeze = True
+
+        # Try with squeezing on.
+        with gsb.open(SAMPLE_RAWDUMP_HEADER, 'rs', raw=SAMPLE_RAWDUMP,
+                      sample_rate=sample_rate, payloadsize=self.payloadsize,
+                      squeeze=True) as fh_r:
             out2 = np.empty((fh_r.size,) + fh_r.sample_shape)
-            fh_r.seek(0)
             fh_r.read(out=out2)
             assert np.all(out2 == out1.squeeze())
             # To compare with directly psasing samples_per_frame below.
@@ -502,24 +504,38 @@ class TestGSB(object):
             sh.seek(0)
             sp.seek(0)
             fh_r.seek(0)
-            with gsb.open(sh, 'rs', raw=sp, sample_rate=fh_r.sample_rate,
-                          samples_per_frame=(
-                              self.payloadsize * (8 // bps))) as fh_n:
-                assert fh_n.header0 == fh_r.header0
-                assert fh_n._last_header == fh_r._last_header
-                assert fh_n.size == fh_r.size
-                assert fh_n.sample_shape == fh_r.sample_shape
-                assert fh_n.start_time == fh_r.start_time
-                assert fh_n.sample_rate == sample_rate
-                assert np.all(fh_n.read() == fh_r.read())
-                assert abs(fh_n.stop_time - fh_n.time) < 1.*u.ns
-                assert abs(fh_n.stop_time - fh_r.stop_time) < 1.*u.ns
+            fh_n = gsb.open(sh, 'rs', raw=sp, sample_rate=fh_r.sample_rate,
+                            samples_per_frame=(self.payloadsize * (8 // bps)))
+            assert fh_n.header0 == fh_r.header0
+            assert fh_n._last_header == fh_r._last_header
+            assert fh_n.size == fh_r.size
+            assert fh_n.sample_shape == fh_r.sample_shape
+            assert fh_n.start_time == fh_r.start_time
+            assert fh_n.sample_rate == sample_rate
+            assert np.all(fh_n.read() == fh_r.read())
+            assert abs(fh_n.stop_time - fh_n.time) < 1.*u.ns
+            assert abs(fh_n.stop_time - fh_r.stop_time) < 1.*u.ns
             # Check that passing samples_per_frame is identical to passing
             # payloadsize.
             fh_r.seek(0)
             assert fh_r.samples_per_frame == spf_from_payloadsize
             assert np.all(fh_r.read() == data1.squeeze())
-            fh_w.close()
+            # Try writing a file with squeeze off.
+            sh.seek(0)
+            sp.seek(0)
+            fh_r.seek(0)
+            fh_wns = gsb.open(sh, 'ws', raw=sp, sample_rate=fh_r.sample_rate,
+                              samples_per_frame=(self.payloadsize *
+                                                 (8 // bps)),
+                              header=fh_r.header0, squeeze=False)
+            fh_wns.write(fh_r.read()[:, np.newaxis])
+            sh.seek(0)
+            sp.seek(0)
+            fh_r.seek(0)
+            fh_nns = gsb.open(sh, 'rs', raw=sp, sample_rate=fh_r.sample_rate,
+                              samples_per_frame=(self.payloadsize *
+                                                 (8 // bps)))
+            assert np.all(fh_nns.read() == fh_r.read())
 
         # Test that opening that raises an exception correctly handles
         # file closing. (Note that the timestamp file always gets closed).
@@ -600,11 +616,13 @@ class TestGSB(object):
             out1 = np.empty_like(data1)
             fh_r.read(out=out1)
             assert np.all(out1 == data1)
-            fh_r.seek(0)
-            fh_r.squeeze = True
+
+        # Try again with squeezing.
+        with gsb.open(SAMPLE_PHASED_HEADER, 'rs', raw=SAMPLE_PHASED,
+                      sample_rate=sample_rate, payloadsize=self.payloadsize,
+                      squeeze=True) as fh_r:
             out2 = np.empty((fh_r.size,) + fh_r.sample_shape,
                             dtype=np.complex64)
-            fh_r.seek(0)
             fh_r.read(out=out2)
             assert np.all(out2 == out1.squeeze())
             # To compare with directly psasing samples_per_frame below.

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -395,18 +395,16 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
 
             # Set decoded value for invalid data.
             self._frame.invalid_data_value = fill_value
-            # Decode data into array.
-            data = self._frame.data
-            if self.subset:
-                data = data[(slice(None),) + self.subset]
-            # Squeeze it if necessary.
-            if self.squeeze:
-                data = data.squeeze()
-            # Copy relevant data from frame into output.
+            # Determine appropriate slice to decode.
             nsample = min(count, self.samples_per_frame - sample_offset)
             sample = self.offset - offset0
-            out[sample:sample + nsample] = data[sample_offset:
-                                                sample_offset + nsample]
+            data_slice = slice(sample_offset, sample_offset + nsample)
+            if self.subset:
+                data_slice = (data_slice,) + self.subset
+            # Copy relevant data from frame into output.
+            out[sample:sample + nsample] = (
+                self._frame.data[data_slice].squeeze() if self.squeeze else
+                self._frame.data[data_slice])
             self.offset += nsample
             count -= nsample
 

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -604,10 +604,9 @@ class TestMark4(object):
                 conv_bytes = s.read()
                 assert conv_bytes == orig_bytes
 
-        # Test that squeeze attribute works on read (including in-place read)
-        # and write, but can be turned off if needed.
+        # Test that squeeze attribute works on read (including in-place read).
         with mark4.open(SAMPLE_FILE, 'rs', ntrack=64,
-                        thread_ids=[0], decade=2010) as fh:
+                        subset=0, decade=2010) as fh:
             assert fh.sample_shape == ()
             assert fh.read(1).shape == (1,)
             fh.seek(0)
@@ -626,12 +625,6 @@ class TestMark4(object):
             fh.read(out=out)
             assert fh.tell() == 12
             assert np.all(out.squeeze() == record[:12, 0])
-
-        with mark4.open(str(tmpdir.join('test.m4')), 'ws',
-                        sample_rate=32*u.MHz, time=start_time,
-                        ntrack=64, bps=1, fanout=4) as fw:
-            assert fw.sample_shape == (16,)
-            assert fw.sample_shape.nchan == 16
 
         # Test writing across decades.
         start_time = Time('2019:365:23:59:59.9975', precision=9)

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -579,12 +579,13 @@ class TestMark4(object):
             assert fw.tell(unit='time') == stop_time
 
         with mark4.open(rewritten_file, 'rs', ntrack=64, decade=2010,
-                        sample_rate=32*u.MHz, thread_ids=[3, 4]) as fh:
+                        sample_rate=32*u.MHz, subset=[3, 4]) as fh:
             assert fh.time == start_time
             assert fh.time == fh.tell(unit='time')
             assert fh.sample_rate == 32 * u.MHz
             record5 = fh.read(160000)
             assert fh.time == stop_time
+            assert fh.sample_shape == (2,)
             assert np.all(record5[:80000] == record[:80000, 3:5])
             assert np.all(record5[80000:] == 0.)
 
@@ -616,7 +617,7 @@ class TestMark4(object):
             assert np.all(out == record[:12, 0])
 
         with mark4.open(SAMPLE_FILE, 'rs', ntrack=64, decade=2010,
-                        thread_ids=[0], squeeze=False) as fh:
+                        subset=0, squeeze=False) as fh:
             assert fh.sample_shape == (1,)
             assert fh.sample_shape.nchan == 1
             assert fh.read(1).shape == (1, 1)

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -216,7 +216,7 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
         header = self._frame.header
         super(Mark5BStreamReader, self).__init__(
             fh_raw, header0=header, bps=bps, complex_data=False, subset=subset,
-            unsliced_shape=tuple(self._frame.payload.sample_shape),
+            unsliced_shape=self._frame.payload.sample_shape,
             samples_per_frame=header.payloadsize * 8 // bps // nchan,
             sample_rate=sample_rate, squeeze=squeeze)
 
@@ -282,18 +282,16 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
 
             # Set decoded value for invalid data.
             self._frame.invalid_data_value = fill_value
-            # Decode data into array.
-            data = self._frame.data
-            if self.subset:
-                data = data[(slice(None),) + self.subset]
-            # Squeeze it if necessary.
-            if self.squeeze:
-                data = data.squeeze()
-            # Copy relevant data from frame into output.
+            # Determine appropriate slice to decode.
             nsample = min(count, self.samples_per_frame - sample_offset)
             sample = self.offset - offset0
-            out[sample:sample + nsample] = data[sample_offset:
-                                                sample_offset + nsample]
+            data_slice = slice(sample_offset, sample_offset + nsample)
+            if self.subset:
+                data_slice = (data_slice,) + self.subset
+            # Copy relevant data from frame into output.
+            out[sample:sample + nsample] = (
+                self._frame[data_slice].squeeze() if self.squeeze else
+                self._frame[data_slice])
             self.offset += nsample
             count -= nsample
 

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -190,8 +190,9 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
     ref_time : `~astropy.time.Time`, or None, optional
         Reference time within 500 days of the observation start time, used
         to infer the full MJD.  Only used if `kday` is ``None``.
-    thread_ids: list of int, optional
-        Specific channels to read.  By default, all channels are read.
+    subset : indexing object, optional
+        Specific components (ie. channels) of the complete sample to decode.
+        By default, all channels are read.
     sample_rate : `~astropy.units.Quantity`, optional
         Number of complete samples per second (ie. the rate at which each
         channel is sampled).  If not given, will be inferred from scanning
@@ -202,9 +203,10 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
     """
 
     _frame_class = Mark5BFrame
+    _sample_shape_maker = Mark5BPayload._sample_shape_maker
 
     def __init__(self, fh_raw, nchan, bps=2, kday=None, ref_time=None,
-                 thread_ids=None, sample_rate=None, squeeze=True):
+                 subset=None, sample_rate=None, squeeze=True):
         # Pre-set fh_raw, so FileReader methods work
         # TODO: move this to StreamReaderBase?
         self.fh_raw = fh_raw
@@ -212,11 +214,9 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
                                       ref_time=ref_time, kday=kday)
         self._frame_data = None
         header = self._frame.header
-        sample_shape = (Mark5BPayload._sample_shape_maker(len(thread_ids)) if
-                        thread_ids else self._frame.payload.sample_shape)
         super(Mark5BStreamReader, self).__init__(
-            fh_raw, header0=header, sample_shape=sample_shape, bps=bps,
-            complex_data=False, thread_ids=thread_ids,
+            fh_raw, header0=header, bps=bps, complex_data=False, subset=subset,
+            unsliced_shape=tuple(self._frame.payload.sample_shape),
             samples_per_frame=header.payloadsize * 8 // bps // nchan,
             sample_rate=sample_rate, squeeze=squeeze)
 
@@ -230,15 +230,15 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
         return last_header
 
     def read(self, count=None, fill_value=0., out=None):
-        """Read count samples.
+        """Read a number of complete (or subset) samples.
 
         The range retrieved can span multiple frames.
 
         Parameters
         ----------
         count : int
-            Number of samples to read.  If omitted or negative, the whole
-            file is read.  Ignored if ``out`` is given.
+            Number of complete/subset samples to read.  If omitted or negative,
+            the whole file is read.  Ignored if ``out`` is given.
         fill_value : float or complex
             Value to use for invalid or missing data.
         out : `None` or array
@@ -287,8 +287,8 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
             self._frame.invalid_data_value = fill_value
             # Decode data into array.
             data = self._frame.data
-            if self.thread_ids:
-                data = data[:, self.thread_ids]
+            if self.subset:
+                data = data[(slice(None),) + self.subset]
             # Copy relevant data from frame into output.
             nsample = min(count, self.samples_per_frame - sample_offset)
             sample = self.offset - offset0
@@ -338,15 +338,15 @@ class Mark5BStreamWriter(VLBIStreamWriterBase, Mark5BFileWriter):
     """
 
     _frame_class = Mark5BFrame
+    _sample_shape_maker = Mark5BPayload._sample_shape_maker
 
     def __init__(self, raw, sample_rate, nchan=1, bps=2, header=None,
                  squeeze=True, **kwargs):
         if header is None:
             header = Mark5BHeader.fromvalues(**kwargs)
-        sample_shape = Mark5BPayload._sample_shape_maker(nchan)
         super(Mark5BStreamWriter, self).__init__(
-            raw, header0=header, sample_shape=sample_shape, bps=bps,
-            complex_data=False, thread_ids=None,
+            raw, header0=header, unsliced_shape=(nchan,), bps=bps,
+            complex_data=False, subset=None,
             samples_per_frame=header.payloadsize * 8 // bps // nchan,
             sample_rate=sample_rate, squeeze=squeeze)
 
@@ -415,8 +415,9 @@ kday : int, or None, optional
 ref_time : `~astropy.time.Time`, or None, optional
     Reference time within 500 days of the observation start time, used to infer
     the full MJD.  Only used if `kday` is ``None``.
-thread_ids: list of int, optional
-    Specific threads to read.  By default, all threads are read.
+subset : slice or other indexing object, optional
+    Specific components (ie. channels) of the complete sample to decode.  By
+    default, all channels are read.
 sample_rate : `~astropy.units.Quantity`, optional
     Number of complete samples per second (ie. the rate at which each channel
     is sampled).  If not given, will be inferred from scanning one second of

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -404,8 +404,10 @@ class TestMark5B(object):
 
         # Read only some selected threads.
         with mark5b.open(SAMPLE_FILE, 'rs', nchan=8, bps=2,
-                         thread_ids=[4, 5], sample_rate=32*u.MHz,
+                         subset=[4, 5], sample_rate=32*u.MHz,
                          ref_time=Time(57000, format='mjd')) as fh:
+            assert fh.sample_shape == (2,)
+            assert fh.subset == ([4, 5],)
             record4 = fh.read(12)
         assert np.all(record4 == record[:, 4:6])
         # Read all data and check that it can be written out.
@@ -492,7 +494,8 @@ class TestMark5B(object):
 
         with mark5b.open(SAMPLE_FILE, 'rs', nchan=8, bps=2,
                          sample_rate=32*u.MHz, kday=56000,
-                         thread_ids=[0], squeeze=False) as fh:
+                         subset=0, squeeze=False) as fh:
+            assert fh.subset == (slice(0, 1),)
             assert fh.sample_shape == (1,)
             assert fh.sample_shape.nchan == 1
             assert fh.read(1).shape == (1, 1)

--- a/baseband/vdif/frame.py
+++ b/baseband/vdif/frame.py
@@ -258,11 +258,12 @@ class VDIFFrameSet(object):
             raise IOError("Could not find all requested frames.")
 
         if sort:
-            frames.sort(key=lambda frame: frame['thread_id'])
-            # If user gives thread_ids out of order, sort by user ordering.
+            # Sort by thread id, by user order if needed.
             if thread_ids:
                 frames.sort(key=lambda frame:
                             thread_ids.index(frame['thread_id']))
+            else:
+                frames.sort(key=lambda frame: frame['thread_id'])
 
         return cls(frames, header0)
 

--- a/baseband/vdif/frame.py
+++ b/baseband/vdif/frame.py
@@ -212,10 +212,11 @@ class VDIFFrameSet(object):
             The thread ids that should be read.  If `None`, continue reading
             threads as long as the frame number does not increase.
         sort : bool
-            Whether to sort the frames by thread_id.  Default: True.
+            Whether to sort the frames by `thread_ids`.  If `thread_ids` is
+            ``None``, sorts frames by their header thread_id.  Default: True.
             Note that this does not influence the header used to look up
-            attributes (it is always the header of the first frame read).
-            It does, however, influence the order in which decoded data is
+            attributes (it is always the header of the first frame read).  It
+            does, however, influence the order in which decoded data is
             returned.
         edv : int or None
             The expected extended data version for the VDIF Header.  If not
@@ -253,14 +254,15 @@ class VDIFFrameSet(object):
         else:  # Move back to before header that had incorrect frame_nr.
             fh.seek(-header.size, 1)
 
-        if thread_ids is None:
-            thread_ids = range(min(len(frames), 1))
-
-        if len(frames) < len(thread_ids):
+        if thread_ids and len(frames) < len(thread_ids):
             raise IOError("Could not find all requested frames.")
 
         if sort:
             frames.sort(key=lambda frame: frame['thread_id'])
+            # If user gives thread_ids out of order, sort by user ordering.
+            if thread_ids:
+                frames.sort(key=lambda frame:
+                            thread_ids.index(frame['thread_id']))
 
         return cls(frames, header0)
 

--- a/docs/baseband/dada/index.rst
+++ b/docs/baseband/dada/index.rst
@@ -52,7 +52,7 @@ writing is in units of samples, and provides access to header information.
     <DADAStreamReader name=... offset=0
         sample_rate=16.0 MHz, samples_per_frame=16000,
         sample_shape=SampleShape(npol=2), bps=8,
-        thread_ids=[0, 1], start_time=2013-07-02T01:39:20.000>
+        start_time=2013-07-02T01:39:20.000>
     >>> d = fh.read(10000)
     >>> d.shape
     (10000, 2)

--- a/docs/baseband/tutorials/getting_started.rst
+++ b/docs/baseband/tutorials/getting_started.rst
@@ -54,7 +54,7 @@ For the rest of this section, let's go back to using VDIF files.
 Decoding Data and the Sample File Pointer
 -----------------------------------------
 
-We gave `~baseband.vdif.open` the `'rs'` flag, which opens the file in 
+We gave `~baseband.vdif.open` the `'rs'` flag, which opens the file in
 "stream reader" mode.  The function returns an instance of
 `~baseband.vdif.base.VDIFStreamReader`, a wrapper around `io.BufferedReader`
 that adds methods to decode files as data frames and seek to and read data
@@ -100,8 +100,6 @@ retain them, we can pass ``squeeze=False`` to `~baseband.vdif.open`:
     (12, 8, 1)
     >>> fhns.close()
 
-``squeeze`` cannot be changed for an already-open file reader.
-
 We can access information about the file by printing ``fh``::
 
     >>> fh
@@ -113,7 +111,7 @@ We can access information about the file by printing ``fh``::
 
 The ``offset`` gives the current location of the sample file pointer - it's at
 ``12`` since we have read in 12 (complete) samples.  If we called ``fh.read
-(12)`` again we would get the next 12 samples.  If we instead called 
+(12)`` again we would get the next 12 samples.  If we instead called
 ``fh.read()``, it would read from the pointer's *current* position to the end
 of the file.  If we wanted all the data in one array, we would move the file
 pointer back to the start of file, using ``fh.seek``, before reading::
@@ -169,7 +167,7 @@ Passing the string ``'time'`` reports the pointer's location in absolute time::
     <Time object: scale='utc' format='isot' value=2014-06-16T05:56:07.001250000>
 
 We can also pass an absolute `astropy.time.Time`, or a positive or negative time
-difference `~astropy.time.TimeDelta` or `astropy.units.Quantity` to ``seek``. 
+difference `~astropy.time.TimeDelta` or `astropy.units.Quantity` to ``seek``.
 If the offset is a `~astropy.time.Time` object, the second argument to seek is
 ignored.
 
@@ -241,7 +239,7 @@ The full list of keywords is available by printing out ``header0``::
                  personality: 131>
 
 A number of derived properties, such as the time (as a `~astropy.time.Time`
-object), are also available through the header object.  
+object), are also available through the header object.
 
     >>> header0.time
     <Time object: scale='utc' format='isot' value=2014-06-16T05:56:07.000000000>
@@ -254,13 +252,13 @@ VDIF file's headers are of class::
 
 and so its attributes can be found `here <baseband.vdif.header.VDIFHeader3>`.
 
-Opening Specific Components of the Data
+Reading Specific Components of the Data
 ---------------------------------------
 
 By default, ``fh.read()`` returns complete samples, i.e. with all
 available threads, polarizations or channels. If we were only interested in
 decoding specific components of the complete sample, we can select them by
-passing indexing objects the ``subset`` keyword in open.  For example, if we
+passing indexing objects to the ``subset`` keyword in open.  For example, if we
 only wanted thread 3 of the sample VDIF file::
 
     >>> fh = vdif.open(SAMPLE_VDIF, 'rs', subset=3, squeeze=False)
@@ -275,8 +273,7 @@ only wanted thread 3 of the sample VDIF file::
 
 Since ``squeeze=False``, ``subset`` is converted from ``3`` to ``slice(3, 4,
 None)`` to retain dimensions of length unity.  This behaviour is turned off
-when ``squeeze=True`` (see below).  Like ``squeeze``, ``subset`` cannot be
-changed for an already-open file reader.
+when ``squeeze=True`` (see below).
 
 Data with multi-dimensional samples can be subset by passing a `tuple` of
 indexing objects with the same dimensional ordering as the sample shape prior
@@ -296,8 +293,7 @@ will only act upon the the first dimension::
     SampleShape(nthread=2, nchan=1)
     >>> fh.close()
 
-Here, we have also selected 1 and 3, and channel 0.  No enclosing `tuple` is
-required for data with single-dimensional samples.
+No enclosing `tuple` is required for data with single-dimensional samples.
 
 If ``squeeze=True``, dimensions of length unity are removed from the decoded
 data after subsetting::
@@ -307,14 +303,12 @@ data after subsetting::
     SampleShape(nthread=2)
     >>> fh.close()
 
-``subset`` accepts any object `that can be used to for basic indexing
-<https://docs.scipy.org/doc/numpy-1.13.0/reference/arrays.indexing.html>`_ of a
-`numpy.ndarray`, with the exceptions of ``None``.  Advanced indexing (as done
-above with ``subset=([1, 3], 0)``) is also possible, but any indexing that
-leads to a change in the number of dimensions will result in errors.  We can
-use broadcasting to select specific threads from more than one sample shape
-dimension; see the Numpy documentation on `integer array indexing.
-<https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html#integer-array-indexing>`_
+Generally, ``subset`` accepts any object that can be used to `index
+<https://docs.scipy.org/doc/numpy-1.13.0/reference/arrays.indexing.html>`_ a
+`numpy.ndarray`, including advanced indexing (as done above, with
+``subset=([1, 3], 0)``).  If possible, slices should be used instead
+of list of integers, since indexing with them returns a view rather
+than a copy and thus avoid unnecessary processing and memory allocation.
 
 .. note:: In the sample VDIF file, frames with even thread IDs have header
    timestamps that are offset from the odd-ID ones.  This is a known error in
@@ -404,7 +398,7 @@ offers wider compatibility, or better fits the structure of the data.  As an
 example, we convert the sample Mark 4 data to VDIF.
 
 Since we don't have a VDIF header handy, we pass the relevant Mark 4 header
-values into `vdif.open <baseband.vdif.open>` to create one. 
+values into `vdif.open <baseband.vdif.open>` to create one.
 
     >>> import baseband.mark4 as mark4
     >>> from baseband.data import SAMPLE_MARK4
@@ -445,6 +439,6 @@ For file format conversion in general, we have to consider how to properly
 scale our data to make the best use of the dynamic range of the new encoded
 format. For VLBI formats like VDIF, Mark 4 and Mark 5B, samples of the same
 size have the same scale, which is why we did not have to rescale our data when
-writing 2-bits-per-sample Mark 4 data to a 2-bits-per-sample VDIF file. 
+writing 2-bits-per-sample Mark 4 data to a 2-bits-per-sample VDIF file.
 Rescaling is necessary, though, to convert DADA or GSB to VDIF.  For examples
 of rescaling, see the ``baseband/tests/test_conversion.py`` file.

--- a/docs/baseband/vdif/index.rst
+++ b/docs/baseband/vdif/index.rst
@@ -99,7 +99,7 @@ coincidentally, what is given by the reader above suffices::
     ...                nthread=2, samples_per_frame=20000, nchan=1,
     ...                sample_rate=32*u.MHz, complex_data=False, bps=2, edv=3,
     ...                station=65532, time=Time('2014-06-16T05:56:07.000000000'))
-    >>> with vdif.open(SAMPLE_VDIF, 'rs', thread_ids=[2, 3]) as fh:
+    >>> with vdif.open(SAMPLE_VDIF, 'rs', subset=[1, 3]) as fh:
     ...    d = fh.read(20000)  # Get some data to write
     >>> fw.write(d)
     >>> fw.close()
@@ -128,6 +128,10 @@ For small files, one could just do::
     ...     fw.write(fr.read())
 
 This copies everything to memory, though, and some header information is lost.
+
+.. note:: In the sample VDIF file, frames with even thread IDs have header
+   timestamps that are offset from the odd-ID ones.  This is a known error in
+   the sample file.
 
 .. _vdif_troubleshooting:
 


### PR DESCRIPTION
Implemented the `subset` property in stream readers, which allows for selectively reading the components (threads, polarisation or channels) of a complete sample.  Any indexing object accepted by a `numpy.ndarray` can be used, except for `None`.  For multi-dimensional indexing, the enclosing structure must be a tuple (i.e. `(dim_1_indexer, dim_2_indexer, ...)`), so multi-dimensional arrays are not accepted.  Advanced indexing that changes the dimensions of the sample shape is also not possible, except for passing single integers since these are transformed into slices within `VLBIStreamBase._get_subset_and_sample_shape`.  Once set, `subset` is used as-is to slice frame data in all formats except VDIF, where threads and channels are sliced separately to retain the selective decoding of frameset frames.  `subset` is a read-only property because it is currently infeasible to re-read a frame every time `subset` changes.

Some notes on design choices:

- As noted above, if the user passes a single number `i` for one dimension, subset's setter turns it into `slice(i, i+1)`. This is because a `namedtuple` with N elements cannot be set with fewer than N objects, and figuring out which dimensions to excise from it (similar to what we do for squeezed shapes in the `sample_shape` getter) requires essentially the same machinery as for converting integers to slices in `subset`.  The latter, however, retains user control of squeezing.
- VDIF reads the first frameset twice now, the first time only to obtain the number of threads. This is ugly, but I'm happy to keep it as is if it turns out not to slow down data read-in very much. Alternatively, can create a `find_nthreads` method in `VDIFFileReader`.
- For consistency with other formats, I'm currently allowing VDIF frames to be returned in the thread ID order the user wishes.  I don't think my implementation of this is self-consistent though, since I still use `return cls(frames, header0)` at the end of `VDIFFrameSet.fromfile`.  Switching that just to `return cls(frames)` gives me a bunch of time offset errors in the test suite I don't fully understand.
- I haven't decided if `_unsliced_shape` should be a tuple or named tuple. Since we use it in a few places (VDIF, GSB) to read new frames, we could initialize `_unsliced_shape` as a genuine sample shape at the same time as `_sample_shape`.