### PR TITLE
Raise error if neither kday nor ref_time passed to mark5b stream reader

### DIFF
--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -281,6 +281,11 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
 
     def __init__(self, fh_raw, ntrack=None, decade=None, ref_time=None,
                  subset=None, sample_rate=None, fill_value=0., squeeze=True):
+
+        if decade is None and ref_time is None:
+            raise ValueError("Mark4 stream reader requires decade or "
+                             "ref_time. Please pass either explicitly.")
+
         # Pre-set fh_raw, so FileReader methods work
         # TODO: move this to StreamReaderBase?
         self.fh_raw = fh_raw

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -732,6 +732,10 @@ class TestMark4(object):
         with pytest.raises(ValueError):
             mark4.open('ts.dat', 's')
 
+    def test_stream_missing_decade(self):
+        with pytest.raises(ValueError):
+            mark4.open(SAMPLE_FILE, 'rs', ntrack=64)
+
 
 class Test32TrackFanout4():
     def test_find_frame(self):

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -208,13 +208,13 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
 
     def __init__(self, fh_raw, nchan, bps=2, kday=None, ref_time=None,
                  subset=None, sample_rate=None, fill_value=0., squeeze=True):
-        # Pre-set fh_raw, so FileReader methods work
-        # TODO: move this to StreamReaderBase?
 
         if kday is None and ref_time is None:
             raise ValueError("Mark5B stream reader requires kday or ref_time. "
                              "Please pass either explicitly.")
 
+        # Pre-set fh_raw, so FileReader methods work
+        # TODO: move this to StreamReaderBase?
         self.fh_raw = fh_raw
         self._frame = self.read_frame(nchan=nchan, bps=bps,
                                       ref_time=ref_time, kday=kday)

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -210,6 +210,11 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
                  subset=None, sample_rate=None, fill_value=0., squeeze=True):
         # Pre-set fh_raw, so FileReader methods work
         # TODO: move this to StreamReaderBase?
+
+        if kday is None and ref_time is None:
+            raise ValueError("Mark5B stream reader requires kday or ref_time. "
+                             "Please pass either explicitly.")
+
         self.fh_raw = fh_raw
         self._frame = self.read_frame(nchan=nchan, bps=bps,
                                       ref_time=ref_time, kday=kday)

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -555,6 +555,11 @@ class TestMark5B(object):
         with pytest.raises(ValueError):
             mark5b.open('ts.dat', 's')
 
+    def test_stream_missing_kday(self):
+          with pytest.raises(ValueError):
+            mark5b.open(SAMPLE_FILE, 'rs', nchan=8, bps=2, 
+                        sample_rate = 32*u.MHz)
+
     # Test that writing an incomplete stream is possible, and that frame set is
     # appropriately marked as invalid.
     @pytest.mark.parametrize('fill_value', (0., -999.))

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -551,15 +551,6 @@ class TestMark5B(object):
             assert abs(fh.start_time - test_time) < 1.*u.ns
             assert fh.header0['frame_nr'] == 198
 
-    def test_stream_invalid(self):
-        with pytest.raises(ValueError):
-            mark5b.open('ts.dat', 's')
-
-    def test_stream_missing_kday(self):
-          with pytest.raises(ValueError):
-            mark5b.open(SAMPLE_FILE, 'rs', nchan=8, bps=2, 
-                        sample_rate = 32*u.MHz)
-
     # Test that writing an incomplete stream is possible, and that frame set is
     # appropriately marked as invalid.
     @pytest.mark.parametrize('fill_value', (0., -999.))
@@ -580,3 +571,12 @@ class TestMark5B(object):
             assert not fwr._frame.valid
             assert np.all(fwr.read() == fwr._frame.invalid_data_value)
             assert fwr._frame.invalid_data_value == fill_value
+
+    def test_stream_invalid(self):
+        with pytest.raises(ValueError):
+            mark5b.open('ts.dat', 's')
+
+    def test_stream_missing_kday(self):
+        with pytest.raises(ValueError):
+            mark5b.open(SAMPLE_FILE, 'rs', nchan=8, bps=2,
+                        sample_rate=32*u.MHz)


### PR DESCRIPTION
Provides an informative error, letting the user know that they must pass a kday or ref_time to the mark5b stream reader if they attempt to use the mark5b stream reader without either argument. 