### PR TITLE
Assume recent pytest to get rid of warning in testing.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ all_files = 1
 upload-dir = docs/_build/html
 show-response = 1
 
-[pytest]
+[tool:pytest]
 minversion = 2.2
 norecursedirs = build docs/_build
 doctest_plus = enabled


### PR DESCRIPTION
fixes #140 