### PR TITLE
Remove vlbi_base.header.VLBIHeaderBase.__getattr__.

### DIFF
--- a/baseband/tests/test_conversion.py
+++ b/baseband/tests/test_conversion.py
@@ -391,7 +391,7 @@ class TestDADAToVDIF1(object):
                        time=vh.time, npol=vnthread, bps=vh.bps,
                        payloadsize=vh.payloadsize*2, nchan=vh.nchan,
                        telescope=vh.station,
-                       complex_data=vh.complex_data) as fw:
+                       complex_data=vh['complex_data']) as fw:
             new_header = fw.header0
             fw.write(dv_data)
 

--- a/baseband/vdif/header.py
+++ b/baseband/vdif/header.py
@@ -601,7 +601,7 @@ class VDIFMark5BHeader(VDIFBaseHeader, Mark5BHeader):
                       HeaderParser((('frame_length', (2, 0, 24, 1254)),)) +
                       HeaderParser(tuple(
                           ((k if k != 'frame_nr' else 'mark5b_frame_nr'),
-                           (v[0]+4,) + v[1:])
+                           (v[0] + 4,) + v[1:])
                           for (k, v) in Mark5BHeader._header_parser.items())))
 
     def verify(self):

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -182,9 +182,9 @@ class TestVDIF(object):
         assert headerX.bps == header.bps
         assert not headerX['complex_data']
         assert headerX.mutable is False
-        assert headerX.nonsense_0 == 2000000000
-        assert headerX.nonsense_1 == 100
-        assert headerX.nonsense_2 == 10000000
+        assert headerX['nonsense_0'] == 2000000000
+        assert headerX['nonsense_1'] == 100
+        assert headerX['nonsense_2'] == 10000000
 
     def test_decoding(self, tmpdir):
         """Check that look-up levels are consistent with mark5access."""
@@ -645,7 +645,7 @@ class TestVDIF(object):
         subset_md = (np.array([5, 3])[:, np.newaxis], np.array([0, 2]))
         with vdif.open(test_file, 'rs', subset=subset_md) as fhn:
             assert fhn.sample_shape == (2, 2)
-            thread_ids = [frame.header.thread_id for frame in
+            thread_ids = [frame.header['thread_id'] for frame in
                           fhn._frameset.frames]
             assert thread_ids == [5, 3]
             assert np.all(fhn.read() == data[(slice(None),) + subset_md])

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -332,7 +332,7 @@ class VLBIStreamReaderBase(VLBIStreamBase):
         oldpos = fh.tell()
         header = header_template.fromfile(fh)
         frame_nr0 = header['frame_nr']
-        sec0 = header.seconds
+        sec0 = header['seconds']
         while header['frame_nr'] == frame_nr0:
             fh.seek(header.payloadsize, 1)
             header = header_template.fromfile(fh)
@@ -342,7 +342,7 @@ class VLBIStreamReaderBase(VLBIStreamBase):
             fh.seek(header.payloadsize, 1)
             header = header_template.fromfile(fh)
 
-        if header.seconds != sec0 + 1:  # pragma: no cover
+        if header['seconds'] != sec0 + 1:  # pragma: no cover
             warnings.warn("header time changed by more than 1 second?")
 
         fh.seek(oldpos)

--- a/baseband/vlbi_base/header.py
+++ b/baseband/vlbi_base/header.py
@@ -467,16 +467,6 @@ class VLBIHeaderBase(object):
             else:
                 raise
 
-    def __getattr__(self, attr):
-        """Get attribute, or, failing that, try to get key from header."""
-        try:
-            return super(VLBIHeaderBase, self).__getattribute__(attr)
-        except AttributeError:
-            if attr in self.keys():
-                return self[attr]
-            else:
-                raise
-
     def keys(self):
         return self._header_parser.keys()
 

--- a/baseband/vlbi_base/tests/test_vlbi_base.py
+++ b/baseband/vlbi_base/tests/test_vlbi_base.py
@@ -153,7 +153,8 @@ class TestVLBIBase(object):
             self.header['bla']
         with pytest.raises(KeyError):
             self.header['bla'] = 1
-        assert self.header.x0_16_4 == 4
+        with pytest.raises(AttributeError):
+            self.header.x0_16_4
         with pytest.raises(AttributeError):
             self.header.xbla
 


### PR DESCRIPTION
Removes access to header parsed values as attributes, distinguishing them from
derived properties.

Resolves #115, though I'm concerned there's no way to test that there are no longer
any calls to parsed values using dot notation anywhere.  I suppose we'll just have to
trust the coverage is >99%.