### PR TITLE
Disallow access to DADA headers via attributes.

### DIFF
--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -205,7 +205,7 @@ class DADAStreamBase(VLBIStreamBase):
         super(DADAStreamBase, self).__init__(
             fh_raw=fh_raw, header0=header0, bps=header0.bps,
             complex_data=header0.complex_data, subset=subset,
-            unsliced_shape=(header0.npol, header0.nchan),
+            unsliced_shape=header0.sample_shape,
             samples_per_frame=header0.samples_per_frame,
             sample_rate=header0.sample_rate, squeeze=squeeze)
 

--- a/baseband/dada/header.py
+++ b/baseband/dada/header.py
@@ -275,17 +275,6 @@ class DADAHeader(OrderedDict):
 
         super(DADAHeader, self).__setitem__(key.upper(), value)
 
-    def __getattr__(self, attr):
-        """Get attribute, or, failing that, try to get key from header."""
-        try:
-            # Note that OrderDict does not have __getattr__
-            return super(DADAHeader, self).__getattribute__(attr)
-        except AttributeError as exc:
-            try:
-                return self[attr.upper()]
-            except Exception:
-                raise exc
-
     @property
     def size(self):
         """Size in bytes of the header."""

--- a/baseband/dada/tests/test_dada.py
+++ b/baseband/dada/tests/test_dada.py
@@ -36,8 +36,6 @@ class TestDADA(object):
         with pytest.raises(TypeError):
             header['NCHAN'] = 2
         assert header['NCHAN'] == 1
-        # access key via attribute
-        assert header.nchan == 1
         with pytest.raises(AttributeError):
             header.python
 


### PR DESCRIPTION
Left-over from similar reductions in VLBI headers. Will just merge this assuming tests pass.