### PR TITLE
Let binary readers have properties needed to read frames/payloads

### DIFF
--- a/baseband/gsb/tests/test_gsb.py
+++ b/baseband/gsb/tests/test_gsb.py
@@ -431,13 +431,9 @@ class TestGSB(object):
         testfile = str(tmpdir.join('test.dat'))
         with gsb.open(testfile, 'wb') as fw:
             fw.write_payload(payload1, bps=4)
-        with gsb.open(testfile, 'rb') as fh:
-            payload2 = fh.read_payload(2**12)
+        with gsb.open(testfile, 'rb', payloadsize=2**12) as fh:
+            payload2 = fh.read_payload()
             assert payload2 == payload1
-
-        # check that extra arguments raise TypeError
-        with pytest.raises(TypeError):
-            gsb.open(SAMPLE_RAWDUMP, 'rb', bps=2)
 
     def test_raw_stream(self, tmpdir):
         bps = 4

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -203,11 +203,11 @@ class TestMark5B(object):
         assert payload2 == payload
 
     def test_frame(self, tmpdir):
-        with mark5b.open(SAMPLE_FILE, 'rb') as fh:
+        with mark5b.open(SAMPLE_FILE, 'rb', nchan=8, bps=2, kday=56000) as fh:
             header = mark5b.Mark5BHeader.fromfile(fh, kday=56000)
             payload = mark5b.Mark5BPayload.fromfile(fh, nchan=8, bps=2)
             fh.seek(0)
-            frame = fh.read_frame(nchan=8, bps=2, kday=56000)
+            frame = fh.read_frame()
 
         assert frame.header == header
         assert frame.payload == payload
@@ -225,13 +225,13 @@ class TestMark5B(object):
         assert frame2 == frame
 
         # Check passing in reference time.
-        with mark5b.open(SAMPLE_FILE, 'rb') as fh:
-            frame3 = fh.read_frame(nchan=8, bps=2,
-                                   ref_time=Time('2014-06-13 12:00:00'))
+        with mark5b.open(SAMPLE_FILE, 'rb', nchan=8, bps=2,
+                         ref_time=Time('2014-06-13 12:00:00')) as fh:
+            frame3 = fh.read_frame()
         assert frame3 == frame
-        with mark5b.open(SAMPLE_FILE, 'rb') as fh:
-            frame4 = fh.read_frame(nchan=8, bps=2,
-                                   ref_time=Time('2015-12-13 12:00:00'))
+        with mark5b.open(SAMPLE_FILE, 'rb', nchan=8, bps=2,
+                         ref_time=Time('2015-12-13 12:00:00')) as fh:
+            frame4 = fh.read_frame()
         assert frame4 == frame
 
         frame5 = mark5b.Mark5BFrame.fromdata(payload.data, header, bps=2)
@@ -260,7 +260,7 @@ class TestMark5B(object):
         assert np.all(frame9.payload.words == 0x11223344)
 
     def test_header_times(self):
-        with mark5b.open(SAMPLE_FILE, 'rb') as fh:
+        with mark5b.open(SAMPLE_FILE, 'rb', nchan=8, bps=2, kday=56000) as fh:
             header0 = mark5b.Mark5BHeader.fromfile(fh, kday=56000)
             start_time = header0.time
             samples_per_frame = header0.payloadsize * 8 // 2 // 8
@@ -269,7 +269,7 @@ class TestMark5B(object):
             fh.seek(0)
             while True:
                 try:
-                    frame = fh.read_frame(nchan=8, bps=2, kday=56000)
+                    frame = fh.read_frame()
                 except EOFError:
                     break
                 header_time = frame.header.time
@@ -329,7 +329,7 @@ class TestMark5B(object):
         # Below, the tests set the file pointer to very close to a header,
         # since otherwise they run *very* slow.  This is somehow related to
         # pytest, since speed is not a big issue running stuff on its own.
-        with mark5b.open(SAMPLE_FILE, 'rb') as fh:
+        with mark5b.open(SAMPLE_FILE, 'rb', kday=56000) as fh:
             header0 = mark5b.Mark5BHeader.fromfile(fh, kday=56000)
             fh.seek(0)
             header_0 = fh.find_header(template_header=header0)
@@ -342,9 +342,7 @@ class TestMark5B(object):
             header_16b = fh.find_header(template_header=header0, forward=False)
             assert fh.tell() == 0
             fh.seek(-10000, 2)
-            header_m10000b = fh.find_header(kday=header0.kday,
-                                            framesize=header0.framesize,
-                                            forward=False)
+            header_m10000b = fh.find_header(forward=False)
             assert fh.tell() == 3 * header0.framesize
             fh.seek(-30, 2)
             header_end = fh.find_header(template_header=header0, forward=True)
@@ -357,10 +355,9 @@ class TestMark5B(object):
             s.write(f.read(10040))
             f.seek(20000)
             s.write(f.read())
-        with mark5b.open(m5_test, 'rb') as fh:
+        with mark5b.open(m5_test, 'rb', kday=header0.kday) as fh:
             fh.seek(0)
-            header_0 = fh.find_header(kday=header0.kday,
-                                      framesize=header0.framesize)
+            header_0 = fh.find_header()
             assert fh.tell() == 0
             fh.seek(10000)
             header_10000f = fh.find_header(template_header=header0,

--- a/baseband/tests/test_conversion.py
+++ b/baseband/tests/test_conversion.py
@@ -104,11 +104,11 @@ class TestVDIFMark5B(object):
 
     def test_frame(self):
         """Check a whole Mark 5B frame can be translated to VDIF."""
-        with mark5b.open(SAMPLE_M5B, 'rb') as fh:
+        with mark5b.open(SAMPLE_M5B, 'rb', nchan=8, bps=2,
+                         ref_time=Time(57000, format='mjd')) as fh:
             # pick second frame just to be different from header checks above.
             fh.seek(10016)
-            m5f = fh.read_frame(nchan=8, bps=2,
-                                ref_time=Time(57000, format='mjd'))
+            m5f = fh.read_frame()
         assert m5f['frame_nr'] == 1
         frame = vdif.VDIFFrame.from_mark5b_frame(m5f)
         assert frame.size == 10032

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -861,13 +861,17 @@ class TestVDIF(object):
                 with pytest.raises(ValueError):
                     f2._last_header
 
-    def test_io_invalid(self):
+    def test_io_invalid(self, tmpdir):
+        tmp_file = str(tmpdir.join('ts.dat'))
+        with open(tmp_file, 'wb') as fw:
+            fw.write(b'      ')
+
         with pytest.raises(TypeError):
             # extra argument
-            vdif.open('ts.dat', 'rb', bla=10)
+            vdif.open(tmp_file, 'rb', bla=10)
         with pytest.raises(ValueError):
             # missing w or r
-            vdif.open('ts.dat', 's')
+            vdif.open(tmp_file, 's')
 
 
 def test_vlbi_vdif():

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -357,9 +357,8 @@ class VLBIStreamReaderBase(VLBIStreamBase):
         """Last header of the file."""
         raw_offset = self.fh_raw.tell()
         self.fh_raw.seek(-self.header0.framesize, 2)
-        last_header = self.find_header(template_header=self.header0,
-                                       maximum=10*self.header0.framesize,
-                                       forward=False)
+        last_header = self.find_header(forward=False,
+                                       template_header=self.header0)
         self.fh_raw.seek(raw_offset)
         if last_header is None:
             raise ValueError("corrupt VLBI frame? No frame in last {0} bytes."

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -608,9 +608,6 @@ def make_opener(fmt, classes, doc='', append_doc=True):
     def open(name, mode='rs', **kwargs):
         if 'b' in mode:
             cls_type = 'File'
-            if kwargs:
-                raise TypeError('got unexpected arguments {}'
-                                .format(kwargs.keys()))
         else:
             cls_type = 'Stream'
 

--- a/docs/baseband/gsb/index.rst
+++ b/docs/baseband/gsb/index.rst
@@ -33,7 +33,7 @@ representing the voltage stream from one polarization of a single dish.  Each
 such file is accompanied by a header file which contains GPS timestamps, in the
 form::
 
-    YYYY MM DD HH MM SS 0.SSSSSSSSS 
+    YYYY MM DD HH MM SS 0.SSSSSSSSS
 
 In the default rawdump observing setup, samples are recorded at a rate of
 33.3333... megasamples per second (Msps).  Each sample is 4 bits in size, and
@@ -128,9 +128,9 @@ the size of one frame in bytes.  Since rawdump samples are 4 bits,
 
     >>> rawdump_samples_per_frame = 2**13
     >>> payloadsize = rawdump_samples_per_frame // 2
-    >>> fb = gsb.open(SAMPLE_GSB_RAWDUMP, 'rb')
-    >>> payload = fb.read_payload(payloadsize, nchan=1, bps=4,
-    ...                           complex_data=False)
+    >>> fb = gsb.open(SAMPLE_GSB_RAWDUMP, 'rb', payloadsize=payloadsize,
+    ...               nchan=1, bps=4, complex_data=False)
+    >>> payload = fb.read_payload()
     >>> payload[:4]
     array([[ 0.],
            [-2.],

--- a/docs/baseband/mark4/index.rst
+++ b/docs/baseband/mark4/index.rst
@@ -66,37 +66,22 @@ modules::
 Opening a Mark 4 file with `~baseband.mark4.open` in binary mode provides
 a normal file reader but extended with methods to read a
 `~baseband.mark4.Mark4Frame`.  Mark 4 files generally **do not start (or end)
-at a frame boundary**, so in binary mode one has to seek the
-first frame using `~baseband.mark4.base.Mark4FileReader.find_frame`.  To use
-`~baseband.mark4.base.Mark4FileReader.find_frame` and 
-`~baseband.mark4.base.Mark4FileReader.read_frame`, one must pass both the
-number of tracks, and either the decade the data was taken, or an equivalent
-reference `~astropy.time.Time` object, since those numbers cannot be inferred
-from the data themselves::
+at a frame boundary**, so in binary mode one has to seek the first
+frame using `~baseband.mark4.base.Mark4FileReader.locate_frame` (which will
+also determine the number of Mark 4 tracks, if not given explicitly). Since
+Mark 4 files do not store the full time information, one must pass either the
+the decade the data was taken, or an equivalent reference `~astropy.time.Time`
+object::
 
-    >>> fb = mark4.open(SAMPLE_MARK4, 'rb')
-    >>> fb.find_frame(ntrack=64)    # Find first frame.
+    >>> fb = mark4.open(SAMPLE_MARK4, 'rb', decade=2010)
+    >>> fb.locate_frame()  # Locate first frame.
     2696
-    >>> frame = fb.read_frame(ntrack=64, decade=2010)
+    >>> frame = fb.read_frame()
     >>> frame.shape
     (80000, 8)
-
-If one does not know the number of tracks, one can attempt to determine
-this using `~baseband.mark4.base.Mark4FileReader.determine_ntracks`
-(which will leave the file pointer at the start of a frame as well)::
-
-    >>> fb.seek(0)
-    0
-    >>> ntrack = fb.determine_ntrack()    # Also finds first frame.
-    >>> ntrack
-    64
-    >>> frame2 = fb.read_frame(ntrack=ntrack, decade=2010)
-    >>> frame2 == frame
-    True
     >>> fb.close()
 
-Opening in stream mode automatically seeks for the first frame (determing
-the number of tracks if not given explicitly), and wraps the
+Opening in stream mode automatically seeks for the first frame, and wraps the
 low-level routines such that reading and writing is in units of samples.  It
 also provides access to header information.  Here we pass a reference
 `~astropy.time.Time` object within 4 years of the observation start time to

--- a/docs/baseband/mark5b/index.rst
+++ b/docs/baseband/mark5b/index.rst
@@ -57,8 +57,8 @@ normal file reader extended with methods to read a
 MJD) and number of bits per sample must all be passed when using
 `~baseband.mark5b.base.Mark5BFileReader.read_frame`::
 
-    >>> fb = mark5b.open(SAMPLE_MARK5B, 'rb')
-    >>> frame = fb.read_frame(nchan=8, kday=56000)
+    >>> fb = mark5b.open(SAMPLE_MARK5B, 'rb', nchan=8, kday=56000)
+    >>> frame = fb.read_frame()
     >>> frame.shape
     (5000, 8)
     >>> fb.close()


### PR DESCRIPTION
So far, only the Mark 5B reader, just to see how it looks.

EDIT: now also Mark 4 and GSB.

The work-arounds for ensuring the file-reader properties get initialized in the streamers are annoying. Am reconsidering whether it was good to inherit from the file reader rather than just wrap it...