### PR TITLE
Remove PYTEST_VERSION fixes in travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,22 +40,21 @@ matrix:
         - env: SETUP_CMD='build_sphinx -w'
 
         # Check Python 3 with stable numpy, also verifying coverage.
-        - env: SETUP_CMD='test --coverage' PYTEST_VERSION=3.2
+        - env: SETUP_CMD='test --coverage'
 
         # Try some older python and numpy versions.
         - python: 2.7
-        - env: PYTEST_VERSION=3.2
 
         - python: 3.5
-          env: NUMPY_VERSION=1.10 PYTEST_VERSION=3.2
+          env: NUMPY_VERSION=1.10
         - python: 2.7
-          env: NUMPY_VERSION=1.9 ASTROPY_VERSION=lts PYTEST_VERSION=3.2
+          env: NUMPY_VERSION=1.9 ASTROPY_VERSION=lts
 
         # Make sure that egg_info works without dependencies
         - env: SETUP_CMD='egg_info'
 
         # Do a PEP8/pyflakes test with flake8 (see setup.cfg for options)
-        - env: MAIN_CMD="flake8 --count baseband" SETUP_CMD='' PYTEST_VERSION=3.2
+        - env: MAIN_CMD="flake8 --count baseband" SETUP_CMD=''
 
 before_install:
 


### PR DESCRIPTION
Should not be necessary any more with update of astropy_helpers.