### PR TITLE
Replace costly sorting of VDIF frames by iterating over dict.

### DIFF
--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -78,15 +78,13 @@ class VDIFFileReader(VLBIFileBase):
         """
         return VDIFFrame.fromfile(self.fh_raw)
 
-    def read_frameset(self, thread_ids=None, sort=True, edv=None, verify=True):
+    def read_frameset(self, thread_ids=None, edv=None, verify=True):
         """Read a single frame (header plus payload).
 
         Parameters
         ----------
         thread_ids : list, optional
             The thread ids that should be read.  By default, read all threads.
-        sort : bool, optional
-            Whether to sort the frames by thread_id.  Default: True.
         edv : int, optional
             The expected extended data version for the VDIF Header.  If not
             given, use that of the first frame.  (Passing it in slightly
@@ -101,8 +99,8 @@ class VDIFFileReader(VLBIFileBase):
             :class:`~baseband.vdif.VDIFHeaders` and the data encoded in the
             frame set, respectively.
         """
-        return VDIFFrameSet.fromfile(self.fh_raw, thread_ids, sort=sort,
-                                     edv=edv, verify=verify)
+        return VDIFFrameSet.fromfile(self.fh_raw, thread_ids, edv=edv,
+                                     verify=verify)
 
     def find_header(self, template_header=None, framesize=None, edv=None,
                     maximum=None, forward=True):

--- a/baseband/vdif/frame.py
+++ b/baseband/vdif/frame.py
@@ -10,7 +10,6 @@ For the VDIF specification, see http://www.vlbi.org/vdif
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from collections import OrderedDict
 import numpy as np
 
 from ..vlbi_base.frame import VLBIFrameBase
@@ -201,7 +200,7 @@ class VDIFFrameSet(object):
             self.header0 = header0
 
     @classmethod
-    def fromfile(cls, fh, thread_ids=None, sort=True, edv=None, verify=True):
+    def fromfile(cls, fh, thread_ids=None, edv=None, verify=True):
         """Read a frame set from a file, starting at the current location.
 
         Parameters
@@ -212,13 +211,6 @@ class VDIFFrameSet(object):
         thread_ids : list or None
             The thread ids that should be read.  If `None`, continue reading
             threads as long as the frame number does not increase.
-        sort : bool
-            Whether to sort the frames by `thread_ids`.  If `thread_ids` is
-            ``None``, sorts frames by their header thread_id.  Default: True.
-            Note that this does not influence the header used to look up
-            attributes (it is always the header of the first frame read).  It
-            does, however, influence the order in which decoded data is
-            returned.
         edv : int or None
             The expected extended data version for the VDIF Header.  If not
             given, use that of the first frame.  (Passing it in slightly
@@ -229,14 +221,15 @@ class VDIFFrameSet(object):
         Returns
         -------
         frameset : VDIFFrameSet instance
-            Holds ''frames'' property with a possibly sorted list of frames.
+            Its ``frames`` property holds a list of frames (in order of either
+            their ``thread_id`` or following the input ``thread_ids`` list).
             Use the ''data'' attribute to convert to an array.
         """
         header0 = VDIFHeader.fromfile(fh, edv, verify)
         edv = header0.edv
         frame_nr = header0['frame_nr']
 
-        frames = OrderedDict()
+        frames = {}
         header = header0
         while header['frame_nr'] == frame_nr:
             thread_id = header['thread_id']
@@ -259,13 +252,11 @@ class VDIFFrameSet(object):
         if thread_ids and len(frames) < len(thread_ids):
             raise IOError("could not find all requested frames.")
 
-        # Turn dict of frames into a possibly sorted list.
-        if sort:
-            if thread_ids is None:
-                thread_ids = sorted(frames.keys())
-            frames = [frames[thread_id] for thread_id in thread_ids]
-        else:
-            frames = list(frames.values())
+        # Turn dict of frames into a list, following order given by
+        # thread_ids, or just sorting by their own thread_id
+        if thread_ids is None:
+            thread_ids = sorted(frames.keys())
+        frames = [frames[tid] for tid in thread_ids]
 
         return cls(frames, header0)
 


### PR DESCRIPTION
@cczhu - I tried to speed up the frame set code, though it ends up helping less than I had thought based on your sample code. So, not sure whether or not this is worth merging.

Somewhat relatedly, I wonder a bit about the use of the sort keyword...  At least when one passes in `thread_ids`, it seems one always should sort.