### PR TITLE
Standardize errors returned when reading beyond the EOF.

### DIFF
--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -267,10 +267,11 @@ class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase, DADAFileReader):
         if out is None:
             if count is None or count < 0:
                 count = self.size - self.offset
+                if count < 0:
+                    raise EOFError
 
             out = np.empty((count,) + self.sample_shape,
                            dtype=self._frame.dtype)
-            # Generate view of the result data set that will be returned.
         else:
             assert out.shape[1:] == self.sample_shape, (
                 "'out' should have trailing shape {}".format(self.sample_shape))

--- a/baseband/dada/tests/test_dada.py
+++ b/baseband/dada/tests/test_dada.py
@@ -290,6 +290,9 @@ class TestDADA(object):
             assert fhseek_int == fhseek_str
             with pytest.raises(ValueError):
                 fh.seek(0, 'last')
+            fh.seek(1, 'end')
+            with pytest.raises(EOFError):
+                fh.read()
 
         assert record1.shape == (12, 2)
         assert np.all(record1[:3] == np.array(

--- a/baseband/gsb/base.py
+++ b/baseband/gsb/base.py
@@ -296,6 +296,8 @@ class GSBStreamReader(GSBStreamBase, VLBIStreamReaderBase):
         if out is None:
             if count is None or count < 0:
                 count = self.size - self.offset
+                if count < 0:
+                    raise EOFError
 
             dtype = np.complex64 if self.complex_data else np.float32
             out = np.empty((count,) + self.sample_shape, dtype)

--- a/baseband/gsb/tests/test_gsb.py
+++ b/baseband/gsb/tests/test_gsb.py
@@ -620,6 +620,9 @@ class TestGSB(object):
             out1 = np.empty_like(data1)
             fh_r.read(out=out1)
             assert np.all(out1 == data1)
+            fh_r.seek(1, 'end')
+            with pytest.raises(EOFError):
+                fh_r.read()
 
         # Try again with squeezing.
         with gsb.open(SAMPLE_PHASED_HEADER, 'rs', raw=SAMPLE_PHASED,

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -377,6 +377,8 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
         if out is None:
             if count is None or count < 0:
                 count = self.size - self.offset
+                if count < 0:
+                    raise EOFError
 
             out = np.empty((count,) + self.sample_shape,
                            dtype=self._frame.dtype)

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -523,6 +523,9 @@ class TestMark4(object):
             assert fhseek_int == fhseek_str
             with pytest.raises(ValueError):
                 fh.seek(0, 'last')
+            fh.seek(1, 'end')
+            with pytest.raises(EOFError):
+                fh.read()
 
         assert record.shape == (642, 8)
         assert np.all(record[:640] == 0.)

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -255,6 +255,8 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
         if out is None:
             if count is None or count < 0:
                 count = self.size - self.offset
+                if count < 0:
+                    raise EOFError
 
             out = np.empty((count,) + self.sample_shape,
                            dtype=self._frame.dtype)

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -371,6 +371,9 @@ class TestMark5B(object):
             assert fhseek_int == fhseek_str
             with pytest.raises(ValueError):
                 fh.seek(0, 'last')
+            fh.seek(1, 'end')
+            with pytest.raises(EOFError):
+                fh.read()
 
         assert last_header['frame_nr'] == 3
         assert last_header['user'] == header['user']

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -380,6 +380,8 @@ class VDIFStreamReader(VDIFStreamBase, VLBIStreamReaderBase, VDIFFileReader):
         if out is None:
             if count is None or count < 0:
                 count = self.size - self.offset
+                if count < 0:
+                    raise EOFError
 
             out = np.empty((count,) + self.sample_shape,
                            dtype=self._frameset.dtype)

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -582,6 +582,9 @@ class TestVDIF(object):
                 fh.samples_per_frame / fh.sample_rate)) < 1. * u.ns
             assert abs(fh.stop_time - fh.start_time -
                        (fh.size / fh.sample_rate)) < 1. * u.ns
+            fh.seek(1, 'end')
+            with pytest.raises(EOFError):
+                fh.read()
 
         assert record.shape == (12, 8)
         assert np.all(record.astype(int)[:, 0] ==

--- a/docs/baseband/tutorials/getting_started.rst
+++ b/docs/baseband/tutorials/getting_started.rst
@@ -142,15 +142,18 @@ files through selective decoding using ``seek`` and ``read``.
 
 .. note::
 
-    Cation should be used when decoding large blocks of data using
-    ``fh.read``.  For typical files, the resulting arrays are far too
-    large to hold in memory.
+    As with file pointers in general, ``fh.seek`` will not return an error if
+    one seeks beyond the end of file.  Attempting to read beyond
+    the end of file, however, will result in an ``EOFError``.
 
 To determine where the pointer is located, we use ``fh.tell()``::
 
     >>> fh.tell()
     40000
     >>> fh.close()
+
+Caution should be used when decoding large blocks of data using ``fh.read``. 
+For typical files, the resulting arrays are far too large to hold in memory.
 
 Seeking and Telling in Time With the Sample Pointer
 ---------------------------------------------------


### PR DESCRIPTION
Baseband now returns an `EOFError` regardless of whether `count` is specified.  A note is also made in the documentation.

Resolves #59.