### PR TITLE
Cache framerate to speed up _frame_info.

### DIFF
--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -81,9 +81,6 @@ class VLBIStreamBase(VLBIFileBase):
         self._subset = subset
         self._sample_shape = self._get_sample_shape(subset_wrapints)
 
-        self._framerate = int(np.round(
-            (self.sample_rate / self.samples_per_frame).to_value(u.Hz)))
-
     @property
     def squeeze(self):
         """Whether data arrays have dimensions with length unity removed.
@@ -256,10 +253,18 @@ class VLBIStreamBase(VLBIFileBase):
         return (self.offset / self.sample_rate).to(unit)
 
     def _frame_info(self):
-        offset = (self.offset +
-                  self.header0['frame_nr'] * self.samples_per_frame)
+        # Can be made less unwieldy if we abstract a StreamBase class such that
+        # VLBIStreamBase is only for VLBI formats.
+        try:
+            framerate = self._framerate
+            offset0 = self._offset0
+        except AttributeError:
+            framerate = self._framerate = int(np.round(
+                (self.sample_rate / self.samples_per_frame).to_value(u.Hz)))
+            offset0 = self._offset0 = self.header0['frame_nr']
+        offset = (self.offset + offset0 * self.samples_per_frame)
         full_frame_nr, extra = divmod(offset, self.samples_per_frame)
-        dt, frame_nr = divmod(full_frame_nr, self._framerate)
+        dt, frame_nr = divmod(full_frame_nr, framerate)
         return dt, frame_nr, extra
 
     def __repr__(self):

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -81,6 +81,9 @@ class VLBIStreamBase(VLBIFileBase):
         self._subset = subset
         self._sample_shape = self._get_sample_shape(subset_wrapints)
 
+        self._framerate = int(np.round(
+            (self.sample_rate / self.samples_per_frame).to_value(u.Hz)))
+
     @property
     def squeeze(self):
         """Whether data arrays have dimensions with length unity removed.
@@ -255,10 +258,8 @@ class VLBIStreamBase(VLBIFileBase):
     def _frame_info(self):
         offset = (self.offset +
                   self.header0['frame_nr'] * self.samples_per_frame)
-        framerate = int(np.round(
-            (self.sample_rate / self.samples_per_frame).to_value(u.Hz)))
         full_frame_nr, extra = divmod(offset, self.samples_per_frame)
-        dt, frame_nr = divmod(full_frame_nr, framerate)
+        dt, frame_nr = divmod(full_frame_nr, self._framerate)
         return dt, frame_nr, extra
 
     def __repr__(self):


### PR DESCRIPTION
Before, `_frame_info` would calculate the frame rate (including an Astropy unit conversion, rounding, and typecast) every time it's called.  `VLBIStreamBase` now calculates and caches `framerate` upon initialization.

Tests with sequentially decoding 500k VDIF frames (1 thread, 8 chan, 4000 samples per frame) show performance boosts of ~30%.