### PR TITLE
Vdif frameset data ordering

### DIFF
--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -432,7 +432,7 @@ class VDIFStreamReader(VDIFStreamBase, VLBIStreamReaderBase, VDIFFileReader):
             self._frameset.invalid_data_value = self.fill_value
             # TODO: maybe slice with data_slice once frameset allows slicing,
             # so we decode only what is needed.
-            data = self._frameset.data.transpose(1, 0, 2)
+            data = self._frameset.data
             # Determine appropriate slice.
             nsample = min(count, self.samples_per_frame - sample_offset)
             sample = self.offset - offset0
@@ -527,8 +527,7 @@ class VDIFStreamWriter(VDIFStreamBase, VLBIStreamWriterBase, VDIFFileWriter):
                 self.header0.sample_rate = self.sample_rate
             assert self.header0.sample_rate == self.sample_rate
         self._data = np.zeros(
-            (self._unsliced_shape.nthread, self.samples_per_frame,
-                self._unsliced_shape.nchan),
+            (self.samples_per_frame,) + self._unsliced_shape,
             np.complex64 if self.complex_data else np.float32)
 
     def write(self, data, invalid_data=False):
@@ -554,7 +553,7 @@ class VDIFStreamWriter(VDIFStreamBase, VLBIStreamWriterBase, VDIFFileWriter):
         count = data.shape[0]
         sample = 0
         offset0 = self.offset
-        frame = self._data.transpose(1, 0, 2)
+        frame = self._data
         while count > 0:
             dt, frame_nr, sample_offset = self._frame_info()
             if sample_offset == 0:

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -394,7 +394,7 @@ class TestVDIF(object):
         assert len(frameset.frames) == 8
         assert frameset.samples_per_frame == 20000
         assert frameset.nchan == 1
-        assert frameset.shape == (8, 20000, 1)
+        assert frameset.shape == (20000, 8, 1)
         assert frameset.size == 8 * frameset.frames[0].size
         assert 'edv' in frameset
         assert 'edv' in frameset.keys()
@@ -419,9 +419,9 @@ class TestVDIF(object):
             frameset2 = fh.read_frameset(thread_ids=[2, 3])
             fh.fh_raw.seek(0)
             frameset3 = fh.read_frameset(thread_ids=[3, 4, 1])
-        assert frameset2.shape == (2, 20000, 1)
-        assert np.all(frameset2.data == frameset.data[2:4])
-        assert np.all(frameset3.data == frameset.data[[3, 4, 1]])
+        assert frameset2.shape == (20000, 2, 1)
+        assert np.all(frameset2.data == frameset.data[:, 2:4])
+        assert np.all(frameset3.data == frameset.data[:, [3, 4, 1]])
 
         frameset3 = vdif.VDIFFrameSet(frameset.frames, frameset.header0)
         assert frameset3 == frameset
@@ -442,7 +442,7 @@ class TestVDIF(object):
             # try reading just a few threads
             frameset4 = fh.read_frameset(thread_ids=[2, 3])
             assert frameset4.header0.time == frameset.header0.time
-            assert np.all(frameset.data[2:4] == frameset4.data)
+            assert np.all(frameset.data[:, 2:4] == frameset4.data)
             # Read beyond end
             fh.seek(-10064, 2)
             with pytest.raises(EOFError):

--- a/docs/baseband/vdif/index.rst
+++ b/docs/baseband/vdif/index.rst
@@ -60,7 +60,7 @@ data container for storing a frame set as well as
     >>> fh = vdif.open(SAMPLE_VDIF, 'rb')
     >>> fs = fh.read_frameset()
     >>> fs.data.shape
-    (8, 20000, 1)
+    (20000, 8, 1)
     >>> fr = fh.read_frame()
     >>> fr.data.shape
     (20000, 1)


### PR DESCRIPTION
I broke my own rules and put this on top of the mark4 work, since I wanted to use `samples_per_frame`... Anyway, for VDIF only look at the last commit.

We would need to do some performance checking to see whether merging the different frames now takes a long time compared to decoding them.

fixes #129