### PR TITLE
Correctly refer to GSB rawdump header time as a GPS time.

### DIFF
--- a/baseband/gsb/tests/test_gsb.py
+++ b/baseband/gsb/tests/test_gsb.py
@@ -30,7 +30,7 @@ class TestGSB(object):
         with open(SAMPLE_RAWDUMP_HEADER, 'rt') as fh:
             header = gsb.GSBHeader.fromfile(fh, verify=True)
         assert header.mode == 'rawdump'
-        assert header['pc'] == '2015 04 27 18 45 00 0.000000240'
+        assert header['gps'] == '2015 04 27 18 45 00 0.000000240'
         # Includes UTC offset.
         assert abs(header.time -
                    Time('2015-04-27T13:15:00.000000240')) < 1.*u.ns


### PR DESCRIPTION
GSB developer Sanjay confirms that rawdump headers use a GPS timestamp.  This
is consistent with rawdump headers having nine digits in the fractional second
like the phased GPS time, rather than six like the phased PC time.  GSB
header.py has been corrected, as has test_gsb.py.

This was discovered during editing of #121, but warranted a separate PR.  #121's new documentation is consistent with this PR.