### PR TITLE
Mark5BHeader.set_time now sets frame_nr.

### DIFF
--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -311,10 +311,10 @@ class TestMark5B(object):
         assert abs(header.get_time(frame_rate) -
                    start_time - 25599. / frame_rate) < 1. * u.ns
         # Check rounding to the nearest second when less than 2 ns away.
-        header.set_time(time=(start_time + 1.8 * u.ns), frame_nr=0)
-        assert header.time == start_time
-        header.set_time(time=(start_time - 1.8 * u.ns), frame_nr=0)
-        assert header.time == start_time
+        header.set_time(time=(start_time + 0.9 * u.ns), frame_nr=0)
+        assert header.seconds == header0.seconds
+        header.set_time(time=(start_time - 0.9 * u.ns), frame_nr=0)
+        assert header.seconds == header0.seconds
 
     def test_find_header(self, tmpdir):
         # Below, the tests set the file pointer to very close to a header,
@@ -567,7 +567,7 @@ class TestMark5B(object):
         samples_per_frame = 5000
         test_time = start_time + 198. * samples_per_frame / sample_rate
         with mark5b.open(m5_test_samplerate, 'ws', time=test_time, nchan=8,
-                         bps=2, sample_rate=sample_rate, frame_nr=198) as fw:
+                         bps=2, sample_rate=sample_rate) as fw:
             assert fw.header0['frame_nr'] == 198
             # Write 4 dummy frames, to include the max frame and frame 0
             fw.write(np.zeros((20000, 8), dtype='float32'))

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -285,6 +285,37 @@ class TestMark5B(object):
         with pytest.raises(ValueError):
             header.get_time(frame_nr=1)
 
+        # Check setting time using framerate.
+        sample_rate = 128. * u.MHz
+        samples_per_frame = 5000
+        # Max frame_nr is 2**15; this sets it to 25600.
+        frame_rate = sample_rate / samples_per_frame
+        header.set_time(time=(start_time + 1. / frame_rate),
+                        framerate=frame_rate)
+        header.get_time(frame_rate)
+        assert abs(header.get_time(frame_rate) -
+                   start_time - 1. / frame_rate) < 1. * u.ns
+        header.set_time(time=(start_time + 3921. / frame_rate),
+                        framerate=frame_rate)
+        assert abs(header.get_time(frame_rate) -
+                   start_time - 3921. / frame_rate) < 1. * u.ns
+        # Test using bcd_fraction gives us within 0.1 ms accuracy
+        assert abs(header.time - start_time - 3921. / frame_rate) < 0.1 * u.ms
+        header.set_time(time=(start_time + 25599. / frame_rate),
+                        framerate=frame_rate)
+        assert abs(header.get_time(frame_rate) -
+                   start_time - 25599. / frame_rate) < 1. * u.ns
+        # Check rounding when using passing fractional frametimes.
+        header.set_time(time=(start_time + 25598.53 / frame_rate),
+                        framerate=frame_rate)
+        assert abs(header.get_time(frame_rate) -
+                   start_time - 25599. / frame_rate) < 1. * u.ns
+        # Check rounding to the nearest second when less than 2 ns away.
+        header.set_time(time=(start_time + 1.8 * u.ns), frame_nr=0)
+        assert header.time == start_time
+        header.set_time(time=(start_time - 1.8 * u.ns), frame_nr=0)
+        assert header.time == start_time
+
     def test_find_header(self, tmpdir):
         # Below, the tests set the file pointer to very close to a header,
         # since otherwise they run *very* slow.  This is somehow related to
@@ -530,13 +561,11 @@ class TestMark5B(object):
             assert np.all(fhs.read(20000) == record[:, 0])
             assert np.all(fhns.read(20000) == record[:, 0])
 
-        # Test that sample_rate can be inferred from max frame number
+        # Test that sample_rate can be inferred from max frame number.
         m5_test_samplerate = str(tmpdir.join('test_samplerate.m5b'))
         sample_rate = 1. * u.MHz
         samples_per_frame = 5000
         test_time = start_time + 198. * samples_per_frame / sample_rate
-        # TODO: frame_nr should be inferred from time & sample_rate;
-        # see gh-158
         with mark5b.open(m5_test_samplerate, 'ws', time=test_time, nchan=8,
                          bps=2, sample_rate=sample_rate, frame_nr=198) as fw:
             assert fw.header0['frame_nr'] == 198

--- a/baseband/tests/test_conversion.py
+++ b/baseband/tests/test_conversion.py
@@ -55,7 +55,7 @@ class TestVDIFMark5B(object):
             m5h2, nchan=m5pl.sample_shape.nchan, bps=m5pl.bps,
             sample_rate=64*u.MHz)
         assert header3.time == header2.time
-        assert header3['frame_nr'] == header2['frame_nr'] + 1
+        assert header3['frame_nr'] == m5h2['frame_nr']
 
         # A copy might remove any `kday` keywords set, but should still work
         # (Regression test for #34)

--- a/baseband/vdif/header.py
+++ b/baseband/vdif/header.py
@@ -261,10 +261,20 @@ class VDIFHeader(VLBIHeaderBase):
             valid VDIF header, but this can be used to pass on, e.g.,
             ``invalid_data``.
         """
+        # We need to treat the time separately since the Mark 5B time may miss
+        # fractional seconds.  However, with the frame number and sample rate
+        # it is uniquely defined.
+        assert 'time' not in kwargs, "Time is inferred from Mark 5B Header."
+        sample_rate = kwargs.pop('sample_rate', None)
+        verify = kwargs.pop('verify', True)
         kwargs.update(mark5b_header)
-        return cls.fromvalues(edv=0xab, time=mark5b_header.time,
-                              bps=bps, nchan=nchan, complex_data=False,
-                              **kwargs)
+        self = cls.fromvalues(edv=0xab, bps=bps, nchan=nchan,
+                              complex_data=False, verify=False, **kwargs)
+        self.set_time(mark5b_header.time, sample_rate=sample_rate,
+                      frame_nr=mark5b_header['frame_nr'])
+        if verify:
+            self.verify()
+        return self
 
     # properties common to all VDIF headers.
     @property
@@ -435,7 +445,7 @@ class VDIFHeader(VLBIHeaderBase):
                         raise ValueError("cannot calculate sample rate for "
                                          "this header. Pass it in explicitly.")
                 framerate = sample_rate / self.samples_per_frame
-                frame_nr = int(round((frac_sec * framerate).to(u.one).value))
+                frame_nr = int(round((frac_sec * framerate).to_value(u.one)))
                 if abs(frame_nr / framerate - 1. * u.s) < 1. * u.ns:
                     frame_nr = 0
                     int_sec += 1
@@ -687,12 +697,10 @@ class VDIFMark5BHeader(VDIFBaseHeader, Mark5BHeader):
         return (ref_epochs[self['ref_epoch']] +
                 TimeDelta(self['seconds'], offset, format='sec', scale='tai'))
 
-    def set_time(self, time, sample_rate=None):
-        Mark5BHeader.set_time(self, time, frame_nr=self['mark5b_frame_nr'])
-        # Without a sample rate, we assume the frame number calculated
-        # by Mark5B header is correct; otherwise we calculate it here.
-        super(VDIFMark5BHeader, self).set_time(
-            time, sample_rate=sample_rate,
-            frame_nr=self['frame_nr'] if sample_rate is None else None)
+    def set_time(self, time, sample_rate=None, frame_nr=None):
+        framerate = None if sample_rate is None else (sample_rate /
+                                                      self.samples_per_frame)
+        Mark5BHeader.set_time(self, time, framerate, frame_nr)
+        super(VDIFMark5BHeader, self).set_time(time, sample_rate, frame_nr)
 
     time = property(get_time, set_time)

--- a/baseband/vdif/header.py
+++ b/baseband/vdif/header.py
@@ -435,8 +435,7 @@ class VDIFHeader(VLBIHeaderBase):
                         raise ValueError("cannot calculate sample rate for "
                                          "this header. Pass it in explicitly.")
                 framerate = sample_rate / self.samples_per_frame
-                frame_nr = int(round((frac_sec * framerate)
-                                     .to(u.dimensionless_unscaled).value))
+                frame_nr = int(round((frac_sec * framerate).to(u.one).value))
                 if abs(frame_nr / framerate - 1. * u.s) < 1. * u.ns:
                     frame_nr = 0
                     int_sec += 1
@@ -689,7 +688,7 @@ class VDIFMark5BHeader(VDIFBaseHeader, Mark5BHeader):
                 TimeDelta(self['seconds'], offset, format='sec', scale='tai'))
 
     def set_time(self, time, sample_rate=None):
-        Mark5BHeader.set_time(self, time)
+        Mark5BHeader.set_time(self, time, frame_nr=self['mark5b_frame_nr'])
         # Without a sample rate, we assume the frame number calculated
         # by Mark5B header is correct; otherwise we calculate it here.
         super(VDIFMark5BHeader, self).set_time(


### PR DESCRIPTION
Enables the frame number to be set by `Mark5BHeader.set_time`, and requires either the framerate or an explicit frame number to set the time with an `astropy.time.Time` object.

The implementation is based off of `VDIFHeader.set_time`, though in doing so I think I've caught a bug in that algorithm.  I'll implement a separate PR.

Addresses #158, though no general check is made to ensure that the timestamp and frame number are consistent with there being an integer number of frames per second (we never do this anyway).