### PR TITLE
VDIFHeader.fromvalues now properly sets frame_nr.

### DIFF
--- a/baseband/tests/test_conversion.py
+++ b/baseband/tests/test_conversion.py
@@ -50,6 +50,13 @@ class TestVDIFMark5B(object):
             assert (header.samples_per_frame ==
                     10000 * 8 // m5pl.bps // m5pl.sample_shape.nchan)
 
+        # Check that we can handle > 512 Mbps sampling rate.
+        header3 = vdif.VDIFHeader.from_mark5b_header(
+            m5h2, nchan=m5pl.sample_shape.nchan, bps=m5pl.bps,
+            sample_rate=64*u.MHz)
+        assert header3.time == header2.time
+        assert header3['frame_nr'] == header2['frame_nr'] + 1
+
         # A copy might remove any `kday` keywords set, but should still work
         # (Regression test for #34)
         header_copy = header2.copy()

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -475,6 +475,8 @@ class VDIFStreamWriter(VDIFStreamBase, VLBIStreamWriterBase, VDIFFileWriter):
     def __init__(self, raw, nthread=1, sample_rate=None, header=None,
                  squeeze=True, **kwargs):
         if header is None:
+            if sample_rate is not None:
+                kwargs['sample_rate'] = sample_rate
             header = VDIFHeader.fromvalues(**kwargs)
         # No frame sets yet exist, so generate a sample shape from values.
         super(VDIFStreamWriter, self).__init__(

--- a/baseband/vdif/header.py
+++ b/baseband/vdif/header.py
@@ -208,7 +208,15 @@ class VDIFHeader(VLBIHeaderBase):
         # Some defaults that are not done by setting properties.
         kwargs.setdefault('legacy_mode', True if edv is False else False)
         kwargs['edv'] = edv
-        return super(VDIFHeader, cls).fromvalues(edv, **kwargs)
+        time = kwargs.pop('time', None)
+        sample_rate = kwargs.pop('sample_rate', None)
+        frame_nr = kwargs.get('frame_nr', None)
+        self = super(VDIFHeader, cls).fromvalues(edv, **kwargs)
+        if sample_rate is not None and 'sample_rate' in self._properties:
+            self.sample_rate = sample_rate
+        if time is not None:
+            self.set_time(time, sample_rate, frame_nr)
+        return self
 
     @classmethod
     def fromkeys(cls, **kwargs):
@@ -250,9 +258,9 @@ class VDIFHeader(VLBIHeaderBase):
             ``invalid_data``.
         """
         kwargs.update(mark5b_header)
-        return cls.fromvalues(edv=0xab, time=mark5b_header.time,
-                              bps=bps, nchan=nchan, complex_data=False,
-                              **kwargs)
+        return super(VDIFHeader, cls).fromvalues(
+            0xab, time=mark5b_header.time, bps=bps, nchan=nchan,
+            complex_data=False, **kwargs)
 
     # properties common to all VDIF headers.
     @property

--- a/baseband/vdif/header.py
+++ b/baseband/vdif/header.py
@@ -210,13 +210,16 @@ class VDIFHeader(VLBIHeaderBase):
         kwargs['edv'] = edv
         time = kwargs.pop('time', None)
         sample_rate = kwargs.pop('sample_rate', None)
+        # Pop verify and pass on False so verify happens after time is set.
+        verify = kwargs.pop('verify', True)
         kwargs['verify'] = False
         self = super(VDIFHeader, cls).fromvalues(edv, **kwargs)
         if sample_rate is not None and 'sample_rate' in self._properties:
             self.sample_rate = sample_rate
         if time is not None:
             self.set_time(time, sample_rate=sample_rate)
-        self.verify()
+        if verify:
+            self.verify()
         return self
 
     @classmethod
@@ -646,7 +649,7 @@ class VDIFMark5BHeader(VDIFBaseHeader, Mark5BHeader):
         In the code, this is "unrounded" to give the exact time of the start
         of the frame for any total bit rate below 512 Mbps.  For rates above
         this value, it is no longer guaranteed that subsequent frames have
-        unique rates, and one should pass in an explicit frame rate instead.
+        unique rates, and one should pass in an explicit sample rate instead.
 
         Set frame_nr=0 to just get the header time from ref_epoch and seconds.
 
@@ -685,6 +688,10 @@ class VDIFMark5BHeader(VDIFBaseHeader, Mark5BHeader):
 
     def set_time(self, time, sample_rate=None):
         Mark5BHeader.set_time(self, time)
-        super(VDIFMark5BHeader, self).set_time(time, frame_nr=self['frame_nr'])
+        # Without a sample rate, we assume the frame number calculated
+        # by Mark5B header is correct; otherwise we calculate it here.
+        super(VDIFMark5BHeader, self).set_time(
+            time, sample_rate=sample_rate,
+            frame_nr=self['frame_nr'] if sample_rate is None else None)
 
     time = property(get_time, set_time)

--- a/baseband/vdif/header.py
+++ b/baseband/vdif/header.py
@@ -210,12 +210,11 @@ class VDIFHeader(VLBIHeaderBase):
         kwargs['edv'] = edv
         time = kwargs.pop('time', None)
         sample_rate = kwargs.pop('sample_rate', None)
-        frame_nr = kwargs.get('frame_nr', None)
         self = super(VDIFHeader, cls).fromvalues(edv, **kwargs)
         if sample_rate is not None and 'sample_rate' in self._properties:
             self.sample_rate = sample_rate
         if time is not None:
-            self.set_time(time, sample_rate, frame_nr)
+            self.set_time(time, sample_rate)
         return self
 
     @classmethod
@@ -424,7 +423,8 @@ class VDIFHeader(VLBIHeaderBase):
                 if sample_rate is None:
                     try:
                         sample_rate = self.sample_rate
-                    except AttributeError:
+                        assert sample_rate.value != 0.
+                    except (AttributeError, AssertionError):
                         raise ValueError("cannot calculate sample rate for "
                                          "this header. Pass it in explicitly.")
                 framerate = sample_rate / self.samples_per_frame

--- a/baseband/vdif/header.py
+++ b/baseband/vdif/header.py
@@ -210,11 +210,13 @@ class VDIFHeader(VLBIHeaderBase):
         kwargs['edv'] = edv
         time = kwargs.pop('time', None)
         sample_rate = kwargs.pop('sample_rate', None)
+        kwargs['verify'] = False
         self = super(VDIFHeader, cls).fromvalues(edv, **kwargs)
         if sample_rate is not None and 'sample_rate' in self._properties:
             self.sample_rate = sample_rate
         if time is not None:
-            self.set_time(time, sample_rate)
+            self.set_time(time, sample_rate=sample_rate)
+        self.verify()
         return self
 
     @classmethod
@@ -257,9 +259,9 @@ class VDIFHeader(VLBIHeaderBase):
             ``invalid_data``.
         """
         kwargs.update(mark5b_header)
-        return super(VDIFHeader, cls).fromvalues(
-            0xab, time=mark5b_header.time, bps=bps, nchan=nchan,
-            complex_data=False, **kwargs)
+        return cls.fromvalues(edv=0xab, time=mark5b_header.time,
+                              bps=bps, nchan=nchan, complex_data=False,
+                              **kwargs)
 
     # properties common to all VDIF headers.
     @property
@@ -681,7 +683,7 @@ class VDIFMark5BHeader(VDIFBaseHeader, Mark5BHeader):
         return (ref_epochs[self['ref_epoch']] +
                 TimeDelta(self['seconds'], offset, format='sec', scale='tai'))
 
-    def set_time(self, time):
+    def set_time(self, time, sample_rate=None):
         Mark5BHeader.set_time(self, time)
         super(VDIFMark5BHeader, self).set_time(time, frame_nr=self['frame_nr'])
 

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -133,7 +133,7 @@ class TestVDIF(object):
         assert header6['edv'] == 100
 
         # Make a new header to test passing time/sample rate.
-        headerT = header5.copy()
+        headerT = header.copy()
         headerT.time = header.time + 1. / framerate
 
         # Test initializing EDV 0 with properties, but off of 1 second mark so

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -132,37 +132,41 @@ class TestVDIF(object):
         assert isinstance(header6, vdif.header.VDIFBaseHeader)
         assert header6['edv'] == 100
 
+        # Make a new header to test passing time/sample rate.
+        headerT = header5.copy()
+        headerT.time = header.time + 1. / framerate
+
         # Test initializing EDV 0 with properties, but off of 1 second mark so
         # frame_nr is used.
-        header5.time = header.time + 1. / framerate
         header8 = vdif.VDIFHeader.fromvalues(
-            edv=0, ref_epoch=header5['ref_epoch'], seconds=header5['seconds'],
-            frame_nr=header5['frame_nr'], complex_data=header5['complex_data'],
-            samples_per_frame=header5.samples_per_frame, bps=header5.bps,
-            station=header5.station, thread_id=header5['thread_id'])
-        assert header8['ref_epoch'] == header5['ref_epoch']
-        assert header8['seconds'] == header5['seconds']
-        assert header8['frame_nr'] == header5['frame_nr']
+            edv=0, ref_epoch=headerT['ref_epoch'], seconds=headerT['seconds'],
+            frame_nr=headerT['frame_nr'], complex_data=headerT['complex_data'],
+            samples_per_frame=headerT.samples_per_frame, bps=headerT.bps,
+            station=headerT.station, thread_id=headerT['thread_id'])
+        assert header8['ref_epoch'] == headerT['ref_epoch']
+        assert header8['seconds'] == headerT['seconds']
+        assert header8['frame_nr'] == headerT['frame_nr']
         # The same header, but created by passing time and sample rate.
         header8_usetime = vdif.VDIFHeader.fromvalues(
-            edv=0, time=header5.time, sample_rate=header5.sample_rate,
-            complex_data=header5['complex_data'], bps=header5.bps,
-            samples_per_frame=header5.samples_per_frame,
-            station=header5.station, thread_id=header5['thread_id'])
+            edv=0, time=headerT.time, sample_rate=headerT.sample_rate,
+            complex_data=headerT['complex_data'], bps=headerT.bps,
+            samples_per_frame=headerT.samples_per_frame,
+            station=headerT.station, thread_id=headerT['thread_id'])
         assert header8_usetime == header8
-        # The same header, but created by passing time and frame number.
-        header8_usetimefrate = vdif.VDIFHeader.fromvalues(
-            edv=0, time=header5.time, frame_nr=header5['frame_nr'],
-            complex_data=header5['complex_data'], bps=header5.bps,
-            samples_per_frame=header5.samples_per_frame,
-            station=header5.station, thread_id=header5['thread_id'])
-        assert header8_usetimefrate == header8
         # Without a sample rate or frame_nr, cannot initialize using time.
         with pytest.raises(ValueError):
             vdif.VDIFHeader.fromvalues(
-                edv=0, time=header5.time, complex_data=header5['complex_data'],
-                bps=header5.bps, samples_per_frame=header5.samples_per_frame,
-                station=header5.station, thread_id=header5['thread_id'])
+                edv=0, time=headerT.time, complex_data=headerT['complex_data'],
+                bps=headerT.bps, samples_per_frame=headerT.samples_per_frame,
+                station=headerT.station, thread_id=headerT['thread_id'])
+
+        # Without a sample rate for EDV 1, 3, cannot initialize using time.
+        with pytest.raises(ValueError):
+            vdif.VDIFHeader.fromvalues(
+                edv=1, time=headerT.time, station=headerT.station,
+                samples_per_frame=headerT.samples_per_frame,
+                bps=headerT.bps, complex_data=headerT['complex_data'],
+                thread_id=headerT['thread_id'])
 
     def test_custom_header(self, tmpdir):
         # Custom header with an EDV that already exists


### PR DESCRIPTION
Fixes bug in VDIFStreamWriter where sample rate is not passed to fromvalues
for EDV 1, 3, which erroneously sets frame_nr = 0.  Bugfix necessitated
building some machinery so that fromvalues properly parses time and
sample_rate even for EDV 0.

Addresses #139.