### PR TITLE
Use sample_shape more directly in read and write.

### DIFF
--- a/baseband/dada/tests/test_dada.py
+++ b/baseband/dada/tests/test_dada.py
@@ -343,7 +343,8 @@ class TestDADA(object):
         with dada.open(SAMPLE_FILE, 'rs') as fh:
             assert fh.sample_shape == (2,)
             assert fh.sample_shape.npol == 2
-            assert fh.read(1).shape == (2,)
+            assert fh.read(1).shape == (1, 2)
+            assert fh.read(10).shape == (10, 2)
             fh.seek(0)
             out = np.zeros((12, 2), dtype=np.complex64)
             fh.read(out=out)
@@ -354,6 +355,7 @@ class TestDADA(object):
             assert fh.sample_shape.npol == 2
             assert fh.sample_shape.nchan == 1
             assert fh.read(1).shape == (1, 2, 1)
+            assert fh.read(10).shape == (10, 2, 1)
             fh.seek(0)
             out = np.zeros((12, 2, 1), dtype=np.complex64)
             fh.read(out=out)

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -605,15 +605,15 @@ class TestMark4(object):
 
         # Test that squeeze attribute works on read (including in-place read)
         # and write, but can be turned off if needed.
-        with mark4.open(SAMPLE_FILE, 'rs', ntrack=64, decade=2010) as fh:
-            assert fh.sample_shape == (8,)
-            assert fh.sample_shape.nchan == 8
-            assert fh.read(1).shape == (8,)
+        with mark4.open(SAMPLE_FILE, 'rs', ntrack=64,
+                        thread_ids=[0], decade=2010) as fh:
+            assert fh.sample_shape == ()
+            assert fh.read(1).shape == (1,)
             fh.seek(0)
-            out = np.zeros((12, 8))
+            out = np.zeros(12)
             fh.read(out=out)
             assert fh.tell() == 12
-            assert np.all(out == record[:12])
+            assert np.all(out == record[:12, 0])
 
         with mark4.open(SAMPLE_FILE, 'rs', ntrack=64, decade=2010,
                         thread_ids=[0], squeeze=False) as fh:

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -257,12 +257,15 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
             if count is None or count < 0:
                 count = self.size - self.offset
 
-            result = np.empty(self._sample_shape + (count,),
-                              dtype=self._frame.dtype).T
-            out = result.squeeze() if self.squeeze else result
+            out = np.empty((count,) + self.sample_shape,
+                           dtype=self._frame.dtype)
         else:
+            assert out.shape[1:] == self.sample_shape, (
+                "'out' should have trailing shape {}".format(self.sample_shape))
             count = out.shape[0]
-            result = self._unsqueeze(out) if self.squeeze else out
+
+        # Create a properly-shaped view of the output if needed.
+        result = self._unsqueeze(out) if self.squeeze else out
 
         offset0 = self.offset
         while count > 0:
@@ -363,13 +366,11 @@ class Mark5BStreamWriter(VLBIStreamWriterBase, Mark5BFileWriter):
         invalid_data : bool, optional
             Whether the current data is valid.  Defaults to `False`.
         """
+        assert data.shape[1:] == self.sample_shape, (
+            "'data' should have trailing shape {}".format(self.sample_shape))
+
         if self.squeeze:
             data = self._unsqueeze(data)
-
-        if data.ndim != 2 or data.shape[1] != self._sample_shape.nchan:
-            raise ValueError('cannot write an array with shape {0} to a '
-                             'stream with {1} threads'
-                             .format(data.shape, self._sample_shape.nchan))
 
         count = data.shape[0]
         sample = 0

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -481,15 +481,14 @@ class TestMark5B(object):
         # Test that squeeze attribute works on read (including in-place read)
         # and write, but can be turned off if needed.
         with mark5b.open(SAMPLE_FILE, 'rs', nchan=8, bps=2,
-                         sample_rate=32*u.MHz, kday=56000) as fh:
-            assert fh.sample_shape == (8,)
-            assert fh.sample_shape.nchan == 8
-            assert fh.read(1).shape == (8,)
+                         thread_ids=[0], sample_rate=32*u.MHz, kday=56000) as fh:
+            assert fh.sample_shape == ()
+            assert fh.read(1).shape == (1,)
             fh.seek(0)
-            out = np.zeros((12, 8))
+            out = np.zeros(12)
             fh.read(out=out)
             assert fh.tell() == 12
-            assert np.all(out == record[:12])
+            assert np.all(out == record[:12, 0])
 
         with mark5b.open(SAMPLE_FILE, 'rs', nchan=8, bps=2,
                          sample_rate=32*u.MHz, kday=56000,

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -538,7 +538,7 @@ class TestVDIF(object):
         with vdif.open(SAMPLE_FILE, 'rs') as fh:
             assert fh.sample_shape == (8,)
             assert fh.sample_shape.nthread == 8
-            assert fh.read(1).shape == (8,)
+            assert fh.read(1).shape == (1, 8)
             fh.seek(0)
             out = np.zeros((12, 8))
             fh.read(out=out)
@@ -574,8 +574,8 @@ class TestVDIF(object):
             assert fh.sample_rate == 320*u.Hz
             assert not fh.complex_data
             assert fh.header0.bps == 2
-            assert fh._sample_shape.nchan == 2
-            assert fh._sample_shape.nthread == 2
+            assert fh.sample_shape.nchan == 2
+            assert fh.sample_shape.nthread == 2
             assert fh.start_time == Time('2010-01-01')
             assert fh.stop_time == fh.start_time + 1.5 * u.s
             fh.seek(16)

--- a/docs/baseband/tutorials/new_edv.rst
+++ b/docs/baseband/tutorials/new_edv.rst
@@ -434,7 +434,7 @@ We can then use the stream reader without further modification::
     >>> fh2 = vdif.open(SAMPLE_DRAO_CORRUPT, 'rs', sample_rate=5**12*u.Hz)
     >>> fh2.header0['eud2'] == header0['eud2']
     True
-    >>> np.array_equal(fh2.read(1), payload0[0])
+    >>> np.all(fh2.read(1) == payload0[0])
     True
     >>> fh2.close()
 


### PR DESCRIPTION
Two things to simplify the code before the 1.0 release:
1. Remove the transpose in the creation of the output arrays in read.  This was originally intended to perhaps speed up reading of vdif, but it is not obvious at all this matters, and it makes the code less clear.
2. Create the output array, and check possible `out` or `data` arrays using self.sample_shape, rather than relying on the private unsqueezed sample_shape.  Instead, use the `_unsqueeze` method.

@cczhu - could you have a look? This slightly affects backwards compatibility in that reading a single item will now return an array with a 1 as its first dimension (I think this is actually more helpful...).

It means some editing for rebasing #118 (which I hope to get to). Note that I started this because I wanted to get rid of any use of `_sample_shape` so I could refactor that one a little. But then I realized this was better anyway, so I made a separate PR.