### PR TITLE
Default values for GSB payload size and framerate

### DIFF
--- a/baseband/gsb/tests/test_gsb.py
+++ b/baseband/gsb/tests/test_gsb.py
@@ -572,6 +572,13 @@ class TestGSB(object):
             assert fh_r.size == fh_r.samples_per_frame
             assert fh_r._last_header == fh_r.header0
 
+        # Test not passing a sample rate and samples per frame to reader
+        # (can't test reading, since the sample file is tiny).
+        with gsb.open(SAMPLE_RAWDUMP_HEADER, 'rs', raw=SAMPLE_RAWDUMP) as fh_r:
+            assert fh_r.sample_rate == (100. / 3.) * u.MHz
+            assert fh_r.samples_per_frame == 2**23
+            assert fh_r._payloadsize == 2**22
+
     def test_phased_stream(self, tmpdir):
         bps = 8
         nchan = 512
@@ -723,6 +730,14 @@ class TestGSB(object):
             assert 'second-to-last entry' in str(w[0].message)
             assert fh_r.size == fh_r.samples_per_frame
             assert fh_r._last_header == fh_r.header0
+
+        # Test not passing a sample rate and samples per frame to reader
+        # (can't test reading, since the sample file is tiny).
+        with gsb.open(SAMPLE_PHASED_HEADER, 'rs', raw=SAMPLE_PHASED) as fh_r:
+            assert fh_r.sample_rate == (fh_r.samples_per_frame *
+                                        (100. / 3. / 2.**23) * u.MHz)
+            assert fh_r.samples_per_frame == 2**13  # 2**23 / 1024
+            assert fh_r._payloadsize == 2**22
 
     def test_stream_invalid(self, tmpdir):
         with pytest.raises(ValueError):


### PR DESCRIPTION
Following discussions with Sanjay and Jayanta, and re-reading both the GSB documentation and the [ArXiv paper](https://arxiv.org/abs/0910.1517) detailing the software backend, I gathered the following:

- For phased, pre-channelized sample rates are 33.333... Msps at 8 bps or 66.666... Msps at 4 bps.  One frame is set by the size of the buffer received by the acquisition nodes, which is 8 MB / channel.  This leads to a framerate of `10**8 / 3 / 2**23` fps in both cases.  The frame size is always `2**23` (or in our case `payloadsize = 2**23 / len(fh_raw[0])`, since we care about the frame size per file and different polarizations are handled by different nodes).
- Rawdump is sampled using the 33.333... Msps mode, but outputs 4 bps data.  Thus, the framerate is `10**8 / 3 / 2**23` fps and the frame size is `2**22` (4 MB).

Added a few lines in `GSBStreamBase` so it can automatically set these values for both reading and writing.  Since it's impossible to test this on our sample files, I successfully tested it against real GSB files and Rob's empirically determined payload sizes and framerates.