### PR TITLE
Mark4 frame getitem

### DIFF
--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -399,8 +399,7 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
             # Determine appropriate slice to decode.
             nsample = min(count, self.samples_per_frame - sample_offset)
             sample = self.offset - offset0
-            # TODO: cannot yet index frame directly.
-            data = self._frame.data[sample_offset:sample_offset + nsample]
+            data = self._frame[sample_offset:sample_offset + nsample]
             data = self._squeeze_and_subset(data)
             # Copy relevant data from frame into output.
             out[sample:sample + nsample] = data

--- a/baseband/vlbi_base/frame.py
+++ b/baseband/vlbi_base/frame.py
@@ -123,14 +123,18 @@ class VLBIFrameBase(object):
         return cls(header, payload, valid=valid, verify=verify)
 
     @property
-    def shape(self):
-        """Shape of the data held in the payload (samples_per_frame, nchan)."""
-        return self.payload.shape
+    def sample_shape(self):
+        """Shape of the samples held in the frame (nchan,)."""
+        return self.payload.sample_shape
+
+    def __len__(self):
+        """Number of samples in the frame."""
+        return len(self.payload)
 
     @property
-    def sample_shape(self):
-        """Shape of the samples held in the payload (nchan,)."""
-        return self.payload.sample_shape
+    def shape(self):
+        """Shape of the data held in the frame (samples_per_frame, nchan)."""
+        return (len(self),) + self.sample_shape
 
     @property
     def dtype(self):

--- a/baseband/vlbi_base/frame.py
+++ b/baseband/vlbi_base/frame.py
@@ -128,6 +128,11 @@ class VLBIFrameBase(object):
         return self.payload.shape
 
     @property
+    def sample_shape(self):
+        """Shape of the samples held in the payload (nchan,)."""
+        return self.payload.sample_shape
+
+    @property
     def dtype(self):
         """Numeric type of the payload."""
         return self.payload.dtype
@@ -172,13 +177,11 @@ class VLBIFrameBase(object):
 
     # Try to get any attribute not on the frame from the header properties.
     def __getattr__(self, attr):
-        try:
+        if attr in self.header._properties:
+            return getattr(self.header, attr)
+        else:
+            # Raise appropriate error.
             return self.__getattribute__(attr)
-        except AttributeError:
-            if attr in self.header._properties:
-                return getattr(self.header, attr)
-            else:
-                raise
 
     # For tests, it is useful to define equality.
     def __eq__(self, other):

--- a/baseband/vlbi_base/payload.py
+++ b/baseband/vlbi_base/payload.py
@@ -128,15 +128,14 @@ class VLBIPayloadBase(object):
         """Size in bytes of payload."""
         return self.words.size * self.words.dtype.itemsize
 
-    @property
-    def nsample(self):
+    def __len__(self):
         """Number of samples in the payload."""
         return self.size * 8 // self._bpfs
 
     @property
     def shape(self):
         """Shape of the decoded data array (nsample, sample_shape)."""
-        return (self.nsample,) + self.sample_shape
+        return (len(self),) + self.sample_shape
 
     @property
     def dtype(self):
@@ -177,9 +176,10 @@ class VLBIPayloadBase(object):
         else:
             sample_index = ()
 
+        nsample = len(self)
         is_slice = isinstance(item, slice)
         if is_slice:
-            start, stop, step = item.indices(self.nsample)
+            start, stop, step = item.indices(nsample)
             n = stop - start
             if step == 1:
                 step = None
@@ -190,14 +190,14 @@ class VLBIPayloadBase(object):
                 raise TypeError("{0} object can only be indexed or sliced."
                                 .format(type(self)))
             if item < 0:
-                item += self.nsample
+                item += nsample
 
-            if not (0 <= item < self.nsample):
+            if not (0 <= item < nsample):
                 raise IndexError("{0} index out of range.".format(type(self)))
 
             start, stop, step, n = item, item+1, 1, 1
 
-        if n == self.nsample:
+        if n == nsample:
             words_slice = slice(None)
             data_slice = slice(None, None, step) if is_slice else 0
 

--- a/baseband/vlbi_base/payload.py
+++ b/baseband/vlbi_base/payload.py
@@ -172,8 +172,10 @@ class VLBIPayloadBase(object):
         with 20 bits/sample).
         """
         if isinstance(item, tuple):
-            word_slice, data_slice = self._item_to_slices(item[0])
-            return word_slice, (data_slice,) + item[1:]
+            sample_index = item[1:]
+            item = item[0]
+        else:
+            sample_index = ()
 
         is_slice = isinstance(item, slice)
         if is_slice:
@@ -226,7 +228,7 @@ class VLBIPayloadBase(object):
                                 "samples have {0} bits and words have {1} bits"
                                 .format(bpfs, bpw))
 
-        return words_slice, data_slice
+        return words_slice, (data_slice,) + sample_index
 
     def __getitem__(self, item=()):
         decoder = self._decoders[self._coder]

--- a/baseband/vlbi_base/tests/test_vlbi_base.py
+++ b/baseband/vlbi_base/tests/test_vlbi_base.py
@@ -330,7 +330,7 @@ class TestVLBIBase(object):
         assert payload.bps == 8
         assert payload.words.dtype is self.Payload._dtype_word
         assert len(payload.words) == 4
-        assert payload.nsample == len(data)
+        assert len(payload) == len(data)
         assert payload.size == 16
         payload2 = self.Payload.fromdata(self.payload.data, self.payload.bps)
         assert payload2 == self.payload
@@ -352,6 +352,8 @@ class TestVLBIBase(object):
     def test_frame_basics(self):
         assert self.frame.header is self.header
         assert self.frame.payload is self.payload
+        assert len(self.frame) == len(self.payload)
+        assert self.frame.sample_shape == self.payload.sample_shape
         assert self.frame.shape == self.payload.shape
         assert np.all(self.frame.data == self.payload.data)
         assert np.all(np.array(self.frame) == np.array(self.payload))


### PR DESCRIPTION
Slices the relevant part of the payload, and sets anything that overlaps with the header to invalid.

As part of this, it also turned out to be handy to propagate `sample_shape` and `nsamples` from the payload to the frame.

fixes #128