### PR TITLE
Leftover from frameset __setitem__ - use it in writer.

### DIFF
--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -541,11 +541,6 @@ class VDIFStreamWriter(VDIFStreamBase, VLBIStreamWriterBase, VDIFFileWriter):
             frames.append(VDIFFrame(header, payload))
         return VDIFFrameSet(frames)
 
-    def _write_frame(self, frameset, valid=True):
-        for frame in frameset.frames:
-            frame.valid = valid
-        self.write_frameset(frameset)
-
 
 open = make_opener('VDIF', globals(), doc="""
 --- For reading a stream : (see :class:`~baseband.vdif.base.VDIFStreamReader`)

--- a/baseband/vdif/frame.py
+++ b/baseband/vdif/frame.py
@@ -199,8 +199,6 @@ class VDIFFrameSet(object):
     """
     def __init__(self, frames, header0=None):
         self.frames = frames
-        # Used in .data below to decode data only once.
-        self._data = None
         if header0 is None:
             self.header0 = self.frames[0].header
         else:

--- a/baseband/vdif/frame.py
+++ b/baseband/vdif/frame.py
@@ -332,6 +332,16 @@ class VDIFFrameSet(object):
         return self.frames[0].dtype
 
     @property
+    def valid(self):
+        return [frame.valid for frame in self.frames]
+
+    @valid.setter
+    def valid(self, valid):
+        valid = np.broadcast_to(valid, (len(self.frames),))
+        for f, v in zip(self.frames, valid):
+            f.valid = v
+
+    @property
     def invalid_data_value(self):
         return self.frames[0].invalid_data_value
 

--- a/baseband/vdif/frame.py
+++ b/baseband/vdif/frame.py
@@ -15,7 +15,7 @@ import numpy as np
 from astropy.extern import six
 
 from ..vlbi_base.frame import VLBIFrameBase
-from .header import VDIFHeader
+from .header import VDIFHeader, VDIFBaseHeader
 from .payload import VDIFPayload
 
 
@@ -333,7 +333,8 @@ class VDIFFrameSet(object):
 
     @property
     def valid(self):
-        return [frame.valid for frame in self.frames]
+        valid = np.array([frame.valid for frame in self.frames])
+        return valid[0] if len(np.unique(valid)) == 1 else valid
 
     @valid.setter
     def valid(self, valid):
@@ -403,8 +404,17 @@ class VDIFFrameSet(object):
     # Let frameset behave appropriately.
     def __getitem__(self, item=()):
         if isinstance(item, six.string_types):
-            # Header behaves as a dictionary.
-            return self.header0.__getitem__(item)
+            # Header behaves as a dictionary.  Assume base keywords are the
+            # same for every frame, except for thread_id (must be different)
+            # and invalid_data (can be different).
+            if item == 'thread_id':
+                return np.array([f.header[item] for f in self.frames])
+            elif (item != 'invalid_data' and
+                  item in VDIFBaseHeader._header_parser.keys()):
+                return self.header0[item]
+
+            values = np.array([f.header[item] for f in self.frames])
+            return values[0] if len(np.unique(values)) == 1 else values
 
         (frames, frame_item,
          single_sample, single_frame, single_channel) = self._get_frames(item)
@@ -427,6 +437,22 @@ class VDIFFrameSet(object):
         return data
 
     def __setitem__(self, item, data):
+        if isinstance(item, six.string_types):
+            # Headers behave as dictionaries; except for thread_id and
+            # invalid_data, assume set base properties all to the same value.
+            data = np.broadcast_to(data, (len(self.frames),))
+            if item == 'thread_id':
+                if len(np.unique(data)) != len(self.frames):
+                    raise ValueError("all thread ids should be unique.")
+            elif (item != 'invalid_data' and
+                  item in VDIFBaseHeader._header_parser.keys()):
+                if data.strides != (0,) and len(np.unique(data)) > 1:
+                    raise ValueError("base header keys should be identical.")
+
+            for f, value in zip(self.frames, data):
+                f.header[item] = value
+            return
+
         (frames, frame_item,
          single_sample, single_frame, single_channel) = self._get_frames(item)
 
@@ -462,7 +488,10 @@ class VDIFFrameSet(object):
 
     def __getattr__(self, attr):
         if attr in self.header0._properties:
-            return getattr(self.header0, attr)
+            if attr in VDIFBaseHeader._properties:
+                return getattr(self.header0, attr)
+            values = np.array([getattr(f.header, attr) for f in self.frames])
+            return values[0] if len(np.unique(values)) == 1 else values
         else:
             return self.__getattribute__(attr)
 

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -514,6 +514,33 @@ class TestVDIF(object):
         assert np.all(frameset2[:, :, 0] == -data[:, :, 0])
         frameset2[:, :, :1] = 1.
         assert np.all(frameset2[:, :, :1] == 1.)
+        # Test header getting/setting.
+        assert np.all(frameset2['thread_id'] == [f.header['thread_id']
+                                                 for f in frameset2.frames])
+        assert frameset2['frame_nr'] == frameset2.header0['frame_nr']
+        frameset2['frame_nr'] = 25
+        assert all(f.header['frame_nr'] == 25 for f in frameset2.frames)
+        assert frameset2['frame_nr'] == 25
+        frameset2['thread_id'] = np.arange(10, 18)
+        assert all(f.header['thread_id'] == v
+                   for f, v in zip(frameset2.frames, np.arange(10, 18)))
+        assert all(frameset2['thread_id'] == np.arange(10, 18))
+        with pytest.raises(ValueError):
+            frameset2['thread_id'] = 0
+        with pytest.raises(ValueError):
+            frameset2['thread_id'] = 0, 1, 2, 3, 4, 5, 6, 1
+        with pytest.raises(ValueError):
+            frameset2['frame_nr'] = 0, 1, 0, 1, 0, 1, 0, 1
+        # And a bit of getattr.
+        assert frameset2.time == frameset2.header0.time
+        assert frameset2.valid
+        mixed_valid = True, True, False, False, True, True, False, False
+        frameset2.valid = mixed_valid
+        assert np.all(frameset2.valid == mixed_valid)
+        frameset2.valid = True
+        assert frameset2.valid
+        frameset2.valid = False
+        assert not frameset2.valid
 
     def test_find_header(self, tmpdir):
         # Below, the tests set the file pointer to very close to a header,

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -561,7 +561,7 @@ class VLBIStreamWriterBase(VLBIStreamBase):
         # Default implementation is to assume this is a frame and use
         # the binary file writer.
         frame.valid = valid
-        self.write_frame(frame)
+        frame.tofile(self.fh_raw)
 
     def close(self):
         extra = self.offset % self.samples_per_frame


### PR DESCRIPTION
As per title, though the later commits also add logic for setting header items. It is somewhat "for completeness", but does seem to make sense.