### PR TITLE
VDIF stream reader now scans for the sample rate first.

### DIFF
--- a/baseband/tests/test_conversion.py
+++ b/baseband/tests/test_conversion.py
@@ -177,7 +177,7 @@ class TestMark5BToVDIF3(object):
         vdif_file = str(tmpdir.join('converted.vdif'))
         # create and fill vdif file with converted data.
         with vdif.open(vdif_file, 'ws', nthread=data.shape[1],
-                       header=header, sample_rate=header.sample_rate) as fw:
+                       header=header) as fw:
             assert (fw.tell(unit='time') - m5h.time) < 2. * u.ns
             fw.write(data)
             assert (fw.tell(unit='time') - time1) < 2. * u.ns
@@ -375,7 +375,7 @@ class TestDADAToVDIF1(object):
         assert abs(header.time - ddh.time) < 2. * u.ns
         vdif_file = str(tmpdir.join('converted_dada.vdif'))
         with vdif.open(vdif_file, 'ws', nthread=data.shape[1],
-                       header=header, sample_rate=header.sample_rate) as fw:
+                       header=header) as fw:
             assert (fw.tell(unit='time') - header.time) < 2. * u.ns
             # Write all data in since frameset, made of two frames.
             fw.write(data)

--- a/baseband/tests/test_conversion.py
+++ b/baseband/tests/test_conversion.py
@@ -177,7 +177,7 @@ class TestMark5BToVDIF3(object):
         vdif_file = str(tmpdir.join('converted.vdif'))
         # create and fill vdif file with converted data.
         with vdif.open(vdif_file, 'ws', nthread=data.shape[1],
-                       header=header) as fw:
+                       header=header, sample_rate=header.sample_rate) as fw:
             assert (fw.tell(unit='time') - m5h.time) < 2. * u.ns
             fw.write(data)
             assert (fw.tell(unit='time') - time1) < 2. * u.ns
@@ -279,7 +279,8 @@ class TestMark4ToVDIF1(object):
             orig_bytes = fh.read(number_of_bytes)
 
         fl = str(tmpdir.join('test.vdif'))
-        with vdif.open(fl, 'ws', nthread=data.shape[1], header=vheader0) as fw:
+        with vdif.open(fl, 'ws', nthread=data.shape[1], header=vheader0,
+                       sample_rate=vheader0.sample_rate) as fw:
             assert (fw.tell(unit='time') - start_time) < 2. * u.ns
             # Write first VDIF frame, matching Mark 4 Header, hence invalid.
             fw.write(data[:160], invalid_data=True)
@@ -374,7 +375,7 @@ class TestDADAToVDIF1(object):
         assert abs(header.time - ddh.time) < 2. * u.ns
         vdif_file = str(tmpdir.join('converted_dada.vdif'))
         with vdif.open(vdif_file, 'ws', nthread=data.shape[1],
-                       header=header) as fw:
+                       header=header, sample_rate=header.sample_rate) as fw:
             assert (fw.tell(unit='time') - header.time) < 2. * u.ns
             # Write all data in since frameset, made of two frames.
             fw.write(data)

--- a/baseband/vdif/header.py
+++ b/baseband/vdif/header.py
@@ -551,14 +551,15 @@ class VDIFSampleRateHeader(VDIFBaseHeader):
         # Sets sample rate correctly for EDV=3, but may not for EDV=1 or for
         # multiple channels per frame (illegal for EDV=3).
         assert sample_rate.to_value(u.Hz) % 1 == 0
-        bandwidth = sample_rate / (1 if self['complex_data'] else 2)
-        self['sampling_unit'] = not (bandwidth.unit == u.kHz or
-                                     bandwidth.to_value(u.MHz) % 1 != 0)
+        complex_sample_rate = sample_rate / (1 if self['complex_data'] else 2)
+        self['sampling_unit'] = not (
+            complex_sample_rate.unit == u.kHz or
+            complex_sample_rate.to_value(u.MHz) % 1 != 0)
         if self['sampling_unit']:
-            self['sampling_rate'] = int(bandwidth.to_value(u.MHz))
+            self['sampling_rate'] = int(complex_sample_rate.to_value(u.MHz))
         else:
-            assert bandwidth.to(u.kHz).value % 1 == 0
-            self['sampling_rate'] = int(bandwidth.to_value(u.kHz))
+            assert complex_sample_rate.to(u.kHz).value % 1 == 0
+            self['sampling_rate'] = int(complex_sample_rate.to_value(u.kHz))
 
 
 class VDIFHeader1(VDIFSampleRateHeader):

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -728,13 +728,13 @@ class TestVDIF(object):
 
         test_file_squeeze = str(tmpdir.join('test_squeeze.vdif'))
         with vdif.open(test_file_squeeze, 'ws', nthread=8,
-                       header=header) as fws:
+                       header=header, sample_rate=header.sample_rate) as fws:
             assert fws.sample_shape == (8,)
             assert fws.sample_shape.nthread == 8
             fws.write(record)
         test_file_nosqueeze = str(tmpdir.join('test_nosqueeze.vdif'))
         with vdif.open(test_file_nosqueeze, 'ws', nthread=8, header=header,
-                       squeeze=False) as fwns:
+                       sample_rate=header.sample_rate, squeeze=False) as fwns:
             assert fwns.sample_shape == (8, 1)
             assert fwns.sample_shape.nthread == 8
             assert fwns.sample_shape.nchan == 1

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -728,13 +728,13 @@ class TestVDIF(object):
 
         test_file_squeeze = str(tmpdir.join('test_squeeze.vdif'))
         with vdif.open(test_file_squeeze, 'ws', nthread=8,
-                       header=header, sample_rate=header.sample_rate) as fws:
+                       header=header) as fws:
             assert fws.sample_shape == (8,)
             assert fws.sample_shape.nthread == 8
             fws.write(record)
         test_file_nosqueeze = str(tmpdir.join('test_nosqueeze.vdif'))
-        with vdif.open(test_file_nosqueeze, 'ws', nthread=8, header=header,
-                       sample_rate=header.sample_rate, squeeze=False) as fwns:
+        with vdif.open(test_file_nosqueeze, 'ws', nthread=8,
+                       header=header, squeeze=False) as fwns:
             assert fwns.sample_shape == (8, 1)
             assert fwns.sample_shape.nthread == 8
             assert fwns.sample_shape.nchan == 1

--- a/docs/baseband/vdif/index.rst
+++ b/docs/baseband/vdif/index.rst
@@ -120,6 +120,7 @@ For small files, one could just do::
 
     >>> with vdif.open(SAMPLE_VDIF, 'rs') as fr, \
     ...         vdif.open('try.vdif', 'ws', header=fr.header0,
+    ...                   sample_rate=fr.sample_rate,
     ...                   nthread=fr.sample_shape.nthread) as fw:
     ...     fw.write(fr.read())
 


### PR DESCRIPTION
For VDIFStreamWriter, implicitly passing sample rate through the header is no longer permitted.  I'm not completely sure this is a good idea, especially since in the test suite I simply pass `header.sample_rate` as the sample rate.

Quick fix for #135, though routines in the header class that use `sample_rate` - `fromvalues`, `get_time` and `set_time` - remain untouched.  We should consider changes to the latter to address #164.

fixes #135