### PR TITLE
Move read up to vlbi_base, requiring a revised _read_frame method.

### DIFF
--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -243,12 +243,11 @@ class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase, DADAFileReader):
         last_frame = self.read_frame(memmap=True)
         return last_frame.header
 
-    def _read_frame(self, frame_nr):
-        self.fh_raw.seek(frame_nr * self.header0.framesize)
+    def _read_frame(self, index):
+        self.fh_raw.seek(index * self.header0.framesize)
         frame = self.read_frame(memmap=True)
-        assert ((frame.header['OBS_OFFSET'] -
-                 self.header0['OBS_OFFSET']) / self.header0.payloadsize ==
-                frame_nr)
+        assert (frame.header['OBS_OFFSET'] - self.header0['OBS_OFFSET'] ==
+                index * self.header0.payloadsize)
         return frame
 
 

--- a/baseband/dada/tests/test_dada.py
+++ b/baseband/dada/tests/test_dada.py
@@ -412,10 +412,9 @@ class TestDADA(object):
         assert len(w) == 1
         assert 'partial buffer' in str(w[0].message)
         with dada.open(filename, 'rs', squeeze=False) as fwr:
-            assert fwr._frame.valid
             data = fwr.read()
             assert np.all(data[:10] == self.payload[:10])
-            assert np.all(data[10:] == fwr._frame.invalid_data_value)
+            assert np.all(data[10:] == fwr.fill_value)
 
     def test_multiple_files_stream(self, tmpdir):
         start_time = self.header.time

--- a/baseband/gsb/base.py
+++ b/baseband/gsb/base.py
@@ -234,7 +234,6 @@ class GSBStreamReader(GSBStreamBase, VLBIStreamReaderBase):
             samples_per_frame=samples_per_frame, payloadsize=payloadsize,
             sample_rate=sample_rate, squeeze=squeeze)
         self.fh_ts.seek(0)
-        self._frame_nr = None
 
     @lazyproperty
     def _last_header(self):
@@ -269,21 +268,21 @@ class GSBStreamReader(GSBStreamBase, VLBIStreamReaderBase):
             last_header = self.header0.__class__(second_last_line_tuple)
         return last_header
 
-    def _read_frame(self, frame_nr):
-        self.fh_ts.seek(self.header0.seek_offset(frame_nr))
+    def _read_frame(self, index):
+        self.fh_ts.seek(self.header0.seek_offset(index))
         if self.header0.mode == 'rawdump':
-            self.fh_raw.seek(frame_nr * self._payloadsize)
+            self.fh_raw.seek(index * self._payloadsize)
         else:
             for fh_pair in self.fh_raw:
                 for fh in fh_pair:
-                    fh.seek(frame_nr * self._payloadsize)
+                    fh.seek(index * self._payloadsize)
         frame = GSBFrame.fromfile(self.fh_ts, self.fh_raw,
                                   payloadsize=self._payloadsize,
                                   nchan=self._unsliced_shape.nchan,
                                   bps=self.bps, complex_data=self.complex_data)
         assert int(round(((frame.header.time - self.start_time) *
                           self.sample_rate / self.samples_per_frame)
-                         .to_value(u.one))) == frame_nr
+                         .to_value(u.one))) == index
         return frame
 
 

--- a/baseband/gsb/base.py
+++ b/baseband/gsb/base.py
@@ -269,82 +269,30 @@ class GSBStreamReader(GSBStreamBase, VLBIStreamReaderBase):
             last_header = self.header0.__class__(second_last_line_tuple)
         return last_header
 
-    def read(self, count=None, out=None):
-        """Read a number of complete (or subset) samples.
-
-        The range retrieved can span multiple frames.
-
-        Parameters
-        ----------
-        count : int, optional
-            Number of complete/subset samples to read.  If omitted or negative,
-            the whole file is read.  Ignored if ``out`` is given.
-        out : `None` or array
-            Array to store the data in. If given, ``count`` will be inferred
-            from the first dimension.  The other dimensions should equal
-            ``sample_shape``.
-
-        Returns
-        -------
-        out : array of float or complex
-            The first dimension is sample-time, and the other two, given by
-            ``sample_shape``, are (polarization, channel).  Any
-            dimension of length unity is removed if ``self.squeeze=True``.
-        """
-        if out is None:
-            if count is None or count < 0:
-                count = self.size - self.offset
-                if count < 0:
-                    raise EOFError
-
-            dtype = np.complex64 if self.complex_data else np.float32
-            out = np.empty((count,) + self.sample_shape, dtype)
-        else:
-            assert out.shape[1:] == self.sample_shape, (
-                "'out' should have trailing shape {}".format(self.sample_shape))
-            count = out.shape[0]
-
-        offset0 = self.offset
-        while count > 0:
-            frame_nr, sample_offset = divmod(self.offset,
-                                             self.samples_per_frame)
-            if(frame_nr != self._frame_nr):
-                # Read relevant frame (possibly reusing data array from
-                # previous frame set).
-                self._read_frame()
-                framerate = self.sample_rate / self.samples_per_frame
-                assert np.isclose(self._frame_nr,
-                                  ((self._frame.header.time -
-                                    self.start_time) * framerate).to(u.one))
-
-            # Determine appropriate slice to decode.
-            nsample = min(count, self.samples_per_frame - sample_offset)
-            sample = self.offset - offset0
-            data = self._frame[sample_offset:sample_offset + nsample]
-            data = self._squeeze_and_subset(data)
-            # Copy relevant data from frame into output.
-            out[sample:sample + nsample] = data
-            self.offset += nsample
-            count -= nsample
-
-        return out
-
-    def _read_frame(self, out=None):
-        frame_nr = self.offset // self.samples_per_frame
-        self.fh_ts.seek(self.header0.seek_offset(frame_nr))
-        if self.header0.mode == 'rawdump':
-            self.fh_raw.seek(frame_nr * self._payloadsize)
-        else:
-            for fh_pair in self.fh_raw:
-                for fh in fh_pair:
-                    fh.seek(frame_nr * self._payloadsize)
-        self._frame = GSBFrame.fromfile(self.fh_ts, self.fh_raw,
-                                        payloadsize=self._payloadsize,
-                                        nchan=self._unsliced_shape.nchan,
-                                        bps=self.bps,
-                                        complex_data=self.complex_data)
-        self._frame_nr = frame_nr
-        return self._frame
+    def _read_frame(self):
+        frame_nr, sample_offset = divmod(self.offset,
+                                         self.samples_per_frame)
+        if frame_nr != self._frame_nr:
+            # Read relevant frame (possibly reusing data array from
+            # previous frame set).
+            self.fh_ts.seek(self.header0.seek_offset(frame_nr))
+            if self.header0.mode == 'rawdump':
+                self.fh_raw.seek(frame_nr * self._payloadsize)
+            else:
+                for fh_pair in self.fh_raw:
+                    for fh in fh_pair:
+                        fh.seek(frame_nr * self._payloadsize)
+            self._frame = GSBFrame.fromfile(self.fh_ts, self.fh_raw,
+                                            payloadsize=self._payloadsize,
+                                            nchan=self._unsliced_shape.nchan,
+                                            bps=self.bps,
+                                            complex_data=self.complex_data)
+            self._frame_nr = frame_nr
+            framerate = self.sample_rate / self.samples_per_frame
+            assert np.isclose(self._frame_nr,
+                              ((self._frame.header.time -
+                                self.start_time) * framerate).to(u.one))
+        return self._frame, sample_offset
 
 
 class GSBStreamWriter(GSBStreamBase, VLBIStreamWriterBase):

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -356,8 +356,8 @@ class Mark4StreamReader(VLBIStreamReaderBase, Mark4FileReader):
         last_header.infer_decade(self.start_time)
         return last_header
 
-    def _read_frame(self, frame_nr):
-        self.fh_raw.seek(self.offset0 + frame_nr * self.header0.framesize)
+    def _read_frame(self, index):
+        self.fh_raw.seek(self.offset0 + index * self.header0.framesize)
         frame = self.read_frame(ntrack=self.header0.ntrack,
                                 ref_time=self.start_time)
         # Set decoded value for invalid data.

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -527,8 +527,6 @@ class TestMark4(object):
         with mark4.open(SAMPLE_FILE, 'rs', ntrack=64, decade=2010,
                         sample_rate=32*u.MHz) as fh:
             assert header == fh.header0
-            # Raw file should be just after frame 0.
-            assert fh.fh_raw.tell() == 0xa88 + fh.header0.framesize
             assert fh.samples_per_frame == 80000
             assert fh.size == 2 * fh.samples_per_frame
             assert fh.sample_rate == 32 * u.MHz
@@ -690,9 +688,8 @@ class TestMark4(object):
         assert 'partial buffer' in str(w[0].message)
         with mark4.open(m4_incomplete, 'rs', ntrack=64, decade=2010,
                         sample_rate=32*u.MHz, fill_value=fill_value) as fwr:
-            assert not fwr._frame.valid
             assert np.all(fwr.read() == fwr._frame.invalid_data_value)
-            assert fwr._frame.invalid_data_value == fill_value
+            assert fwr.fill_value == fill_value
 
     def test_corrupt_stream(self, tmpdir):
         with mark4.open(SAMPLE_FILE, 'rb') as fh, \

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -234,18 +234,18 @@ class Mark5BStreamReader(VLBIStreamReaderBase, Mark5BFileReader):
         last_header.infer_kday(self.start_time)
         return last_header
 
-    def _read_frame(self, frame_nr):
-        self.fh_raw.seek(frame_nr * self.header0.framesize)
+    def _read_frame(self, index):
+        self.fh_raw.seek(index * self.header0.framesize)
         frame = self.read_frame(nchan=self._unsliced_shape.nchan,
                                 bps=self.bps, ref_time=self.start_time)
         # Set decoded value for invalid data.
         frame.invalid_data_value = self.fill_value
         # TODO: OK to ignore leap seconds? Not sure what writer does.
-        dt = (frame.seconds - self.header0.seconds +
-              86400 * (frame.kday + frame.jday -
-                       self.header0.kday - self.header0.jday))
-        assert (dt * self._framerate +
-                frame['frame_nr'] - self.header0['frame_nr']) == frame_nr
+        assert (self._framerate *
+                (frame.seconds - self.header0.seconds +
+                 86400 * (frame.kday + frame.jday -
+                          self.header0.kday - self.header0.jday)) +
+                frame['frame_nr'] - self.header0['frame_nr']) == index
         return frame
 
 

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -568,9 +568,9 @@ class TestMark5B(object):
         with mark5b.open(m5_incomplete, 'rs', nchan=8, bps=2,
                          sample_rate=32*u.MHz, kday=56000,
                          fill_value=fill_value) as fwr:
-            assert not fwr._frame.valid
-            assert np.all(fwr.read() == fwr._frame.invalid_data_value)
-            assert fwr._frame.invalid_data_value == fill_value
+            assert fwr.fill_value == fill_value
+            check = fwr.read()
+            assert np.all(check == fill_value)
 
     def test_stream_invalid(self):
         with pytest.raises(ValueError):

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -343,7 +343,6 @@ class TestMark5B(object):
         with mark5b.open(SAMPLE_FILE, 'rs', nchan=8, bps=2,
                          sample_rate=32*u.MHz, kday=56000) as fh:
             assert header == fh.header0
-            assert fh.fh_raw.tell() == header.framesize
             assert fh.samples_per_frame == 5000
             assert fh.sample_rate == 32 * u.MHz
             last_header = fh._last_header

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -396,14 +396,14 @@ class VDIFStreamReader(VDIFStreamBase, VLBIStreamReaderBase, VDIFFileReader):
 
         return data
 
-    def _read_frame(self, frame_nr):
-        self.fh_raw.seek(frame_nr * self._framesetsize)
+    def _read_frame(self, index):
+        self.fh_raw.seek(index * self._framesetsize)
         frameset = self.read_frameset(self._thread_ids,
                                       edv=self.header0.edv)
         frameset.invalid_data_value = self.fill_value
         assert ((frameset['seconds'] - self.header0['seconds']) *
                 self._framerate +
-                frameset['frame_nr'] - self.header0['frame_nr']) == frame_nr
+                frameset['frame_nr'] - self.header0['frame_nr']) == index
         # TODO: once framesets are sliceable, just return frameset itself.
         # For now, keep it around for testing, inspection.
         self._frameset = frameset

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -759,8 +759,8 @@ class TestVDIF(object):
         assert 'partial buffer' in str(w[0].message)
         with vdif.open(vdif_incomplete, 'rs', fill_value=fill_value) as fwr:
             assert all([not frame.valid for frame in fwr._frameset.frames])
-            assert np.all(fwr.read() == fwr._frameset.invalid_data_value)
-            assert fwr._frameset.invalid_data_value == fill_value
+            assert fwr.fill_value == fill_value
+            assert np.all(fwr.read() == fill_value)
 
     def test_corrupt_stream(self, tmpdir):
         with vdif.open(SAMPLE_FILE, 'rb') as fh, \

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -72,6 +72,7 @@ class VLBIStreamBase(VLBIFileBase):
             subset = (subset,)
         self._subset = subset
         self._sample_shape = self._get_sample_shape()
+        self._frame_nr = None
 
     @property
     def squeeze(self):
@@ -482,7 +483,13 @@ class VLBIStreamReaderBase(VLBIStreamBase):
         sample = 0
         while count > 0:
             # For current position, get frame plus offset in that frame.
-            frame, sample_offset = self._read_frame()
+            frame_nr, sample_offset = divmod(self.offset,
+                                             self.samples_per_frame)
+            if frame_nr != self._frame_nr:
+                self._frame = self._read_frame(frame_nr)
+                self._frame_nr = frame_nr
+
+            frame = self._frame
             nsample = min(count, len(frame) - sample_offset)
             data = frame[sample_offset:sample_offset + nsample]
             data = self._squeeze_and_subset(data)

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -72,7 +72,7 @@ class VLBIStreamBase(VLBIFileBase):
             subset = (subset,)
         self._subset = subset
         self._sample_shape = self._get_sample_shape()
-        self._frame_nr = None
+        self._frame_index = None
 
     @property
     def squeeze(self):
@@ -483,11 +483,11 @@ class VLBIStreamReaderBase(VLBIStreamBase):
         sample = 0
         while count > 0:
             # For current position, get frame plus offset in that frame.
-            frame_nr, sample_offset = divmod(self.offset,
-                                             self.samples_per_frame)
-            if frame_nr != self._frame_nr:
-                self._frame = self._read_frame(frame_nr)
-                self._frame_nr = frame_nr
+            frame_index, sample_offset = divmod(self.offset,
+                                                self.samples_per_frame)
+            if frame_index != self._frame_index:
+                self._frame = self._read_frame(frame_index)
+                self._frame_index = frame_index
 
             frame = self._frame
             nsample = min(count, len(frame) - sample_offset)

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -481,9 +481,11 @@ class VLBIStreamReaderBase(VLBIStreamBase):
         offset0 = self.offset
         start = 0
         while start < count:
-            # Get data chunk.  Generally, one frame's worth, but guaranteed
-            # to start at the current offset and have at most count samples.
-            data = self.get_chunk(count)
+            # Get reference to frame that overlaps the current offset, as well as offset
+            # we need to take to be at the current offset.
+            frame, sample_offset = self._read_frame()
+            sample_stop = min(sample_offset + count, len(frame))
+            data = frame[sample_offset:sample_stop]
             data = self._squeeze_and_subset(data)
             # Copy to relevant part of output.
             stop = start + len(data)


### PR DESCRIPTION
Apply this to Mark 5B.

This is mostly to see how it would look. Overall, I quite like how it, with a nice separation of concerns.

Name of `get_chunk` definitely up for bike-shedding.

EDIT: avoided introducing a new function.