### PR TITLE
Setup and documentation files for release

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,4 +1,25 @@
-E-mail addresses (parentheses) end in @astro.utoronto.ca.
+*******************
+Authors and Credits
+*******************
 
-* Marten van Kerkwijk (mhvk)
-* Chenchong Charles Zhu (cczhu)
+Baseband Project Contributors
+=============================
+
+Authors
+-------
+
+* Marten van Kerkwijk (@mhvk)
+* Chenchong Charles Zhu (@cczhu)
+
+
+Alphabetical list of contributors
+---------------------------------
+
+* Rebecca Lin (@00rebe)
+* Nikhil Mahajan (@theXYZT)
+* Robert Main (@ramain)
+* Dana Simard (@danasimard)
+
+If you have contributed to Baseband but are not listed above, please send one
+of the authors an e-mail, or `open a pull request for this page
+<https://github.com/mhvk/baseband/edit/master/AUTHORS.rst>`_.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,4 @@
+1.0.0 (Unreleased)
+------------------
+
+- Initial release.

--- a/README.rst
+++ b/README.rst
@@ -43,5 +43,8 @@ ASCL for ADS link?  Zenodo?
 License
 -------
 
-Baseband is licensed under the GNU General Public License v3.0 - see
-LICENSE.rst.
+Baseband is licensed under the GNU General Public License v3.0 - see the
+``LICENSE`` file.
+
+.. _@mhvk: https://github.com/mhvk
+.. _@cczhu: https://github.com/cczhu

--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,48 @@
-Baseband data input and output
-==============================
+Baseband: a Package for Radio Baseband I/O
+==========================================
 
 .. image:: http://img.shields.io/badge/powered%20by-AstroPy-orange.svg?style=flat
     :target: http://www.astropy.org
     :alt: Powered by Astropy Badge
 
-This is a package for reading and writing VLBI and other radio baseband
-files. It relies on numpy and astropy.  
+Baseband is a package for reading and writing VLBI and other radio baseband
+files, with the aim of simplifying and streamlining data conversion and
+standardization.  It relies on NumPy and Astropy.
 
 For installation and usage instructions, please see the `online documentation 
 <https://baseband.readthedocs.io/>`_.
+
+Project Status
+--------------
+
+.. image:: https://travis-ci.org/mhvk/baseband.svg?branch=master
+    :target: https://travis-ci.org/mhvk/baseband
+    :alt: Baseband's Travis CI Status
+
+.. image:: https://coveralls.io/repos/github/mhvk/baseband/badge.svg?branch=master
+    :target: https://coveralls.io/github/mhvk/baseband?branch=master
+    :alt: Baseband's Coveralls Status
+
+Contributing
+------------
+
+Please open a new issue for bugs, feedback or feature requests. 
+
+We welcome code contributions, in particular support for new file formats! 
+To add a contribution, please submit a pull request.  If you would like
+assistance in using GitHub or how to begin modifying Baseband, please feel free
+to contact @mhvk or @cczhu.
+
+For more information on how to make code contributions, please see the `Astropy
+developer documentation <http://docs.astropy.org/en/stable/index.html#developer-documentation)>`_.
+
+Citation
+--------
+
+ASCL?
+
+License
+-------
+
+Baseband is licensed under the GNU General Public License v3.0 - see the
+LICENSE file.

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,8 @@ Baseband: a Package for Radio Baseband I/O
 
 Baseband is a package for reading and writing VLBI and other radio baseband
 files, with the aim of simplifying and streamlining data conversion and
-standardization.  It relies on NumPy and Astropy.
+standardization.  It relies on `NumPy <http://www.numpy.org/>`_ and `Astropy
+<http://www.astropy.org/>`_.
 
 For installation and usage instructions, please see the `online documentation 
 <https://baseband.readthedocs.io/>`_.
@@ -16,8 +17,6 @@ Project Status
 --------------
 
 .. image:: https://travis-ci.org/mhvk/baseband.svg?branch=master
-    :target: https://travis-ci.org/mhvk/baseband
-    :alt: Baseband's Travis CI Status
 
 .. image:: https://coveralls.io/repos/github/mhvk/baseband/badge.svg?branch=master
     :target: https://coveralls.io/github/mhvk/baseband?branch=master
@@ -31,7 +30,7 @@ Please open a new issue for bugs, feedback or feature requests.
 We welcome code contributions, in particular support for new file formats! 
 To add a contribution, please submit a pull request.  If you would like
 assistance in using GitHub or how to begin modifying Baseband, please feel free
-to contact @mhvk or @cczhu.
+to contact `@mhvk`_ or `@cczhu`_.
 
 For more information on how to make code contributions, please see the `Astropy
 developer documentation <http://docs.astropy.org/en/stable/index.html#developer-documentation)>`_.
@@ -39,10 +38,10 @@ developer documentation <http://docs.astropy.org/en/stable/index.html#developer-
 Citation
 --------
 
-ASCL?
+ASCL for ADS link?  Zenodo?
 
 License
 -------
 
-Baseband is licensed under the GNU General Public License v3.0 - see the
-LICENSE file.
+Baseband is licensed under the GNU General Public License v3.0 - see
+LICENSE.rst.

--- a/README.rst
+++ b/README.rst
@@ -19,8 +19,8 @@ Project Status
 .. image:: https://travis-ci.org/mhvk/baseband.svg?branch=master
 
 .. image:: https://coveralls.io/repos/github/mhvk/baseband/badge.svg?branch=master
-    :target: https://coveralls.io/github/mhvk/baseband?branch=master
-    :alt: Baseband's Coveralls Status
+   :target: https://coveralls.io/github/mhvk/baseband?branch=master
+
 
 Contributing
 ------------
@@ -34,11 +34,6 @@ to contact `@mhvk`_ or `@cczhu`_.
 
 For more information on how to make code contributions, please see the `Astropy
 developer documentation <http://docs.astropy.org/en/stable/index.html#developer-documentation)>`_.
-
-Citation
---------
-
-ASCL for ADS link?  Zenodo?
 
 License
 -------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,7 @@
+.. _changelog:
+
+**************
+Full Changelog
+**************
+
+.. include:: ../CHANGES.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,6 +79,12 @@ format extensions such as VDIF EDV.
 Project details
 ===============
 
+.. image:: https://travis-ci.org/mhvk/baseband.svg?branch=master
+
+.. image:: https://coveralls.io/repos/github/mhvk/baseband/badge.svg?branch=master
+    :target: https://coveralls.io/github/mhvk/baseband?branch=master
+    :alt: Baseband's Coveralls Status
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,3 +83,5 @@ Project details
    :maxdepth: 1
 
    authors_for_sphinx
+   changelog
+   license

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -8,7 +8,7 @@ Requirements
 
 Baseband requires:
 
-    - `Astropy`_ v1.0.4 or later
+    - `Astropy`_ v2.0 or later
     - `Numpy <http://www.numpy.org/>`_ v1.9 or later
 
 .. _installation:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -16,14 +16,18 @@ Baseband requires:
 Installing Baseband
 ===================
 
-.. Using pip
-   ---------
+Using pip
+---------
 
-   Baseband currently cannot be built with `pip <http://www.pip-installer.org/en/latest/>`_,
-   but eventually...
+To install Baseband with `pip <http://www.pip-installer.org/en/latest/>`_,
+run::
 
-Currently, Baseband can only be installed by getting its source code,
-and either running it directly or installing it.
+    pip3 install baseband
+
+.. note::
+
+    To run without pip potentially updating Numpy and Astropy, run, include the
+    ``--no-deps`` flag.
 
 Obtaining source code
 ---------------------

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,0 +1,13 @@
+.. _license:
+
+********
+Licenses
+********
+
+Baseband License
+================
+
+Baseband is licensed under the GNU General Public License v3.0:
+
+.. include:: ../LICENSE
+    :literal:

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -7,7 +7,6 @@ Licenses
 Baseband License
 ================
 
-Baseband is licensed under the GNU General Public License v3.0:
-
-.. include:: ../LICENSE
-    :literal:
+Baseband is licensed under the `GNU General Public License v3.0
+<https://www.gnu.org/licenses/gpl-3.0.en.html>`_.  The full text
+of the license can be found in ``LICENSE`` under Baseband's root directory.

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,16 +39,16 @@ exclude=
 
 [metadata]
 package_name = baseband
-description = Radio baseband data
+description = Radio baseband data I/O
 long_description = This is a package for reading and writing VLBI and other radio baseband files. It relies on numpy and astropy.
-author = Marten H. van Kerkwijk
+author = Marten H. van Kerkwijk, Chenchong Zhu
 author_email = mhvk@astro.utoronto.ca
 license = GPLv3
 edit_on_github = True
 github_project = mhvk/baseband
 install_requires = astropy
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 0.0.dev
+version = 1.0.0rc1
 url = https://baseband.readthedocs.io
 
 [entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,8 +47,8 @@ license = GPLv3
 edit_on_github = True
 github_project = mhvk/baseband
 install_requires = astropy
-# version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 1.0.0rc1
+# Version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
+version = 0.0.0.dev
 url = https://baseband.readthedocs.io
 
 [entry_points]


### PR DESCRIPTION
Updates to root directory readme and config files, and additional changelog and license sections to the documentation.  These are separate from the source code and most of the docs, so can just be rebased with master before final release on PyPi.

Currently this branch builds into my bare Python2 and Python3 virtualenvs with `pip install -e`, and tests run successfully.

Things to consider before merging this PR:

- Not sure how to include LICENSE.rst as a block of text in the documentation without inciting an error.
- I can try to get a Zenodo DOI for citation, or registry on the Astrophysics Source Code Library before PyPi release.  If we elect to do these after release, then under `Citation` we should recommend citing the GitHub link directly.
- Maybe we should add our astro e-mail addresses to our profiles.
- This repo might need to be moved out of @mhvk's profile.