### PR TITLE
Replaced stream reader calls to `header0.time` with `start_time`.

### DIFF
--- a/baseband/gsb/base.py
+++ b/baseband/gsb/base.py
@@ -469,7 +469,7 @@ class GSBStreamWriter(GSBStreamBase, VLBIStreamWriterBase):
                         mem_block=((self.header0['mem_block'] + frame_nr) % 8))
                 else:
                     self._header = self.header0.__class__.fromvalues(
-                        time=self.header0.time + time_offset)
+                        time=self.start_time + time_offset)
 
             nsample = min(count, self.samples_per_frame - sample_offset)
             sample_end = sample_offset + nsample

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -348,7 +348,7 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
         last_header = super(Mark4StreamReader, self)._last_header
         # Infer the decade, assuming the end of the file is no more than
         # 4 years away from the start.
-        last_header.infer_decade(self.header0.time)
+        last_header.infer_decade(self.start_time)
         return last_header
 
     def read(self, count=None, fill_value=0., out=None):
@@ -414,7 +414,7 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
         frame_nr = self.offset // self.samples_per_frame
         self.fh_raw.seek(self.offset0 + frame_nr * self.header0.framesize)
         self._frame = self.read_frame(ntrack=self.header0.ntrack,
-                                      ref_time=self.header0.time)
+                                      ref_time=self.start_time)
         # Convert payloads to data array.
         self._frame_nr = frame_nr
 

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -226,7 +226,7 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
         last_header = super(Mark5BStreamReader, self)._last_header
         # Infer kday, assuming the end of the file is no more than
         # 500 days away from the start.
-        last_header.infer_kday(self.header0.time)
+        last_header.infer_kday(self.start_time)
         return last_header
 
     def read(self, count=None, fill_value=0., out=None):
@@ -301,7 +301,7 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
         self.fh_raw.seek(self.offset // self.samples_per_frame *
                          self._frame.size)
         self._frame = self.read_frame(nchan=self._unsliced_shape.nchan,
-                                      bps=self.bps, ref_time=self.header0.time)
+                                      bps=self.bps, ref_time=self.start_time)
 
 
 class Mark5BStreamWriter(VLBIStreamWriterBase, Mark5BFileWriter):


### PR DESCRIPTION
Calls to decode header times are expensive, and `start_time` is a lazy property, so replaced all calls to `header0.time` in stream readers with `start_time` (amazing that I didn't do this to begin with!).

Tests with sequentially decoding 400k Mark 5B frames (4 chan, 10,000 samples per frame) show performance boosts of ~20% (since the start time is used in `_read_frame`).