### PR TITLE
Documentation for sequentialfile.

### DIFF
--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -24,12 +24,14 @@ class DADAFileNameSequencer:
     """List-like generator of filenames using a template.
 
     The template is formatted, filling in any items in curly brackets with
-    values from the header, as well as possibly a file number, indicated with
-    '{file_nr}'.  The value '{obs_offset}' is treated specially, in being
-    calculated using ``header['OBS_OFFSET'] + file_nr * header['FILE_SIZE']``.
+    values from the header, as well as possibly a file number equal to the
+    indexing value, indicated with '{file_nr}'.  The value '{obs_offset}' is
+    treated specially, in being calculated using ``header['OBS_OFFSET'] +
+    file_nr * header['FILE_SIZE']``, where ``header['FILE_SIZE']`` is the file
+    size in bytes.
 
     The length of the instance will be the number of files that exist that
-    match the template for increasing values of the file fumber.
+    match the template for increasing values of the file number.
 
     Parameters
     ----------
@@ -37,6 +39,7 @@ class DADAFileNameSequencer:
         Template to format to get specific filenames.
     header : dict-like
         Structure holding key'd values that are used to fill in the format.
+        Keys must be in all caps (eg. ``DATE``), as with DADA header keys.
 
     Examples
     --------
@@ -45,6 +48,10 @@ class DADAFileNameSequencer:
     >>> dfs = dada.base.DADAFileNameSequencer('a{file_nr:03d}.dada', {})
     >>> dfs[10]
     'a010.dada'
+    >>> dfs = dada.base.DADAFileNameSequencer(
+    ...     '{date}_{file_nr:03d}.dada', {'DATE': "2018-01-01"})
+    >>> dfs[10]
+    '2018-01-01_010.dada'
     >>> from baseband.data import SAMPLE_DADA
     >>> with open(SAMPLE_DADA, 'rb') as fh:
     ...     header = dada.DADAHeader.fromfile(fh)
@@ -482,7 +489,7 @@ Notes
 -----
 For streams, one can also pass in a list of files, or a template string that
 can be formatted using 'frame_nr', 'obs_offset', and other header keywords
-(using :class:`~baseband.dada.base.DADAFileNameSequencer`).
+(by `~baseband.dada.base.DADAFileNameSequencer`).
 
 For writing, one can mimic what is done at quite a few telescopes by using
 the template '{utc_start}_{obs_offset:016d}.000000.dada'.

--- a/baseband/helpers/sequentialfile.py
+++ b/baseband/helpers/sequentialfile.py
@@ -275,9 +275,9 @@ def open(files, mode='rb', file_size=None, opener=None):
     Parameters
     ----------
     files : list, tuple, or other iterable of str, filehandle
-        The contains the names of the underlying files that should be combined.
-        If not a list or tuple, it should allow indexing with positive indices,
-        and raise `IndexError` if these are out of range.
+        Contains the names of the underlying files that should be combined,
+        ordered in time.  If not a list or tuple, it should allow indexing with
+        positive indices, and raise `IndexError` if these are out of range.
     mode : str, optional
         The mode with which the files should be opened (default: 'rb').
     file_size : int, optional
@@ -297,6 +297,9 @@ def open(files, mode='rb', file_size=None, opener=None):
     Methods other than ``read``, ``write``, ``seek``, ``tell``, and ``close``
     are tried on the underlying file.  This implies, e.g., ``readline`` is
     possible, though the line cannot span multiple files.
+
+    The reader assumes the sequence of files is **contiguous in time**, ie.
+    with no gaps in the data.
     """
     if 'r' in mode:
         if file_size is not None:

--- a/docs/baseband/dada/index.rst
+++ b/docs/baseband/dada/index.rst
@@ -66,8 +66,10 @@ stream mode, see its API entry.
            [-105.+60.j,   85.-15.j]], dtype=complex64)
     >>> fh.close()
 
-To set up a file for writing as a stream is possible as well.  Here, we use an
-even smaller size of the payload, to show how one can define multiple files.
+To set up a file for writing as a stream is possible as well.  For a full list
+of parameters, including header keywords, that can be passed to
+`~baseband.dada.open` in stream writing mode, see the
+`~baseband.dada.base.DADAStreamWriter` API entry.
 
 ::
 
@@ -88,9 +90,18 @@ even smaller size of the payload, to show how one can define multiple files.
     True
     >>> fr.close()
 
-For a full list of parameters, including header keywords, that can be passed to
-`~baseband.dada.open` in stream writing mode, see the
-`~baseband.dada.base.DADAStreamWriter` API entry.
+Here, we have used an even smaller size of the payload, to show how one can
+define multiple files.  DADA data are typically stored in sequences of files. 
+If, in place of a single filename, one passes a time-ordered list or tuple of
+filenames to `~baseband.dada.open`, it uses |sequentialfile.open| to read or
+write to them as a single contiguous file.  If, as above, one passes a template
+string, `~baseband.dada.open` uses `~baseband.dada.base.DADAFileNameSequencer`
+to create a subscriptable filename generator, which is then passed to
+|sequentialfile.open|.  For further details, and usage examples, see the
+`~baseband.dada.open` and `~baseband.dada.base.DADAFileNameSequencer` API
+entries.
+
+.. |sequentialfile.open| replace:: `sequentialfile.open <baseband.helpers.sequentialfile.open>`
 
 .. _dada_api:
 

--- a/docs/baseband/dada/index.rst
+++ b/docs/baseband/dada/index.rst
@@ -45,11 +45,7 @@ sample file is encoded using 8 bits, the above example thus loads 12 bytes into
 memory).
 
 Opening in stream mode wraps the low-level routines such that reading and
-writing is in units of samples, and provides access to header information.  For
-a full list of parameters that can be passed to `~baseband.dada.open` in
-stream mode, see its API entry.
-
-::
+writing is in units of samples, and provides access to header information::
 
     >>> fh = dada.open(SAMPLE_DADA, 'rs')
     >>> fh
@@ -66,12 +62,7 @@ stream mode, see its API entry.
            [-105.+60.j,   85.-15.j]], dtype=complex64)
     >>> fh.close()
 
-To set up a file for writing as a stream is possible as well.  For a full list
-of parameters, including header keywords, that can be passed to
-`~baseband.dada.open` in stream writing mode, see the
-`~baseband.dada.base.DADAStreamWriter` API entry.
-
-::
+To set up a file for writing as a stream is possible as well::
 
     >>> from astropy.time import Time
     >>> fw = dada.open('{utc_start}.{obs_offset:016d}.000000.dada', 'ws',
@@ -97,9 +88,7 @@ filenames to `~baseband.dada.open`, it uses |sequentialfile.open| to read or
 write to them as a single contiguous file.  If, as above, one passes a template
 string, `~baseband.dada.open` uses `~baseband.dada.base.DADAFileNameSequencer`
 to create a subscriptable filename generator, which is then passed to
-|sequentialfile.open|.  For further details, and usage examples, see the
-`~baseband.dada.open` and `~baseband.dada.base.DADAFileNameSequencer` API
-entries.
+|sequentialfile.open|.  (See API links for further details.)
 
 .. |sequentialfile.open| replace:: `sequentialfile.open <baseband.helpers.sequentialfile.open>`
 

--- a/docs/baseband/gsb/index.rst
+++ b/docs/baseband/gsb/index.rst
@@ -144,8 +144,7 @@ number of binary files*.)
 Opening in stream mode allows timestamp and binary files to be read in
 concert to create data frames, and also wraps the low-level routines such that
 reading and writing is in units of samples, and provides access to header
-information.  For a full list of parameters that can be passed to
-`~baseband.gsb.open` in stream mode, see its API entry.
+information.
 
 When opening a rawdump file in stream mode, we pass the timestamp file as the
 first argument, and the binary file to the ``raw`` keyword.  As per above, we
@@ -235,10 +234,6 @@ simply uses the same time for both GPS and PC times.  Since the PC time can
 drift from the GPS time by several tens of milliseconds,
 ``test_phased.timestamp`` will not be identical to ``SAMPLE_GSB_PHASED``, even
 though we have written the exact same data to file.
-
-For a full list of parameters, including header keywords, that can be passed to
-`~baseband.gsb.open` in stream writing mode, see the
-`~baseband.gsb.base.GSBStreamWriter` API entry.
 
 .. _gsb_api:
 

--- a/docs/baseband/helpers/index.rst
+++ b/docs/baseband/helpers/index.rst
@@ -1,5 +1,7 @@
 .. _helpers:
 
+.. include:: ../tutorials/glossary_substitutions.rst
+
 ****************
 Baseband Helpers
 ****************
@@ -7,6 +9,92 @@ Baseband Helpers
 Helpers assist with reading and writing all file formats.  Currently,
 they only include the :mod:`~baseband.helpers.sequentialfile` module
 for reading a sequence of files as a single one.
+
+.. _sequential_file:
+
+Sequential File
+===============
+
+The `~baseband.helpers.sequentialfile` module is for reading from and writing
+to a sequence of files as if they were a single, contiguous one.  Like with
+file formats, there is a master `sequentialfile.open
+<baseband.helpers.sequentialfile.open>` function to open sequences either
+for reading or writing.  It returns sequential file objects that have ``read``,
+``write``, ``seek``, ``tell``, and ``close`` methods that work identically to
+their single file object counterparts.  They additionally have ``memmap``
+methods to read or write to files through `numpy.memmap`.  For a full list of
+parameters that can be passed to |open|, please see its API entry.
+
+As an example of how to use |open|, we write the data from the sample VDIF
+file ``baseband/data/sample.vdif`` into a sequence of two files - as the sample
+file has two |framesets| - and then read the files back in.  We first load the
+required data::
+
+    >>> from baseband import vdif
+    >>> from baseband.data import SAMPLE_VDIF
+    >>> import numpy as np
+    >>> fh = vdif.open(SAMPLE_VDIF, 'rs')
+    >>> d = fh.read()
+
+We now open a sequential file object for writing::
+
+    >>> from baseband.helpers import sequentialfile as sf
+    >>> filenames = ["seqvdif_{0}".format(i) for i in range(2)]
+    >>> file_size = fh.fh_raw.seek(0, 2) // 2
+    >>> fwr = sf.open(filenames, mode='wb', file_size=file_size)
+
+The first argument passed to |open| must be a **time-ordered sequence** of
+filenames in a list, tuple, or other subscriptable object that returns
+``IndexError`` when the index is out of bounds.  The read mode is 'wb',
+though note that writing using `numpy.memmap` (eg. required for the DADA stream
+writer) is only possible if ``mode='w+b'``.  ``file_size`` determines the
+largest size a file may reach before the next one in the sequence is opened
+for writing.  We set ``file_size`` such that each file holds exactly one
+frameset.
+
+.. note::
+
+    Setting ``file_size`` to a larger value than above will lead to the
+    two files having different sizes.  By default, ``file_size=None``, meaning
+    it can be arbitrarily large, in which case only one file will be created.
+
+To write the data, we pass ``fwr`` to `vdif.open <baseband.vdif.open>`::
+
+    >>> fw = vdif.open(fwr, 'ws', nthread=fh.sample_shape.nthread,
+    ...                sample_rate=fh.sample_rate, header=fh.header0)
+    >>> fw.write(d)
+    >>> fw.close()    # This implicitly closes fwr.
+
+To read the sequence and confirm their contents are identical to the sample
+file's, we may again use |open|::
+
+    >>> frr = sf.open(filenames, mode='rb')
+    >>> fr = vdif.open(frr, 'rs', sample_rate=fh.sample_rate)
+    >>> fr.header0.time == fh.header0.time
+    True
+    >>> np.all(fr.read() == d)
+    True
+    >>> fr.close()
+
+We can also open the second file on its own and confirm it contains the second
+frameset of the sample file::
+
+    >>> fsf = vdif.open(filenames[1], mode='rs', sample_rate=fh.sample_rate)
+    >>> dps = fh.fh_raw.seek(40256)    # Seek to start of second frameset.
+    >>> frameset = fh.read_frameset()
+    >>> fsf.header0.time == frameset.header0.time
+    True
+    >>> np.all(fsf.read() == frameset.data.transpose(1, 0, 2).squeeze())
+    True
+    >>> fsf.close()
+    >>> fh.close()  # Close sample file.
+
+While `~baseband.helpers.sequentialfile` can be used for any format, since
+file sequences are common for DADA, it is **implicitly used** if a list of
+files or filename template is passed to `dada.open <baseband.dada.open>`. 
+See the DADA :ref:`Usage <dada_usage>` section for details.
+
+.. |open| replace:: `~baseband.helpers.sequentialfile.open`
 
 Reference/API
 =============

--- a/docs/baseband/helpers/index.rst
+++ b/docs/baseband/helpers/index.rst
@@ -22,8 +22,7 @@ file formats, there is a master `sequentialfile.open
 for reading or writing.  It returns sequential file objects that have ``read``,
 ``write``, ``seek``, ``tell``, and ``close`` methods that work identically to
 their single file object counterparts.  They additionally have ``memmap``
-methods to read or write to files through `numpy.memmap`.  For a full list of
-parameters that can be passed to |open|, please see its API entry.
+methods to read or write to files through `numpy.memmap`.
 
 As an example of how to use |open|, we write the data from the sample VDIF
 file ``baseband/data/sample.vdif`` into a sequence of two files - as the sample
@@ -80,17 +79,17 @@ We can also open the second file on its own and confirm it contains the second
 frameset of the sample file::
 
     >>> fsf = vdif.open(filenames[1], mode='rs', sample_rate=fh.sample_rate)
-    >>> dps = fh.fh_raw.seek(40256)    # Seek to start of second frameset.
-    >>> frameset = fh.read_frameset()
-    >>> fsf.header0.time == frameset.header0.time
+    >>> fh.seek(fh.size // 2)    # Seek to start of second frameset.
+    20000
+    >>> fsf.header0.time == fh.time
     True
-    >>> np.all(fsf.read() == frameset.data.transpose(1, 0, 2).squeeze())
+    >>> np.all(fsf.read() == fh.read())
     True
     >>> fsf.close()
     >>> fh.close()  # Close sample file.
 
 While `~baseband.helpers.sequentialfile` can be used for any format, since
-file sequences are common for DADA, it is **implicitly used** if a list of
+file sequences are common for DADA, it is implicitly used if a list of
 files or filename template is passed to `dada.open <baseband.dada.open>`. 
 See the DADA :ref:`Usage <dada_usage>` section for details.
 

--- a/docs/baseband/mark4/index.rst
+++ b/docs/baseband/mark4/index.rst
@@ -101,10 +101,7 @@ the number of tracks if not given explicitly), and wraps the
 low-level routines such that reading and writing is in units of samples.  It
 also provides access to header information.  Here we pass a reference
 `~astropy.time.Time` object within 4 years of the observation start time to
-``ref_time``, rather than a ``decade``.  For a full list of parameters that can
-be passed to `~baseband.mark4.open` in stream mode, see its API entry.
-
-::
+``ref_time``, rather than a ``decade``::
 
     >>> fh = mark4.open(SAMPLE_MARK4, 'rs', ref_time=Time('2013:100:23:00:00'))
     >>> fh
@@ -128,12 +125,7 @@ reader includes these overwritten samples as invalid data (zeros, by default)::
     True
 
 When writing to file, we need to pass in the sample rate in addition
-to ``decade``.  The number of tracks can be inferred from the header.
-For a full list of parameters, including header keywords, that can be
-passed to `~baseband.mark4.open` in stream writing mode, see the
-`~baseband.mark4.base.Mark4StreamWriter` API entry.
-
-::
+to ``decade``.  The number of tracks can be inferred from the header::
 
     >>> fw = mark4.open('sample_mark4_segment.m4', 'ws', header=frame.header,
     ...                 decade=2010, sample_rate=32*u.MHz)

--- a/docs/baseband/mark5b/index.rst
+++ b/docs/baseband/mark5b/index.rst
@@ -89,9 +89,6 @@ we also must provide ``nchan``, ``sample_rate``, and ``ref_time`` or ``kday``::
     array([-3.316505, -1.      ,  1.      ], dtype=float32)
     >>> fh.close()
 
-For a full list of parameters that can be passed to `~baseband.mark5b.open` in
-stream mode, see its API entry.
-
 When writing to file, we again need to pass in ``sample_rate`` and ``nchan``,
 though time can either be passed explicitly or inferred from the header::
 
@@ -105,10 +102,6 @@ though time can either be passed explicitly or inferred from the header::
     >>> np.all(fh.read() == d)
     True
     >>> fh.close()
-
-For a full list of parameters, including header keywords, that can be passed to
-`~baseband.mark5b.open` in stream writing mode, see the
-`~baseband.mark5b.base.Mark4StreamWriter` API entry.
 
 .. _mark5b_api:
 

--- a/docs/baseband/tutorials/getting_started.rst
+++ b/docs/baseband/tutorials/getting_started.rst
@@ -442,3 +442,16 @@ size have the same scale, which is why we did not have to rescale our data when
 writing 2-bits-per-sample Mark 4 data to a 2-bits-per-sample VDIF file.
 Rescaling is necessary, though, to convert DADA or GSB to VDIF.  For examples
 of rescaling, see the ``baseband/tests/test_conversion.py`` file.
+
+.. _getting_started_multifile:
+
+Reading or Writing to a Sequence of Files
+=========================================
+
+Data from one continuous observation is often spread over a sequence of files. 
+The `~baseband.helpers.sequentialfile` module is available for reading in a
+sequence as if it were one contiguous file.  Simple usage examples can be found
+in the :ref:`Sequential File <sequential_file>` section.  DADA data is so
+often stored in a file sequence that reading a time-ordered list of filenames
+is built into `baseband.dada.open`; for details, see the `its API entry
+<baseband.dada.open>`.

--- a/docs/baseband/tutorials/getting_started.rst
+++ b/docs/baseband/tutorials/getting_started.rst
@@ -48,7 +48,7 @@ file formats.  When using ``open`` for Mark 4 and Mark 5B files, however, two
 keywords - ``ntrack``, and ``decade`` - may need to be set manually.  For these
 and VDIF, ``sample_rate`` may also need to be passed if it can't be read
 or inferred from the file.  Notes on such features and quirks of individual
-formats can be found in the docstrings of their ``open`` functions, and
+formats can be found in the API entries of their ``open`` functions, and
 within the :ref:`Specific file format <specific_file_formats_toc>`
 documentation.
 

--- a/docs/baseband/tutorials/glossary_substitutions.rst
+++ b/docs/baseband/tutorials/glossary_substitutions.rst
@@ -5,7 +5,12 @@
 .. |data frames| replace:: :term:`data frames<data frame>`
 .. |elementary samples| replace:: :term:`elementary samples<elementary sample>`
 .. |Elementary samples| replace:: :term:`elementary samples<elementary sample>`
+.. |frame| replace:: :term:`frame<data frame>`
+.. |frames| replace:: :term:`frames<data frame>`
+.. |frameset| replace:: :term:`frameset<data frame>`
+.. |framesets| replace:: :term:`framesets<data frameset>`
 .. |headers| replace:: :term:`headers<header>`
+.. |payloads| replace:: :term:`payloads<payload>`
 .. |samples| replace:: :term:`samples<sample>`
 .. |squeezed| replace:: :term:`squeezed<squeezing>`
 .. |threads| replace:: :term:`threads<thread>`

--- a/docs/baseband/vdif/index.rst
+++ b/docs/baseband/vdif/index.rst
@@ -70,10 +70,7 @@ data container for storing a frame set as well as
 
 Opening in stream mode wraps the low-level routines such that reading
 and writing is in units of samples.  It also provides access to header
-information.  For a full list of parameters that can be passed to
-`~baseband.vdif.open` in stream mode, see its API entry.
-
-::
+information::
 
     >>> fh = vdif.open(SAMPLE_VDIF, 'rs')
     >>> fh
@@ -127,9 +124,6 @@ For small files, one could just do::
     ...     fw.write(fr.read())
 
 This copies everything to memory, though, and some header information is lost. 
-For a full list of parameters, including header keywords, that can be passed to
-`~baseband.vdif.open` in stream writing mode, see the
-`~baseband.vdif.base.Mark4StreamWriter` API entry.
 
 .. _vdif_troubleshooting:
 


### PR DESCRIPTION
Added a tutorial for sequentialfile module, and cleaned up some of the associated docstrings.  Also added tutorial text pointing to the DADAFileNameSequencer, and cleaned up its docstring.

Addresses #46.