### PR TITLE
dada.open now accepts sequentialfile objects

### DIFF
--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -430,19 +430,31 @@ def open(name, mode='rs', subset=None, header=None, **kwargs):
     is_template = isinstance(name, six.string_types) and ('{' in name and
                                                           '}' in name)
     is_sequence = isinstance(name, (tuple, list))
+    is_sequentialfile = isinstance(name, (sf.SequentialFileReader,
+                                          sf.SequentialFileWriter))
 
     if 'b' not in mode:
         if header is None:
             if 'w' in mode:
+                # If sequentialfile object, check that it's opened for writing.
+                if is_sequentialfile:
+                    assert name.mode == 'w+b', (
+                        'open only accepts sequential files opened in '
+                        '\'w+b\' mode for writing.')
                 # For writing a header is required.
-                if 'nthread' in kwargs:
-                    kwargs.setdefault('npol', kwargs.pop('nthread'))
                 header = DADAHeader.fromvalues(**kwargs)
                 kwargs = {}
 
+            elif is_sequentialfile:
+                # If sequentialfile object, check that it's opened for reading.
+                assert name.mode == 'rb', ('open only accepts sequential '
+                                           'files opened in \'rb\' mode '
+                                           'for reading.')
+                header = {}
+
             elif is_template and 'OBS_OFFSET' in name or 'obs_offset' in name:
-                # for reading try reading header from first file if needed.
-                # we make a temporary file sequencer for this, as the real one
+                # For reading try reading header from first file if needed.
+                # We make a temporary file sequencer for this, as the real one
                 # will need the header file size.
                 kwargs = {key.upper(): value for key, value in kwargs.items()}
                 for key in ('FILE_NR', 'FRAME_NR', 'OBS_OFFSET', 'FILE_SIZE'):
@@ -475,7 +487,7 @@ def open(name, mode='rs', subset=None, header=None, **kwargs):
 open.__doc__ = opener.__doc__ + """\n
 Notes
 -----
-For streams, one can also pass in a list of files or a template string that
+For streams, one can also pass in a list of files, or a template string that
 can be formatted using 'frame_nr', 'obs_offset', and other header keywords
 (using :class:`~baseband.dada.base.DADAFileNameSequencer`).
 
@@ -489,4 +501,8 @@ first file name, before any header is read, and therefore the only keywords
 available are 'frame_nr', 'file_nr', and 'obs_offset', all of which are
 assumed to be zero for the first file. To avoid this restriction, pass in
 keyword arguments with values appropriate for the first file.
+
+One may also pass in a `~baseband.helpers.sequentialfile` object
+(opened in 'rb' mode for reading or 'w+b' for writing), though for typical use
+cases it is practically identical to passing in a list or template.
 """

--- a/baseband/dada/tests/test_dada.py
+++ b/baseband/dada/tests/test_dada.py
@@ -446,7 +446,12 @@ class TestDADA(object):
             assert fr.time == fr.stop_time
         assert np.all(data2 == data)
 
-        # Pass sequentialfile object to reader.
+        # Pass sequentialfile objects to reader.
+        with sf.open(filenames, 'w+b',
+                     file_size=(header.payloadsize + 4096)) as fraw, \
+                dada.open(fraw, 'ws', header=header) as fw:
+            fw.write(data)
+
         with sf.open(filenames, 'rb') as fraw, \
                 dada.open(fraw, 'rs') as fr:
             data3 = fr.read()

--- a/baseband/dada/tests/test_dada.py
+++ b/baseband/dada/tests/test_dada.py
@@ -9,6 +9,7 @@ import astropy.units as u
 from astropy.time import Time
 from astropy.tests.helper import catch_warnings
 from ... import dada
+from ...helpers import sequentialfile as sf
 from ..base import DADAFileNameSequencer
 from ...data import SAMPLE_DADA as SAMPLE_FILE
 
@@ -322,7 +323,7 @@ class TestDADA(object):
         h = self.header
         with dada.open(filename, 'ws', time=h.time, bps=h.bps,
                        complex_data=h.complex_data, sample_rate=h.sample_rate,
-                       payloadsize=32000, nthread=1, nchan=1) as fw:
+                       payloadsize=32000, npol=1, nchan=1) as fw:
             fw.write(self.payload.data[:, 0, 0])
             assert np.abs(fw.start_time - start_time) < 1.*u.ns
             assert (np.abs(fw.time - (start_time + 16000 / (16. * u.MHz))) <
@@ -346,7 +347,7 @@ class TestDADA(object):
         data2d = np.array([data, -data]).transpose(1, 2, 0)
         with dada.open(filename, 'ws', time=h.time, bps=h.bps,
                        complex_data=h.complex_data, sample_rate=h.sample_rate,
-                       payloadsize=32000, nthread=2, nchan=2) as fw:
+                       payloadsize=32000, npol=2, nchan=2) as fw:
             fw.write(data2d)
             assert np.abs(fw.start_time - start_time) < 1.*u.ns
             assert (np.abs(fw.time - (start_time + 16000 / (16. * u.MHz))) <
@@ -444,6 +445,12 @@ class TestDADA(object):
             data2 = fr.read()
             assert fr.time == fr.stop_time
         assert np.all(data2 == data)
+
+        # Pass sequentialfile object to reader.
+        with sf.open(filenames, 'rb') as fraw, \
+                dada.open(fraw, 'rs') as fr:
+            data3 = fr.read()
+        assert np.all(data3 == data)
 
     def test_template_stream(self, tmpdir):
         start_time = self.header.time


### PR DESCRIPTION
Not super-useful, since it's easier to pass a list of files to `dada.open`, but it now also accepts `baseband.helpers.sequentialfile` objects.  Fixes #134.