### PR TITLE
Pull request to solve #146

### DIFF
--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -270,6 +270,8 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
         Number of complete samples per second (ie. the rate at which each
         channel is sampled).  If not given, will be inferred from scanning two
         frames of the file.
+    fill_value : float or complex
+        Value to use for invalid or missing data (Default value is 0).
     squeeze : bool, optional
         If `True` (default), remove any dimensions of length unity from
         decoded data.
@@ -278,7 +280,7 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
     _sample_shape_maker = Mark4Payload._sample_shape_maker
 
     def __init__(self, fh_raw, ntrack=None, decade=None, ref_time=None,
-                 subset=None, sample_rate=None, squeeze=True):
+                 subset=None, sample_rate=None, fill_value=0., squeeze=True):
         # Pre-set fh_raw, so FileReader methods work
         # TODO: move this to StreamReaderBase?
         self.fh_raw = fh_raw
@@ -303,7 +305,7 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
             unsliced_shape=self._frame.payload.sample_shape,
             bps=header.bps, complex_data=False, subset=subset,
             samples_per_frame=header.samples_per_frame,
-            squeeze=squeeze)
+            fill_value=fill_value, squeeze=squeeze)
 
     @staticmethod
     def _get_frame_rate(fh, header_template):
@@ -350,7 +352,7 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
         last_header.infer_decade(self.start_time)
         return last_header
 
-    def read(self, count=None, fill_value=0., out=None):
+    def read(self, count=None, out=None):
         """Read count samples.
 
         The range retrieved can span multiple frames.
@@ -360,8 +362,6 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
         count : int
             Number of samples to read.  If omitted or negative, the whole
             file is read.  Ignored if ``out`` is given.
-        fill_value : float
-            Value to use for invalid or missing data.
         out : `None` or array
             Array to store the data in. If given, ``count`` will be inferred
             from the first dimension.  The other dimension should equal
@@ -395,7 +395,7 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
                 self._read_frame()
 
             # Set decoded value for invalid data.
-            self._frame.invalid_data_value = fill_value
+            self._frame.invalid_data_value = self.fill_value
             # Determine appropriate slice to decode.
             nsample = min(count, self.samples_per_frame - sample_offset)
             sample = self.offset - offset0
@@ -532,6 +532,8 @@ sample_rate : `~astropy.units.Quantity`, optional
     Number of complete samples per second (ie. the rate at which each channel
     is sampled).  If not given, will be inferred from scanning two frames of
     the file.
+fill_value : float or complex
+    Value to use for invalid or missing data (Default value is 0).
 squeeze : bool, optional
     If `True` (default), remove any dimensions of length unity from
     decoded data.

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -662,10 +662,9 @@ class TestMark4(object):
         assert len(w) == 1
         assert 'partial buffer' in str(w[0].message)
         with mark4.open(m4_incomplete, 'rs', ntrack=64, decade=2010,
-                        sample_rate=32*u.MHz) as fwr:
+                        sample_rate=32*u.MHz, fill_value=fill_value) as fwr:
             assert not fwr._frame.valid
-            assert np.all(fwr.read(fill_value=fill_value) ==
-                          fwr._frame.invalid_data_value)
+            assert np.all(fwr.read() == fwr._frame.invalid_data_value)
             assert fwr._frame.invalid_data_value == fill_value
 
     def test_corrupt_stream(self, tmpdir):

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -570,8 +570,8 @@ class TestMark5B(object):
         assert len(w) == 1
         assert 'partial buffer' in str(w[0].message)
         with mark5b.open(m5_incomplete, 'rs', nchan=8, bps=2,
-                         sample_rate=32*u.MHz, kday=56000) as fwr:
+                         sample_rate=32*u.MHz, kday=56000,
+                         fill_value=fill_value) as fwr:
             assert not fwr._frame.valid
-            assert np.all(fwr.read(fill_value=fill_value) ==
-                          fwr._frame.invalid_data_value)
+            assert np.all(fwr.read() == fwr._frame.invalid_data_value)
             assert fwr._frame.invalid_data_value == fill_value

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -238,7 +238,7 @@ class VDIFStreamBase(VLBIStreamBase):
     _sample_shape_maker = namedtuple('SampleShape', 'nthread, nchan')
 
     def __init__(self, fh_raw, header0, subset, nthread, sample_rate=None,
-                 squeeze=True):
+                 fill_value=0., squeeze=True):
         samples_per_frame = header0.samples_per_frame
         if sample_rate is None:
             try:
@@ -251,7 +251,7 @@ class VDIFStreamBase(VLBIStreamBase):
             unsliced_shape=(nthread, header0.nchan),
             bps=header0.bps, complex_data=header0['complex_data'],
             subset=subset, samples_per_frame=samples_per_frame,
-            sample_rate=sample_rate, squeeze=squeeze)
+            sample_rate=sample_rate, fill_value=fill_value, squeeze=squeeze)
 
     def _get_time(self, header):
         """Get time from a header.
@@ -294,12 +294,15 @@ class VDIFStreamReader(VDIFStreamBase, VLBIStreamReaderBase, VDIFFileReader):
         Number of complete samples per second (ie. the rate at which each
         channel in each thread is sampled).  If not given, will be inferred
         from the header or by scanning one second of the file.
+    fill_value : float or complex
+        Value to use for invalid or missing data (Default value is 0).
     squeeze : bool, optional
         If `True` (default), remove any dimensions of length unity from
         decoded data.
     """
 
-    def __init__(self, fh_raw, subset=None, sample_rate=None, squeeze=True):
+    def __init__(self, fh_raw, subset=None, sample_rate=None, fill_value=0.,
+                 squeeze=True):
         # We use the very first header in the file, since in some VLBA files
         # not all the headers have the right time.  Hopefully, the first is
         # least likely to have problems...
@@ -313,9 +316,9 @@ class VDIFStreamReader(VDIFStreamBase, VLBIStreamReaderBase, VDIFFileReader):
         self._frameset = self.read_frameset()
         thread_ids = [fr['thread_id'] for fr in self._frameset.frames]
         self._framesetsize = fh_raw.tell()
-        super(VDIFStreamReader, self).__init__(fh_raw, header, subset,
-                                               len(self._frameset.frames),
-                                               sample_rate, squeeze)
+        super(VDIFStreamReader, self).__init__(
+            fh_raw, header, subset, len(self._frameset.frames),
+            sample_rate=sample_rate, fill_value=fill_value, squeeze=squeeze)
         # Set _thread_ids.  If subsetting, decode first frameset again.
         if self.subset:
             # Squeeze in case subset[0] uses broadcasting.
@@ -353,7 +356,7 @@ class VDIFStreamReader(VDIFStreamBase, VLBIStreamReaderBase, VDIFFileReader):
         self.fh_raw.seek(raw_offset)
         return last_header
 
-    def read(self, count=None, fill_value=0., out=None):
+    def read(self, count=None, out=None):
         """Read a number of complete (or subset) samples.
 
         The range retrieved can span multiple frames.
@@ -363,8 +366,6 @@ class VDIFStreamReader(VDIFStreamBase, VLBIStreamReaderBase, VDIFFileReader):
         count : int, optional
             Number of complete/subset samples to read.  If omitted or negative,
             the whole file is read.  Ignored if ``out`` is given.
-        fill_value : float or complex
-            Value to use for invalid or missing data.
         out : `None` or array
             Array to store the data in. If given, ``count`` will be inferred
             from the first dimension.  The other dimensions should equal
@@ -403,7 +404,7 @@ class VDIFStreamReader(VDIFStreamBase, VLBIStreamReaderBase, VDIFFileReader):
                 assert frame_nr == self._frameset['frame_nr']
 
             # Set decoded value for invalid data.
-            self._frameset.invalid_data_value = fill_value
+            self._frameset.invalid_data_value = self.fill_value
             # Determine appropriate slice to decode.
             nsample = min(count, self.samples_per_frame - sample_offset)
             sample = self.offset - offset0
@@ -479,7 +480,7 @@ class VDIFStreamWriter(VDIFStreamBase, VLBIStreamWriterBase, VDIFFileWriter):
             header = VDIFHeader.fromvalues(**kwargs)
         # No frame sets yet exist, so generate a sample shape from values.
         super(VDIFStreamWriter, self).__init__(
-            raw, header, None, nthread, sample_rate=sample_rate,
+            raw, header, None, nthread, sample_rate=sample_rate, 
             squeeze=squeeze)
         # Set sample rate in the header, if it's possible, and not set already.
         try:
@@ -554,6 +555,8 @@ sample_rate : `~astropy.units.Quantity`, optional
     Number of complete samples per second (ie. the rate at which each channel
     in each thread is sampled).  If not given, will be inferred from the header
     or by scanning one second of the file.
+fill_value : float or complex
+    Value to use for invalid or missing data (Default value is 0).
 squeeze : bool, optional
     If `True` (default), remove any dimensions of length unity from
     decoded data.

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -717,10 +717,9 @@ class TestVDIF(object):
                     fw.write(record)
         assert len(w) == 1
         assert 'partial buffer' in str(w[0].message)
-        with vdif.open(vdif_incomplete, 'rs') as fwr:
+        with vdif.open(vdif_incomplete, 'rs', fill_value=fill_value) as fwr:
             assert all([not frame.valid for frame in fwr._frameset.frames])
-            assert np.all(fwr.read(fill_value=fill_value) ==
-                          fwr._frameset.invalid_data_value)
+            assert np.all(fwr.read() == fwr._frameset.invalid_data_value)
             assert fwr._frameset.invalid_data_value == fill_value
 
     def test_corrupt_stream(self, tmpdir):

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -49,7 +49,8 @@ class VLBIStreamBase(VLBIFileBase):
     _sample_shape_maker = None
 
     def __init__(self, fh_raw, header0, unsliced_shape, bps, complex_data,
-                 subset, samples_per_frame, sample_rate, squeeze=True):
+                 subset, samples_per_frame, sample_rate, fill_value=0., 
+                 squeeze=True):
         super(VLBIStreamBase, self).__init__(fh_raw)
         self._header0 = header0
         self._bps = bps
@@ -57,6 +58,7 @@ class VLBIStreamBase(VLBIFileBase):
         self.samples_per_frame = samples_per_frame
         self.sample_rate = sample_rate
         self.offset = 0
+        self._fill_value = fill_value
 
         if self._sample_shape_maker is not None:
             self._unsliced_shape = self._sample_shape_maker(*unsliced_shape)
@@ -78,6 +80,11 @@ class VLBIStreamBase(VLBIFileBase):
                 subset = subset_wrapints
         self._subset = subset
         self._sample_shape = self._get_sample_shape(subset_wrapints)
+
+    @property
+    def fill_value(self):
+        """Value to use for invalid or missing data (Default value is 0)."""
+        return self._fill_value
 
     @property
     def squeeze(self):
@@ -271,7 +278,7 @@ class VLBIStreamBase(VLBIFileBase):
 class VLBIStreamReaderBase(VLBIStreamBase):
 
     def __init__(self, fh_raw, header0, unsliced_shape, bps, complex_data,
-                 subset, samples_per_frame, sample_rate=None,
+                 subset, samples_per_frame, sample_rate=None, fill_value=0.,
                  squeeze=True):
 
         if sample_rate is None:
@@ -289,7 +296,7 @@ class VLBIStreamReaderBase(VLBIStreamBase):
 
         super(VLBIStreamReaderBase, self).__init__(
             fh_raw, header0, unsliced_shape, bps, complex_data, subset,
-            samples_per_frame, sample_rate, squeeze)
+            samples_per_frame, sample_rate, fill_value, squeeze)
 
     @staticmethod
     def _get_frame_rate(fh, header_template):


### PR DESCRIPTION
Moved `fill_value` out of fh.read(...) and made it a property of the file handle for VDIF, Mark4, Mark5B, and GSB. The DADA file format doesn't seem to use `fill_value`.