### PR TITLE
Removed sanity check that header times change by less than 1 second, …

### DIFF
--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -332,7 +332,6 @@ class VLBIStreamReaderBase(VLBIStreamBase):
         oldpos = fh.tell()
         header = header_template.fromfile(fh)
         frame_nr0 = header['frame_nr']
-        sec0 = header['seconds']
         while header['frame_nr'] == frame_nr0:
             fh.seek(header.payloadsize, 1)
             header = header_template.fromfile(fh)
@@ -341,9 +340,6 @@ class VLBIStreamReaderBase(VLBIStreamBase):
             max_frame = max(header['frame_nr'], max_frame)
             fh.seek(header.payloadsize, 1)
             header = header_template.fromfile(fh)
-
-        if header['seconds'] != sec0 + 1:  # pragma: no cover
-            warnings.warn("header time changed by more than 1 second?")
 
         fh.seek(oldpos)
         return (max_frame + 1) * u.Hz


### PR DESCRIPTION
…as header['seconds'] is not guaranteed to exist in all formats (e.g. mark5b)