### PR TITLE
Glossary and Format Documentation

### DIFF
--- a/baseband/dada/header.py
+++ b/baseband/dada/header.py
@@ -312,7 +312,7 @@ class DADAHeader(OrderedDict):
 
     @property
     def bps(self):
-        """Bits per sample (or real/imaginary part)."""
+        """Bits per elementary sample."""
         return self['NBIT']
 
     @bps.setter

--- a/baseband/gsb/base.py
+++ b/baseband/gsb/base.py
@@ -192,7 +192,7 @@ class GSBStreamReader(GSBStreamBase, VLBIStreamReaderBase):
     sample_rate : `~astropy.units.Quantity`, optional
         Number of complete samples per second (ie. the rate at which each
         channel of each polarization is sampled).  If not given, will be
-        inferred assuming the framerate is exactly 251.658240 ms.
+        inferred assuming the framerate is exactly 0.25165824 s.
     nchan : int, optional
         Number of channels. Default is `None`, which sets it to 1 for rawdump,
         512 for phased.
@@ -367,7 +367,7 @@ class GSBStreamWriter(GSBStreamBase, VLBIStreamWriterBase):
     sample_rate : `~astropy.units.Quantity`, optional
         Number of complete samples per second (ie. the rate at which each
         channel of each polarization is sampled).  If not given, will be
-        inferred assuming the framerate is exactly 251.658240 ms.
+        inferred assuming the framerate is exactly 0.25165824 s.
     header : `~baseband.gsb.GSBHeader`, optional
         Header for the first frame, holding time information, etc.
     nchan : int, optional

--- a/baseband/mark4/header.py
+++ b/baseband/mark4/header.py
@@ -542,7 +542,7 @@ class Mark4Header(Mark4TrackHeader):
 
     @property
     def bps(self):
-        """Number of bits per sample (either 1 or 2).
+        """Bits per elementary sample (either 1 or 2).
 
         If set, combined with ``fanout`` and ``ntrack`` to updates
         ``magnitude_bit`` for all tracks.

--- a/baseband/vdif/header.py
+++ b/baseband/vdif/header.py
@@ -281,7 +281,7 @@ class VDIFHeader(VLBIHeaderBase):
 
     @property
     def bps(self):
-        """Bits per sample (adding bits for imaginary and real for complex)."""
+        """Bits per elementary sample."""
         return self['bits_per_sample'] + 1
 
     @bps.setter
@@ -291,7 +291,7 @@ class VDIFHeader(VLBIHeaderBase):
 
     @property
     def nchan(self):
-        """Number of channels in frame."""
+        """Number of channels in the frame."""
         return 2**self['lg2_nchan']
 
     @nchan.setter
@@ -302,7 +302,7 @@ class VDIFHeader(VLBIHeaderBase):
 
     @property
     def samples_per_frame(self):
-        """Number of complete samples encoded in the frame."""
+        """Number of complete samples in the frame."""
         # Values are not split over word boundaries.
         values_per_word = 32 // self.bps // (2 if self['complex_data'] else 1)
         # samples are not split over payload boundaries.

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -194,7 +194,7 @@ class VLBIStreamBase(VLBIFileBase):
 
     @property
     def bps(self):
-        """Number of bits for each part (real or imaginary) of a sample."""
+        """Bits per elementary sample."""
         return self._bps
 
     @property

--- a/docs/baseband/dada/index.rst
+++ b/docs/baseband/dada/index.rst
@@ -4,46 +4,50 @@
 DADA
 ****
 
-Distributed Acquisition and Data Analysis (DADA) format data files contain an
-ASCII header of typically 4096 bytes followed by a payload.
+Distributed Acquisition and Data Analysis (DADA) format data files contain a
+single :term:`data frame` consisting of an ASCII :term:`header` of typically
+4096 bytes followed by a :term:`payload`.
 
 .. _dada_usage:
 
 Usage
 =====
 
-This section covers DADA-specific features of Baseband.  Tutorials for general
-usage can be found under the :ref:`Using Baseband <using_baseband_toc>` section.
-The examples below use the small sample file ``baseband/data/sample.dada``,
-and assume the `astropy.units` and `baseband.dada` modules have been imported::
+This section covers reading and writing DADA files with Baseband; general usage
+is covered in the :ref:`Using Baseband <using_baseband_toc>` section.  The
+examples below use the sample file ``baseband/data/sample.dada``, and the
+the `astropy.units` and `baseband.dada` modules::
 
     >>> from baseband import dada
     >>> import astropy.units as u
     >>> from baseband.data import SAMPLE_DADA
 
-Single files can be opened with :func:`~baseband.dada.open` in binary mode. 
-Dada files consist of just a single header and payload, and can be read into a
-single :class:`~baseband.dada.DADAFrame`.
+Single files can be opened with `~baseband.dada.open` in binary mode. 
+DADA files typically consist of just a single header and payload, and can be
+read into a single `~baseband.dada.DADAFrame`.
 
 ::
 
-    >>> fh = dada.open(SAMPLE_DADA, 'rb')
-    >>> frame = fh.read_frame()
+    >>> fb = dada.open(SAMPLE_DADA, 'rb')
+    >>> frame = fb.read_frame()
     >>> frame.shape
     (16000, 2, 1)
     >>> frame[:3].squeeze()
     array([[ -38.-38.j,  -38.-38.j],
            [ -38.-38.j,  -40. +0.j],
            [-105.+60.j,   85.-15.j]], dtype=complex64)
-    >>> fh.close()
+    >>> fb.close()
 
-Since the files can be quite large, the payload is mapped, so that if one
-accesses part of the data, only the corresponding parts of the encoded payload
-are loaded into memory (since the sample file is encoded using 8 bits, the
-above example thus loads 12 bytes into memory).
+Since the files can be quite large, the payload is mapped (with
+`numpy.memmap`), so that if one accesses part of the data, only the
+corresponding parts of the encoded payload are loaded into memory (since the
+sample file is encoded using 8 bits, the above example thus loads 12 bytes into
+memory).
 
 Opening in stream mode wraps the low-level routines such that reading and
-writing is in units of samples, and provides access to header information.
+writing is in units of samples, and provides access to header information.  For
+a full list of parameters that can be passed to `~baseband.dada.open` in
+stream mode, see its API entry.
 
 ::
 
@@ -83,6 +87,10 @@ even smaller size of the payload, to show how one can define multiple files.
     >>> (d == d2).all()
     True
     >>> fr.close()
+
+For a full list of parameters, including header keywords, that can be passed to
+`~baseband.dada.open` in stream writing mode, see the
+`~baseband.dada.base.DADAStreamWriter` API entry.
 
 .. _dada_api:
 

--- a/docs/baseband/gsb/index.rst
+++ b/docs/baseband/gsb/index.rst
@@ -1,14 +1,244 @@
 .. _gsb:
 
+.. include:: ../tutorials/glossary_substitutions.rst
+
 ***
 GSB
 ***
 
 The GMRT software backend (GSB) file format is the standard output of
-the `Giant Metrewave Radio Telescope (GMRT) <http://www.gmrt.ncra.tifr.res.in/>`_.
-Specifications, design notes and operating procedures for the software
-backend are found 
-`here <http://gmrt.ncra.tifr.res.in/gmrt_hpage/sub_system/gmrt_gsb/index.htm>`_.
+the initial correlator of the `Giant Metrewave Radio Telescope (GMRT)
+<http://www.gmrt.ncra.tifr.res.in/>`_.  The GSB design is described by Roy et
+al. (`2010, Exper. Astron. 28:25-60 <https://doi.org/10.1007%2Fs10686-010-9187-0>`_)
+with further specifications and operating procedures given on the relevant
+`GMRT/GSB pages <http://gmrt.ncra.tifr.res.in/gmrt_hpage/sub_system/gmrt_gsb/index.htm>`_.
+
+.. _gsb_file_structure:
+
+File Structure
+==============
+
+A GSB dataset consists of an ASCII file with a sequence of |headers|,
+and one or more accompanying binary data files.  Each line in the header and
+its corresponding data comprise a :term:`data frame`, though these do not have
+explicit divisions in the data files.
+
+Baseband currently supports two forms of GSB data: **rawdump**, for storing
+real-valued raw voltage timestreams, and **phased**, for storing complex
+pre-channelized data from the GMRT in phased array baseband mode.
+
+Data in `rawdump format <http://gmrt.ncra.tifr.res.in/gmrt_hpage/sub_system/
+gmrt_gsb/GSB_rawdump_data_format_v2.pdf>`_ is stored in a binary file
+representing the voltage stream from one polarization of a single dish.  Each
+such file is accompanied by a header file which contains GPS timestamps, in the
+form::
+
+    YYYY MM DD HH MM SS 0.SSSSSSSSS 
+
+In the default rawdump observing setup, samples are recorded at a rate of
+33.3333... megasamples per second (Msps).  Each sample is 4 bits in size, and
+two samples are grouped into bytes such that the oldest sample occupies
+the least significant bit.  Each frame consists of **4 megabytes** of data,
+or :math:`2^{23}`, samples; as such, the timespan of one frame is exactly
+**0.25165824 s**.
+
+Data in `phased format <http://gmrt.ncra.tifr.res.in/gmrt_hpage/sub_system/
+gmrt_gsb/GSB_beam_timestamp_note_v1.pdf>`_ is normally spread over four binary
+files and one accompanying header file.  The binary files come in two pairs,
+one for each polarization, with the pair contain the first and second half of
+the data of each frame.
+
+When recording GSB in phased array voltage beam (ie. baseband) mode, the "raw",
+or pre-channelized, :term:`sample rate` is either 33.3333... Msps at 8 bits per
+sample or 66.6666... Msps at 4 bits per sample (in the latter case, sample
+bit-ordering is the same as for rawdump).   Channelization via fast Fourier
+transform sets the channelized :term:`complete sample` rate to the raw rate
+divided by :math:`2N_\mathrm{F}`, where :math:`N_\mathrm{F}` is the number of
+Fourier channels (either 256 or 512). The timespan of one frame is **0.25165824
+s**, and one frame is **8 megabytes** in size, for either raw sample rate.
+
+The phased header's structure is::
+
+    <PC TIME> <GPS TIME> <SEQ NUMBER> <MEM BLOCK>
+
+where ``<PC TIME>`` and ``<GPS TIME>`` are the less accurate computer-based
+and exact GPS-based timestamps, respectively, with the same format as the
+rawdump timestamp; ``<SEQ NUMBER>`` is the frame number; and ``<MEM BLOCK>``
+a redundant modulo-8 shared memory block number.
+
+.. _gsb_usage:
+
+Usage Notes
+===========
+
+This section covers reading and writing GSB files with Baseband; general usage
+is covered in the :ref:`Using Baseband <using_baseband_toc>` section.
+The examples below use the sample files in the ``baseband/data/gsb/``
+directory, and the `numpy`, `astropy.units` and `baseband.gsb` modules::
+
+    >>> import numpy as np
+    >>> import astropy.units as u
+    >>> from baseband import gsb
+    >>> from baseband.data import (
+    ...     SAMPLE_GSB_RAWDUMP, SAMPLE_GSB_RAWDUMP_HEADER,
+    ...     SAMPLE_GSB_PHASED, SAMPLE_GSB_PHASED_HEADER)
+
+A single timestamp file can be opened with `~baseband.gsb.open` in text
+mode::
+
+    >>> ft = gsb.open(SAMPLE_GSB_RAWDUMP_HEADER, 'rt')
+    >>> ft.read_timestamp()
+    <GSBRawdumpHeader gps: 2015 04 27 18 45 00 0.000000240>
+    >>> ft.close()
+
+Reading payloads requires the samples per frame or sample rate.  For phased the
+sample rate is::
+
+    sample_rate = raw_sample_rate / (2 * nchan)
+
+where the raw sample rate is the pre-channelized one, and `nchan` the number
+of Fourier channels.  The samples per frame for both rawdump and phased is::
+
+    samples_per_frame = timespan_of_frame * sample_rate
+
+.. note::
+    Since the number of samples per frame is an integer number while
+    both the frame timespan and sample rate are not, it is better to separately
+    caculate ``samples_per_frame`` rather than multiplying
+    ``timespan_of_frame`` with ``sample_rate`` in order to avoid rounding
+    issues.
+
+Alternatively, if the size of the frame buffer and the framerate are known, the
+former can be used to determine ``samples_per_frame``, and the latter used to
+determine ``sample_rate`` by inverting the above equation.
+
+If ``samples_per_frame`` is not given, Baseband assumes it is the equivalent of
+4 megabytes of data for rawdump, or 8 megabytes if phased.  If ``sample_rate``
+is not given, it is calculated from ``samples_per_frame`` assuming
+``timespan_of_frame = 0.25165824`` (see :ref:`File Structure
+<gsb_file_structure>` above).
+
+A single payload file can be opened with `~baseband.gsb.open` in binary mode.
+Here, for our sample file, we have to take into account that in order to keep
+these files small, their sample size has been reduced to only **4 or 8
+kilobytes** worth of samples per frame (for the default timespan).  So, we
+define their sample rate here, and use that to calculate ``payloadsize``,
+the size of one frame in bytes.  Since rawdump samples are 4 bits,
+``payloadsize`` is just ``samples_per_frame / 2``::
+
+    >>> rawdump_samples_per_frame = 2**13
+    >>> payloadsize = rawdump_samples_per_frame // 2
+    >>> fb = gsb.open(SAMPLE_GSB_RAWDUMP, 'rb')
+    >>> payload = fb.read_payload(payloadsize, nchan=1, bps=4,
+    ...                           complex_data=False)
+    >>> payload[:4]
+    array([[ 0.],
+           [-2.],
+           [-2.],
+           [ 0.]], dtype=float32)
+    >>> fb.close()
+
+(``payloadsize`` for phased data is the size of one frame *divided by the
+number of binary files*.)
+
+Opening in stream mode allows timestamp and binary files to be read in
+concert to create data frames, and also wraps the low-level routines such that
+reading and writing is in units of samples, and provides access to header
+information.  For a full list of parameters that can be passed to
+`~baseband.gsb.open` in stream mode, see its API entry.
+
+When opening a rawdump file in stream mode, we pass the timestamp file as the
+first argument, and the binary file to the ``raw`` keyword.  As per above, we
+also pass ``samples_per_frame``::
+
+    >>> fh_rd = gsb.open(SAMPLE_GSB_RAWDUMP_HEADER, mode='rs',
+    ...                  raw=SAMPLE_GSB_RAWDUMP,
+    ...                  samples_per_frame=rawdump_samples_per_frame)
+    >>> fh_rd.header0
+    <GSBRawdumpHeader gps: 2015 04 27 18 45 00 0.000000240>
+    >>> dr = fh_rd.read()
+    >>> dr.shape
+    (81920,)
+    >>> dr[:3]
+    array([ 0., -2., -2.], dtype=float32)
+    >>> fh_rd.close()
+
+To open a phased fileset in stream mode, we package the binary files into a
+nested tuple with the format::
+
+    ((L pol stream 1, L pol stream 2), (R pol stream 1, R pol stream 2))
+
+The nested tuple is passed to ``raw`` (note that we again have to pass a
+non-default sample rate)::
+
+    >>> phased_samples_per_frame = 2**3
+    >>> fh_ph = gsb.open(SAMPLE_GSB_PHASED_HEADER, mode='rs',
+    ...                  raw=SAMPLE_GSB_PHASED,
+    ...                  samples_per_frame=phased_samples_per_frame)
+    >>> header0 = fh_ph.header0     # To be used for writing, below.
+    >>> dp = fh_ph.read()
+    >>> dp.shape
+    (80, 2, 512)
+    >>> dp[0, 0, :3]    # doctest: +FLOAT_CMP
+    array([30.+12.j, -1. +8.j,  7.+19.j], dtype=complex64)
+    >>> fh_ph.close()
+
+To set up a file for writing, we need to pass names for both
+timestamp and raw files, as well as ``sample_rate``, ``samples_per_frame``, and
+either the first header or a ``time`` object.  We first calculate
+``sample_rate``::
+
+    >>> timespan = 0.25165824 * u.s
+    >>> rawdump_sample_rate = (rawdump_samples_per_frame / timespan).to(u.MHz)
+    >>> phased_sample_rate = (phased_samples_per_frame / timespan).to(u.MHz)
+
+To write a rawdump file::
+
+    >>> from astropy.time import Time
+    >>> fw_rd = gsb.open('test_rawdump.timestamp',
+    ...                  mode='ws', raw='test_rawdump.dat',
+    ...                  sample_rate=rawdump_sample_rate,
+    ...                  samples_per_frame=rawdump_samples_per_frame,
+    ...                  time=Time('2015-04-27T13:15:00'))
+    >>> fw_rd.write(dr)
+    >>> fw_rd.close()
+    >>> fh_rd = gsb.open('test_rawdump.timestamp', mode='rs',
+    ...                  raw='test_rawdump.dat',
+    ...                  sample_rate=rawdump_sample_rate,
+    ...                  samples_per_frame=rawdump_samples_per_frame)
+    >>> np.all(dr == fh_rd.read())
+    True
+    >>> fh_rd.close()
+
+To write a phased file, we need to pass a nested tuple of filenames or
+filehandles::
+
+    >>> test_phased_bin = (('test_phased_pL1.dat', 'test_phased_pL2.dat'),
+    ...                    ('test_phased_pR1.dat', 'test_phased_pR2.dat'))
+    >>> fw_ph = gsb.open('test_phased.timestamp',
+    ...                  mode='ws', raw=test_phased_bin,
+    ...                  sample_rate=phased_sample_rate,
+    ...                  samples_per_frame=phased_samples_per_frame,
+    ...                  header=header0)
+    >>> fw_ph.write(dp)
+    >>> fw_ph.close()
+    >>> fh_ph = gsb.open('test_phased.timestamp', mode='rs',
+    ...                  raw=test_phased_bin,
+    ...                  sample_rate=phased_sample_rate,
+    ...                  samples_per_frame=phased_samples_per_frame)
+    >>> np.all(dp == fh_ph.read())
+    True
+    >>> fh_ph.close()
+
+Baseband does not use the PC time in the phased header, and, when writing,
+simply uses the same time for both GPS and PC times.  Since the PC time can
+drift from the GPS time by several tens of milliseconds,
+``test_phased.timestamp`` will not be identical to ``SAMPLE_GSB_PHASED``, even
+though we have written the exact same data to file.
+
+For a full list of parameters, including header keywords, that can be passed to
+`~baseband.gsb.open` in stream writing mode, see the
+`~baseband.gsb.base.GSBStreamWriter` API entry.
 
 .. _gsb_api:
 

--- a/docs/baseband/index.rst
+++ b/docs/baseband/index.rst
@@ -24,6 +24,7 @@ Using Baseband
    :maxdepth: 1
 
    tutorials/getting_started
+   tutorials/glossary
 
 .. _specific_file_formats_toc:
 

--- a/docs/baseband/mark4/index.rst
+++ b/docs/baseband/mark4/index.rst
@@ -1,53 +1,112 @@
 .. _mark4:
 
+.. include:: ../tutorials/glossary_substitutions.rst
+
 ******
 MARK 4
 ******
 
-The Mark 4 VLBI format is described in the `Mark IIIA/IV/VLBA documentation
-<http://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf>`_.
+The Mark 4 format is the output format of the MIT Haystack Observatory's Mark 4
+VLBI magnetic tape-based data acquisition system, and one output format of its
+successor, the Mark 5A hard drive-based system. The format's specification is
+in the `Mark IIIA/IV/VLBA documentation <m4spec>`_.
+
+Baseband currently only supports files that have been parity-stripped and
+corrected for barrel roll and data modulation.
+
+.. _m4spec: http://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
+
+.. _mark4_file_structure:
+
+File Structure
+==============
+
+Mark 4 files contain up to 64 concurrent data "tracks".  Tracks are divided
+into 22500-bit "tape frames", each of which consists of a 160-bit
+:term:`header` followed by a 19840-bit :term:`payload`.  The header includes a
+timestamp (accurate to 1.25 ms), track ID, sideband, and fan-out/in factor
+(see below); the details of these can be found in 2.1.1 - 2.1.3 in the
+`specification document <m4spec>`_.  The payload consists of a 1-bit
+:term:`stream`.  When recording 2-bit |elementary samples|, the data is split
+into two tracks, with one carrying the sign bit, and the other the magnitude
+bit.
+
+The header takes the place of the first 160 bits of payload data, so that the
+first sample occurs ``fanout * 160`` sample times after the header time.  This
+means that a Mark 4 stream is not contiguous in time.  The length of
+one frame ranges from 1.25 ms to 160 ms in octave steps (which ensures an
+integer number of frames falls within 1 minute), setting the maximum sample
+rate per track to 18 megabits/track/s.
+
+Data from a single :term:`channel` may be distributed to multiple tracks -
+"fan-out" - or multiple channels fed to one track - "fan-in".  Fan-out
+is used when sampling at rates higher than 18 megabits/track/s.  Baseband
+currently only supports tracks using fan-out ("longitudinal data format").
+
+Baseband reconstructs the tracks into channels (reconstituting 2-bit data from
+two tracks into a single channel if necessary) and combines tape
+frame headers into a single :term:`data frame` header.
 
 .. _mark4_usage:
 
 Usage
 =====
 
-This section covers Mark 4-specific features of Baseband.  Tutorials for general
+This section covers reading and writing Mark 4 files with Baseband; general
 usage can be found under the :ref:`Using Baseband <using_baseband_toc>` section.
-The examples below use the small sample file ``baseband/data/sample.m4``,
-and assumes the `numpy`, `astropy.units`, and `baseband.mark4` modules have
-been imported::
+The examples below use the small sample file ``baseband/data/sample.m4``, and
+the `numpy`, `astropy.units`, `astropy.time.Time`, and `baseband.mark4`
+modules::
 
     >>> import numpy as np
     >>> import astropy.units as u
+    >>> from astropy.time import Time
     >>> from baseband import mark4
     >>> from baseband.data import SAMPLE_MARK4
 
-Opening a Mark 4 file with :func:`~baseband.mark4.open` in binary mode provides
+Opening a Mark 4 file with `~baseband.mark4.open` in binary mode provides
 a normal file reader but extended with methods to read a
-:class:`~baseband.mark4.Mark4Frame`.  Mark 4 data files generally do not start 
-(or end) at a frame boundary, so in binary mode one has to seek the first frame
-using `~baseband.mark4.base.Mark4StreamReader.find_frame`.  One also has to pass
-in the number of tracks used to `~baseband.mark4.base.Mark4StreamReader.read_frame`,
-and the decade the data were taken, since those numbers cannot be inferred from
-the data themselves::
+`~baseband.mark4.Mark4Frame`.  Mark 4 files generally **do not start (or end)
+at a frame boundary**, so in binary mode one has to seek the
+first frame using `~baseband.mark4.base.Mark4FileReader.find_frame`.  To use
+`~baseband.mark4.base.Mark4FileReader.find_frame` and 
+`~baseband.mark4.base.Mark4FileReader.read_frame`, one must pass both the
+number of tracks, and either the decade the data was taken, or an equivalent
+reference `~astropy.time.Time` object, since those numbers cannot be inferred
+from the data themselves::
 
-    >>> fh = mark4.open(SAMPLE_MARK4, 'rb')
-    >>> fh.find_frame(ntrack=64)    # Find first frame.
+    >>> fb = mark4.open(SAMPLE_MARK4, 'rb')
+    >>> fb.find_frame(ntrack=64)    # Find first frame.
     2696
-    >>> frame = fh.read_frame(ntrack=64, decade=2010)
+    >>> frame = fb.read_frame(ntrack=64, decade=2010)
     >>> frame.shape
     (80000, 8)
-    >>> fh.close()
 
-Opening in stream mode automatically seeks for the first frame, and wraps the
+If one does not know the number of tracks, one can attempt to determine
+this using `~baseband.mark4.base.Mark4FileReader.determine_ntracks`
+(which will leave the file pointer at the start of a frame as well)::
+
+    >>> fb.seek(0)
+    0
+    >>> ntrack = fb.determine_ntrack()    # Also finds first frame.
+    >>> ntrack
+    64
+    >>> frame2 = fb.read_frame(ntrack=ntrack, decade=2010)
+    >>> frame2 == frame
+    True
+    >>> fb.close()
+
+Opening in stream mode automatically seeks for the first frame (determing
+the number of tracks if not given explicitly), and wraps the
 low-level routines such that reading and writing is in units of samples.  It
-also provides access to header information.  In lieu of ``decade``, one may
-also provide a reference time within 4 years of the observation start time::
+also provides access to header information.  Here we pass a reference
+`~astropy.time.Time` object within 4 years of the observation start time to
+``ref_time``, rather than a ``decade``.  For a full list of parameters that can
+be passed to `~baseband.mark4.open` in stream mode, see its API entry.
 
-    >>> from astropy.time import Time
-    >>> fh = mark4.open(SAMPLE_MARK4, 'rs', ntrack=64,
-    ...                 ref_time=Time('2013:100:23:00:00'))
+::
+
+    >>> fh = mark4.open(SAMPLE_MARK4, 'rs', ref_time=Time('2013:100:23:00:00'))
     >>> fh
     <Mark4StreamReader name=... offset=0
         sample_rate=32.0 MHz, samples_per_frame=80000,
@@ -56,26 +115,39 @@ also provide a reference time within 4 years of the observation start time::
     >>> d = fh.read(6400)
     >>> d.shape
     (6400, 8)
-    >>> d[635:645, 0].astype(int)  # first thread
+    >>> d[635:645, 0].astype(int)  # first channel
     array([ 0,  0,  0,  0,  0, -1,  1,  3,  1, -1])
     >>> fh.close()
 
-For Mark 4 files, the header takes the place of the first 160 samples of each
-track, such that the first payload sample occurs ''fanout * 160'' sample times
-after the header time.  The stream reader includes these overwritten samples as
-invalid data (zeros, by default)::
+As mentioned in the :ref:`mark4_file_structure` section, because the header
+takes the place of the first 160 samples of each track, the first payload
+sample occurs ``fanout * 160`` sample times after the header time.  The stream
+reader includes these overwritten samples as invalid data (zeros, by default)::
 
     >>> np.array_equal(d[:640], np.zeros((640,) + d.shape[1:]))
     True
 
-When writing to file, we need to pass in the sample rate in addition to 
-``ntrack`` and ``decade`` so that times for individual samples can be
-calculated.
+When writing to file, we need to pass in the sample rate in addition
+to ``decade``.  The number of tracks can be inferred from the header.
+For a full list of parameters, including header keywords, that can be
+passed to `~baseband.mark4.open` in stream writing mode, see the
+`~baseband.mark4.base.Mark4StreamWriter` API entry.
+
+::
 
     >>> fw = mark4.open('sample_mark4_segment.m4', 'ws', header=frame.header,
-    ...                 ntrack=64, decade=2010, sample_rate=32*u.MHz)
+    ...                 decade=2010, sample_rate=32*u.MHz)
     >>> fw.write(frame.data)
     >>> fw.close()
+    >>> fh = mark4.open('sample_mark4_segment.m4', 'rs', decade=2010,
+    ...                 sample_rate=32.*u.MHz)
+    >>> np.all(fh.read(80000) == frame.data)
+    True
+    >>> fh.close()
+
+Note that above we had to pass in the sample rate even when opening
+the file for reading; this is because there is only a single frame in
+the file, and hence the sample rate cannot be inferred automatically.
 
 .. _mark4_api:
 

--- a/docs/baseband/mark5b/index.rst
+++ b/docs/baseband/mark5b/index.rst
@@ -1,11 +1,114 @@
 .. _mark5b:
 
+.. include:: ../tutorials/glossary_substitutions.rst
+
 *******
 MARK 5B
 *******
 
-The Mark 5B VLBI format is described in its `design specifications
-<http://www.haystack.mit.edu/tech/vlbi/mark5/mark5_memos/019.pdf>`_.
+The Mark 5B format is the output format of the Mark 5B disk-based VLBI data
+system.  It is described in its `design specifications <m5bspec>`_ (these
+exact specifications are also found in the `Mark 5B user manual
+<https://www.haystack.mit.edu/tech/vlbi/mark5/docs/Mark%205B%20users%20manual.pdf>`_).
+
+.. _m5bspec: http://www.haystack.mit.edu/tech/vlbi/mark5/mark5_memos/019.pdf
+
+.. _mark5b_file_structure:
+
+File Structure
+==============
+
+Each :term:`data frame` consists of a :term:`header` consisting of four 32-bit
+words (16 bytes) followed by a :term:`payload` of 2500 32-bit words (10000
+bytes).  The header contains a sync word, frame number, and timestamp 
+(accurate to 1 ms), as well as user-specified data; see Sec. 1 of the
+`specifications <m5bspec>`_ for details.  The payload supports $2^n$
+1-bit-streams, for $0 \leq n \leq 5$, and the first sample of each stream
+corresponds precisely to the header time.  |Elementary samples| may be 1 or 2
+bits in size, with the latter being stored in two successive bit streams.  The
+number of |channels| is equal to the number of bit-streams
+divided by the number of bits per elementary sample (Baseband currently only
+supports files where all bit-streams are active).  Files begin at a header 
+(unlike for Mark 4), and an integer number of frames fit within 1 second.
+
+The Mark 5B system also outputs files with the active bit-stream mask, number
+of frames per second, and observational metadata (Sec. 1.3 of the
+`specifications <m5bspec>`_).  Baseband does not use these files (instead
+requiring the user specify, for example, the :term:`sample rate`).
+
+.. _mark5b_usage:
+
+Usage
+=====
+
+This section covers reading and writing Mark 5B files with Baseband; general
+usage can be found under the :ref:`Using Baseband <using_baseband_toc>` section.
+The examples below use the small sample file ``baseband/data/sample.m5b``, and
+the `numpy`, `astropy.units`, `astropy.time.Time`, and `baseband.mark5`
+modules::
+
+    >>> import numpy as np
+    >>> import astropy.units as u
+    >>> from astropy.time import Time
+    >>> from baseband import mark5b
+    >>> from baseband.data import SAMPLE_MARK5B
+
+Opening a Mark 5B file with `~baseband.mark5b.open` in binary mode provides a
+normal file reader extended with methods to read a
+`~baseband.mark5b.Mark5BFrame`.  The number of channels, kiloday (thousands of
+MJD) and number of bits per sample must all be passed when using
+`~baseband.mark5b.base.Mark5BFileReader.read_frame`::
+
+    >>> fb = mark5b.open(SAMPLE_MARK5B, 'rb')
+    >>> frame = fb.read_frame(nchan=8, kday=56000)
+    >>> frame.shape
+    (5000, 8)
+    >>> fb.close()
+
+Our sample file has 2-bit :term:`component` samples, which is also the default
+for `~baseband.mark5b.base.Mark5BFileReader.read_frame`, so it does not need to
+be passed.  Also, we may pass a reference `~astropy.time.Time` object within
+500 days of the observation start time to ``ref_time``, rather than ``kday``.
+
+Opening as a stream wraps the low-level routines such that reading and writing
+is in units of samples.  It also provides access to header information.  Here,
+we also must provide ``nchan``, ``sample_rate``, and ``ref_time`` or ``kday``::
+
+    >>> fh = mark5b.open(SAMPLE_MARK5B, 'rs', nchan=8, sample_rate=32*u.MHz,
+    ...                  ref_time=Time('2014-06-13 12:00:00'))
+    >>> fh
+    <Mark5BStreamReader name=... offset=0
+        sample_rate=32.0 MHz, samples_per_frame=5000,
+        sample_shape=SampleShape(nchan=8), bps=2,
+        start_time=2014-06-13T05:30:01.000000000>
+    >>> header0 = fh.header0    # To be used for writing, below.
+    >>> d = fh.read(10000)
+    >>> d.shape
+    (10000, 8)
+    >>> d[0, :3]    # doctest: +FLOAT_CMP
+    array([-3.316505, -1.      ,  1.      ], dtype=float32)
+    >>> fh.close()
+
+For a full list of parameters that can be passed to `~baseband.mark5b.open` in
+stream mode, see its API entry.
+
+When writing to file, we again need to pass in ``sample_rate`` and ``nchan``,
+though time can either be passed explicitly or inferred from the header::
+
+
+    >>> fw = mark5b.open('test.m5b', 'ws', header=header0, nchan=8,
+    ...                  sample_rate=32*u.MHz)
+    >>> fw.write(d)
+    >>> fw.close()
+    >>> fh = mark5b.open('test.m5b', 'rs', nchan=8, sample_rate=32*u.MHz,
+    ...                  kday=57000)
+    >>> np.all(fh.read() == d)
+    True
+    >>> fh.close()
+
+For a full list of parameters, including header keywords, that can be passed to
+`~baseband.mark5b.open` in stream writing mode, see the
+`~baseband.mark5b.base.Mark4StreamWriter` API entry.
 
 .. _mark5b_api:
 

--- a/docs/baseband/tutorials/getting_started.rst
+++ b/docs/baseband/tutorials/getting_started.rst
@@ -1,11 +1,14 @@
 .. _getting_started:
 
+.. include:: ../tutorials/glossary_substitutions.rst
+
 ***************
 Getting Started
 ***************
 
-This tutorial covers the basic features of Baseband.  It assumes that Numpy and
-the Astropy units module have been imported::
+This tutorial covers the basic features of Baseband.  It assumes that 
+`NumPy <http://www.numpy.org/>`_ and the `Astropy`_ units module have been
+imported::
 
     >>> import numpy as np
     >>> import astropy.units as u
@@ -54,12 +57,12 @@ For the rest of this section, let's go back to using VDIF files.
 Decoding Data and the Sample File Pointer
 -----------------------------------------
 
-We gave `~baseband.vdif.open` the `'rs'` flag, which opens the file in
+We gave `~baseband.vdif.open` the ``'rs'`` flag, which opens the file in
 "stream reader" mode.  The function returns an instance of
 `~baseband.vdif.base.VDIFStreamReader`, a wrapper around `io.BufferedReader`
-that adds methods to decode files as data frames and seek to and read data
-samples.  To decode the first 12 data samples into an `~numpy.ndarray`, we
-would use the `~baseband.vdif.base.VDIFStreamReader.read` method::
+that adds methods to decode files as |data frames| and seek to and read data
+|samples|.  To decode the first 12 samples into a `~numpy.ndarray`, we would
+use the `~baseband.vdif.base.VDIFStreamReader.read` method::
 
     >>> fh = vdif.open(SAMPLE_VDIF, 'rs')
     >>> d = fh.read(12)
@@ -71,26 +74,27 @@ would use the `~baseband.vdif.base.VDIFStreamReader.read` method::
     array([-1, -1,  3, -1,  1, -1,  3, -1,  1,  3, -1,  1])
 
 As discussed in detail in the :ref:`VDIF section <vdif>`, VDIF files are
-sequences of "frames", each of which is comprised of a header (which holds
-information like the time at which the data was taken) and a block of
-data.  Multiple concurrent time streams can be stored within a single frame;
-each of these is called a "channel".  Moreover, groups of channels can be
-stored over multiple frames, each of which is called a "thread".  Our sample
-file is an "8-thread, single-channel file" (8 concurrent time streams with 1
-stream per frame), and in the example above, ``fh.read`` decoded the first 12
-samples from all 8 threads, mapping thread number to the second axis of the
-decoded data array.  Reading files with multiple threads and channels will
-produce 3-dimensional arrays.
+sequences of data frames, each of which is comprised of a :term:`header` (which
+holds information like the time at which the data was taken) and a
+:term:`payload`, or block of data.  Multiple concurrent time streams can be
+stored within a single frame; each of these is called a ":term:`channel`". 
+Moreover, groups of channels can be stored over multiple frames, each of which
+is called a ":term:`thread`".  Our sample file is an "8-thread, single-channel
+file" (8 concurrent time streams with 1 stream per frame), and in the example
+above, ``fh.read`` decoded the first 12 samples from all 8 threads, mapping
+thread number to the second axis of the decoded data array.  Reading files with
+multiple threads and channels will produce 3-dimensional arrays.
 
-If you want to know the shape of a single complete sample - the set of samples
-from all available threads, channels, etc., for a given point in time - it is
+If you want to know the shape of a :term:`complete sample` - the set of samples
+from all available threads and channels for one point in time - it is
 accessible through::
 
     >>> fh.sample_shape
     SampleShape(nthread=8)
 
-By default, dimensions of length unity are removed from the sample shape.  To
-retain them, we can pass ``squeeze=False`` to `~baseband.vdif.open`:
+By default, dimensions of length unity are |squeezed|, or removed from the
+sample shape.  To retain them, we can pass ``squeeze=False`` to
+`~baseband.vdif.open`:
 
     >>> fhns = vdif.open(SAMPLE_VDIF, 'rs', squeeze=False)
     >>> fhns.sample_shape    # Sample shape now keeps channel dimension.
@@ -257,9 +261,9 @@ Reading Specific Components of the Data
 
 By default, ``fh.read()`` returns complete samples, i.e. with all
 available threads, polarizations or channels. If we were only interested in
-decoding specific components of the complete sample, we can select them by
-passing indexing objects to the ``subset`` keyword in open.  For example, if we
-only wanted thread 3 of the sample VDIF file::
+decoding a :term:`subset` of the complete sample, we can select specific
+components by passing indexing objects to the ``subset`` keyword in open.  For
+example, if we only wanted thread 3 of the sample VDIF file::
 
     >>> fh = vdif.open(SAMPLE_VDIF, 'rs', subset=3, squeeze=False)
     >>> fh.sample_shape

--- a/docs/baseband/tutorials/glossary.rst
+++ b/docs/baseband/tutorials/glossary.rst
@@ -1,0 +1,71 @@
+.. _glossary:
+
+.. include:: glossary_substitutions.rst
+
+********
+Glossary
+********
+
+.. glossary::
+
+   channel
+      A single component of the :term:`complete sample`, or a :term:`stream`
+      thereof.  They typically represent one frequency sub-band, the output
+      from a single antenna, or (for channelized data) one spectral or Fourier
+      channel, ie. one part of a Fourier spectrum.
+
+   complete sample
+      Set of all component samples - ie. from all threads, polarizations,
+      channels, etc. - for one point in time.  Its dimensions are given by the
+      :term:`sample shape`.
+
+   component
+      One individual :term:`thread` and :term:`channel`, or one polarization
+      and channel, etc.  Component samples each occupy one element in decoded
+      data arrays.  A component sample is composed of one :term:`elementary
+      sample` if it is real, and two if it is complex.
+
+   data frame
+      A block of time-sampled data, or :term:`payload`, accompanied by a
+      :term:`header`. "Frame" for short.
+
+   data frameset
+      In the VDIF format, the set of all |data frames| representing the same
+      segment of time.  Each data frame consists of sets of |channels| from
+      different |threads|.
+
+   elementary sample
+      The smallest subdivision of a complete sample, i.e. the real / imaginary
+      part of one :term:`component` of a :term:`complete sample`.
+
+   header
+      Metadata accompanying a :term:`data frame`.
+
+   payload
+      The data within a :term:`data frame`.
+
+   sample
+      Data from one point in time.  |Complete samples| contain samples from all
+      |components|, while |elementary samples| are one part of one component.
+
+   sample rate
+      Rate of complete samples.
+
+   sample shape
+      The lengths of the dimensions of the complete sample.
+
+   squeezing
+      The removal of any dimensions of length unity from decoded data.
+
+   stream
+      Timeseries of |samples|; may refer to all of, or a subsection of, the
+      dataset.
+
+   subset
+      A subset of a complete sample, in particular one defined by the user for
+      selective decoding.
+
+   thread
+      A collection of |channels| from the :term:`complete sample`, or a
+      :term:`stream` thereof.  For VDIF, each thread is carried by a separate 
+      (set of) :term:`data frame(s)<data frame>`.

--- a/docs/baseband/tutorials/glossary_substitutions.rst
+++ b/docs/baseband/tutorials/glossary_substitutions.rst
@@ -1,0 +1,11 @@
+.. |channels| replace:: :term:`channels<channel>`
+.. |Complete samples| replace:: :term:`Complete samples<complete sample>`
+.. |complete samples| replace:: :term:`complete samples<complete sample>`
+.. |components| replace:: :term:`components<component>`
+.. |data frames| replace:: :term:`data frames<data frame>`
+.. |elementary samples| replace:: :term:`elementary samples<elementary sample>`
+.. |Elementary samples| replace:: :term:`elementary samples<elementary sample>`
+.. |headers| replace:: :term:`headers<header>`
+.. |samples| replace:: :term:`samples<sample>`
+.. |squeezed| replace:: :term:`squeezed<squeezing>`
+.. |threads| replace:: :term:`threads<thread>`

--- a/docs/baseband/vdif/index.rst
+++ b/docs/baseband/vdif/index.rst
@@ -1,5 +1,7 @@
 .. _vdif:
 
+.. include:: ../tutorials/glossary_substitutions.rst
+
 ****
 VDIF
 ****
@@ -11,44 +13,38 @@ specifications are found in VDIF's `specification document
 
 .. _vdif_file_structure:
 
-VDIF File Structure
-===================
+File Structure
+==============
 
-A VDIF file or data transmission is composed of a sequence of **data frames**,
-each of which is comprised of a self-identifying data frame
-header followed by a sequence, or **payload**, of data covering a single time
-segment of observations from one or more frequency sub-bands.  The header
-is a pre-defined 32-bytes long, while the payload is task-specific and can
-range from 32 bytes to ~134 megabytes.  Both are little-endian and grouped
-into 32-bit **words**.  The first four words of a VDIF header hold the same
-information in all VDIF files, but the last four words hold optional
-user-defined data.  The layout of these four words is specified by the file's
-**extended-data version**, or EDV.  More detailed information on the header
-can be found in the :ref:`tutorial for supporting a new VDIF EDV <new_edv>`.
+A VDIF file is composed of |data frames|.  Each has a :term:`header` of eight
+32-bit words (32 bytes; the exception is the "legacy VDIF" format, which is
+four words, or 16 bytes, long), and a :term:`payload` that ranges from 32 bytes
+to ~134 megabytes.  Both are little-endian.  The first four words of a VDIF
+header hold the same information in all VDIF files, but the last four words
+hold optional user-defined data.  The layout of these four words is specified
+by the file's **extended-data version**, or EDV.  More detailed information on
+the header can be found in the :ref:`tutorial for supporting a new VDIF EDV
+<new_edv>`.
 
-A data frame may carry one or multiple frequency sub-bands or Fourier
-channels, and we refer to either of these as **channels** for short.  A sequence
-of data frames all carrying the same (set of) channels is called a **data
-thread**, denoted by its thread ID.  A data set consisting of multiple
-concurrent threads is transmitted or stored as a serial sequence of frames
-called a **data stream**.  The collection of frames that cover all threads for a
-single time segment - equivalently, all thread IDs for the same header time and
-frame number - is a **dataframe set** (or just "frame set").
+A data frame may carry one or multiple |channels|, and a :term:`stream` of data
+frames all carrying the same (set of) channels is known as a :term:`thread` and
+denoted by its thread ID.  The collection of frames representing the same time
+segment (and all possible thread IDs) is called a  :term:`data frameset` (or
+just "frameset").
 
-Strict time ordering of frames in the stream, while considered part of VDIF
-best practices, is not mandated, and cannot be guaranteed during data
-transmission over the internet.
+Strict time and thread ID ordering of frames in the stream, while considered
+part of VDIF best practices, is not mandated, and cannot be guaranteed during
+data transmission over the internet.
 
 .. _vdif_usage:
 
 Usage Notes
 ===========
 
-This section covers VDIF-specific features of Baseband.  Tutorials for general
+This section covers reading and writing VDIF files with Baseband; general
 usage can be found under the :ref:`Using Baseband <using_baseband_toc>` section.
-The examples below use the small sample file ``baseband/data/sample.vdif``,
-and assume the `numpy`, `astropy.units`, and `baseband.vdif` modules have been
-imported::
+The examples below use the small sample file ``baseband/data/sample.vdif``, and
+the `numpy`, `astropy.units`, and `baseband.vdif` modules::
 
     >>> import numpy as np
     >>> from baseband import vdif
@@ -56,10 +52,10 @@ imported::
     >>> from baseband.data import SAMPLE_VDIF
 
 Simple reading and writing of VDIF files can be done entirely using
-:func:`~baseband.vdif.open`. Opening in binary mode provides a normal file
-reader, but extended with methods to read a :class:`~baseband.vdif.VDIFFrameSet`
+`~baseband.vdif.open`. Opening in binary mode provides a normal file
+reader, but extended with methods to read a `~baseband.vdif.VDIFFrameSet`
 data container for storing a frame set as well as
-:class:`~baseband.vdif.VDIFFrame` one for storing a single frame::
+`~baseband.vdif.VDIFFrame` one for storing a single frame::
 
     >>> fh = vdif.open(SAMPLE_VDIF, 'rb')
     >>> fs = fh.read_frameset()
@@ -70,11 +66,14 @@ data container for storing a frame set as well as
     (20000, 1)
     >>> fh.close()
 
-As with other formats, ``fr.data`` is a read-only property of the frame.
+(As with other formats, ``fr.data`` is a read-only property of the frame.)
 
 Opening in stream mode wraps the low-level routines such that reading
 and writing is in units of samples.  It also provides access to header
-information::
+information.  For a full list of parameters that can be passed to
+`~baseband.vdif.open` in stream mode, see its API entry.
+
+::
 
     >>> fh = vdif.open(SAMPLE_VDIF, 'rs')
     >>> fh
@@ -127,7 +126,10 @@ For small files, one could just do::
     ...                   nthread=fr.sample_shape.nthread) as fw:
     ...     fw.write(fr.read())
 
-This copies everything to memory, though, and some header information is lost.
+This copies everything to memory, though, and some header information is lost. 
+For a full list of parameters, including header keywords, that can be passed to
+`~baseband.vdif.open` in stream writing mode, see the
+`~baseband.vdif.base.Mark4StreamWriter` API entry.
 
 .. _vdif_troubleshooting:
 
@@ -135,10 +137,10 @@ Troubleshooting
 ===============
 
 In situations where the VDIF files being handled are corrupted or modified
-in an unusual way, using :func:`~baseband.vdif.open` will likely lead
-either to an exception being raised or to unexpected behavior.  In such
-cases, it may still be possible to read in the data.  Below, we provide a
-few solutions and workarounds to do so.
+in an unusual way, using `~baseband.vdif.open` will likely lead to an
+exception being raised or to unexpected behavior.  In such cases, it may still
+be possible to read in the data.  Below, we provide a few solutions and
+workarounds to do so.
 
 .. note::
     This list is certainly incomplete.   If you have an issue (solved
@@ -148,7 +150,7 @@ few solutions and workarounds to do so.
 AssertionError when checking EDV in header ``verify`` function
 --------------------------------------------------------------
 
-All VDIF header classes (other than :class:`~baseband.vdif.header.VDIFLegacyHeader`)
+All VDIF header classes (other than `~baseband.vdif.header.VDIFLegacyHeader`)
 check, using their ``verify`` function, that the EDV read from file matches
 the class EDV.  If they do not, the following line
 
@@ -159,7 +161,7 @@ supported by Baseband, support can be added by implementing a custom header
 class.  If the EDV is supported, but the header deviates from the format
 found in the `VLBI.org EDV registry <http://www.vlbi.org/vdif/>`_, the
 best solution is to create a custom header class, then override the
-subclass selector in :class:`~baseband.vdif.header.VDIFHeader`.  Tutorials
+subclass selector in `~baseband.vdif.header.VDIFHeader`.  Tutorials
 for doing either can be found :ref:`here <new_edv>`.
 
 EOFError encountered in ``_get_frame_rate`` when reading
@@ -168,11 +170,11 @@ EOFError encountered in ``_get_frame_rate`` when reading
 When the sample rate is not input by the user and cannot be deduced from header
 information (if EDV = 1 or, the sample rate is found in the header), Baseband
 tries to determine the frame rate using the private method ``_get_frame_rate``
-in :class:`~baseband.vdif.base.VDIFStreamReader` (and then multiply by the
+in `~baseband.vdif.base.VDIFStreamReader` (and then multiply by the
 samples per frame to obtain the sample rate).  This function raises `EOFError`
 if the file contains less than one second of data, or is corrupt.  In either
 case the file can be opened still by explicitly passing in the sample rate to
-:func:`~baseband.vdif.open` via the `sample_rate` argument.
+`~baseband.vdif.open` via the ``sample_rate`` keyword.
 
 .. _vdif_api:
 


### PR DESCRIPTION
Created a glossary of terms, and created links for terms throughout the documentation, to partly address #116 (we still need to reorder the arguments to close that though).  Added descriptions of GSB, Mark 4 and 5B formats, and revised VDIF's.  Added usage examples for GSB and Mark 5B.

Should only be merged after #118 (I didn't want to have to revise the docs yet again once subsetting has been finalized).