### PR TITLE
Consistently use `valid` and `fill value`.

### DIFF
--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -314,7 +314,7 @@ npol : int, optional
 nchan : int, optional
     Number of channels (default: 1).
 complex_data : bool, optional
-    Whether data is complex (default: False).
+    Whether data are complex (default: False).
 bps : int, optional
     Bits per elementary sample, i.e. per real or imaginary component for
     complex data (default: 8).

--- a/baseband/dada/frame.py
+++ b/baseband/dada/frame.py
@@ -20,19 +20,19 @@ class DADAFrame(VLBIFrameBase):
     payload : `~baseband.dada.DADAPayload`
         Wrapper around the payload, provding mechanisms to decode it.
     valid : bool, optional
-        Whether this frame contains valid data (default: True).
+        Whether the data are valid.  Default: `True`.
     verify : bool, optional
-        Whether to do basic verification of integrity (default: True)
+        Whether to do basic verification of integrity.  Default: `True`.
 
     Notes
     -----
     DADA files do not support storing whether data are valid or not on disk.
     Hence, this has to be determined independently.  If ``valid=False``, any
-    decoded data is set to ``cls.invalid_data_value`` (by default, 0).
+    decoded data are set to ``cls.fill_value`` (by default, 0).
 
     The Frame can also be instantiated using class methods:
 
-      fromfile : read header and and map or read payload from a filehandle
+      fromfile : read header and map or read payload from a filehandle
 
       fromdata : encode data as payload
 
@@ -65,9 +65,9 @@ class DADAFrame(VLBIFrameBase):
             If `True` (default), use `~numpy.memmap` to map the payload.
             If `False`, just read it from disk.
         valid : bool, optional
-            Whether the data is valid. Note that this cannot be inferred from
-            the header or payload itself.  If `True`, any data read will be
-            set to ``cls.invalid_data_value``.
+            Whether the data are valid (default: `True`). Note that this cannot
+            be inferred from the header or payload itself.  If `False`, any
+            data read will be set to ``cls.fill_value``.
         verify : bool, optional
             Whether to do basic verification of integrity.  Default: `True`.
         """
@@ -90,7 +90,7 @@ class DADAFrame(VLBIFrameBase):
         header : `~baseband.dada.DADAHeader` or None
             If not given, will attempt to generate one using the keywords.
         valid : bool, optional
-            Whether the data is valid (default: `True`). Note that this
+            Whether the data are valid (default: `True`). Note that this
             information cannot be written to disk.
         verify : bool
             Whether or not to do basic assertions that check the integrity.

--- a/baseband/dada/payload.py
+++ b/baseband/dada/payload.py
@@ -36,7 +36,7 @@ class DADAPayload(VLBIPayloadBase):
     sample_shape : tuple, optional
         Shape of the samples; e.g., (nchan,).  Default: ().
     complex_data : bool, optional
-        Whether data is complex.  Default: `False`.
+        Whether data are complex.  Default: `False`.
     """
     _decoders = {
         8: decode_8bit}

--- a/baseband/gsb/base.py
+++ b/baseband/gsb/base.py
@@ -68,7 +68,7 @@ class GSBFileReader(VLBIFileBase):
         Bits per elementary sample, i.e. per real or imaginary component
         for complex data.  Default: 4.
     complex_data : bool, optional
-        Whether data is complex.  Default: False.
+        Whether data are complex.  Default: False.
     """
     def __init__(self, fh_raw, payloadsize, nchan=1, bps=4,
                  complex_data=False):
@@ -217,7 +217,7 @@ class GSBStreamReader(GSBStreamBase, VLBIStreamReaderBase):
         Bits per elementary sample, i.e. per real or imaginary component for
         complex data.  Default: 4 for rawdump, 8 for phased.
     complex_data : bool, optional
-        Whether data is complex.  Default: `False` for rawdump, `True` for
+        Whether data are complex.  Default: `False` for rawdump, `True` for
         phased.
     squeeze : bool, optional
         If `True` (default), remove any dimensions of length unity from decoded
@@ -333,7 +333,7 @@ class GSBStreamWriter(GSBStreamBase, VLBIStreamWriterBase):
         Bits per elementary sample, i.e. per real or imaginary component for
         complex data.  Default: 4 for rawdump, 8 for phased.
     complex_data : bool, optional
-        Whether data is complex.  Default: `False` for rawdump, `True` for
+        Whether data are complex.  Default: `False` for rawdump, `True` for
         phased.
     squeeze : bool, optional
         If `True` (default), ``write`` accepts squeezed arrays as input, and
@@ -447,7 +447,7 @@ def open(name, mode='rs', **kwargs):
         Bits per elementary sample, i.e. per real or imaginary component for
         complex data.  Default: 4 for rawdump, 8 for phased.
     complex_data : bool, optional
-        Whether data is complex.  Default: `False` for rawdump, `True` for
+        Whether data are complex.  Default: `False` for rawdump, `True` for
         phased.
     squeeze : bool, optional
         If `True` (default) and reading, remove any dimensions of length unity

--- a/baseband/gsb/frame.py
+++ b/baseband/gsb/frame.py
@@ -26,9 +26,34 @@ class GSBFrame(VLBIFrameBase):
         Based on a single block of rawdump data, or the combined blocks for
         phased data.
     valid : bool, optional
-        Whether the frame contains valid data.  Default: `True`.
+        Whether the data are valid.  Default: `True`.
     verify : bool, optional
         Whether to verify consistency of the frame parts.  Default: `True`.
+
+    Notes
+    -----
+    GSB files do not support storing whether data are valid or not on disk.
+    Hence, this has to be determined independently.  If ``valid=False``, any
+    decoded data are set to ``cls.fill_value`` (by default, 0).
+
+    The Frame can also be read instantiated using class methods:
+
+      fromfile : read header and payload from their respective filehandles
+
+      fromdata : encode data as payload
+
+    Of course, one can also do the opposite:
+
+      tofile : method to write header and payload to filehandles (splitting
+               payload in the appropriate files).
+
+      data : property that yields full decoded payload
+
+    A number of properties are defined: ``shape`` and ``dtype`` are the shape
+    and type of the data array, and ``size`` the frame size in bytes.
+    Furthermore, the frame acts as a dictionary, with keys those of the header.
+    Any attribute that is not defined on the frame itself, such as ``.time``
+    will be looked up on the header as well.
     """
     _header_class = GSBHeader
     _payload_class = GSBPayload
@@ -57,9 +82,11 @@ class GSBFrame(VLBIFrameBase):
         bps : int, optional
             Bits per elementary sample.  Default: 4.
         complex_data : bool, optional
-            Whether data is complex.  Default: `False`.
+            Whether data are complex.  Default: `False`.
         valid : bool, optional
-            Whether the frame contains valid data.  Default: `True`.
+            Whether the data are valid (default: `True`). Note that this cannot
+            be inferred from the header or payload itself.  If `False`, any
+            data read will be set to ``cls.fill_value``.
         verify : bool, optional
             Whether to verify consistency of the frame parts.  Default: `True`.
         """

--- a/baseband/gsb/payload.py
+++ b/baseband/gsb/payload.py
@@ -68,7 +68,7 @@ class GSBPayload(VLBIPayloadBase):
     bps : int, optional
         Bits per elementary sample.  Default: 2.
     complex_data : bool, optional
-        Whether data is complex.  Default: `False`.
+        Whether data are complex.  Default: `False`.
     """
 
     _encoders = {4: encode_4bit,
@@ -95,7 +95,7 @@ class GSBPayload(VLBIPayloadBase):
         Parameters
         ----------
         fh : filehandle or tuple of tuple of filehandle
-            Handles to the sets of files from which data is read.  The outer
+            Handles to the sets of files from which data are read.  The outer
             tuple holds distinct threads, while the inner ones holds parts of
             those threads.  Typically, these are the two polarisations and the
             two parts of each in which phased baseband data are stored.
@@ -106,7 +106,7 @@ class GSBPayload(VLBIPayloadBase):
         bps : int, optional
             Bits per elementary sample.  Default: 4.
         complex_data : bool, optional
-            Whether data is complex.  Default: False.
+            Whether data are complex.  Default: False.
         """
         if hasattr(fh, 'read'):
             return super(GSBPayload,

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -383,7 +383,7 @@ class Mark4StreamReader(Mark4StreamBase, VLBIStreamReaderBase):
         self.fh_raw.seek(self._offset0 + index * self.header0.framesize)
         frame = self.fh_raw.read_frame()
         # Set decoded value for invalid data.
-        frame.invalid_data_value = self.fill_value
+        frame.fill_value = self.fill_value
         # TODO: add check that we got the right frame.
         return frame
 

--- a/baseband/mark4/frame.py
+++ b/baseband/mark4/frame.py
@@ -33,8 +33,8 @@ class Mark4Frame(VLBIFrameBase):
     payload : `~baseband.mark4.Mark4Payload`
         Wrapper around the payload, provding mechanisms to decode it.
     valid : bool or None, optional
-        Whether the data is valid.  If `None` (default), inferred from header.
-        Note that the header is updated in-place if `True` or `False`.
+        Whether the data are valid.  If `None` (default), inferred from header.
+        Note that `header` is updated in-place if `True` or `False`.
     verify : bool, optional
         Whether or not to do basic assertions that check the integrity
         (e.g., that channel information and number of tracks are consistent
@@ -56,13 +56,13 @@ class Mark4Frame(VLBIFrameBase):
 
     One can decode part of the payload by indexing or slicing the frame.
     If the frame does not contain valid data, all values returned are set
-    to ``self.invalid_data_value``.
+    to ``self.fill_value``.
 
     A number of properties are defined: ``shape`` and ``dtype`` are the shape
-    and type of the data array, ``words`` the full encoded frame, and ``size``
-    the frame size in bytes.  Furthermore, the frame acts as a dictionary, with
-    keys those of the header. Any attribute that is not defined on the frame
-    itself, such as ``.time`` will be looked up on the header as well.
+    and type of the data array, and ``size`` the frame size in bytes.
+    Furthermore, the frame acts as a dictionary, with keys those of the header.
+    Any attribute that is not defined on the frame itself, such as ``.time``
+    will be looked up on the header as well.
     """
 
     _header_class = Mark4Header
@@ -246,7 +246,7 @@ class Mark4Frame(VLBIFrameBase):
         (payload_item, sample_index, data_shape,
          ninvalid) = self._get_payload_item(item)
         if not self.valid or payload_item is None:
-            data = np.full(data_shape, self.invalid_data_value, self.dtype)
+            data = np.full(data_shape, self.fill_value, self.dtype)
 
         elif ninvalid == 0:
             data = self.payload[payload_item]
@@ -255,7 +255,7 @@ class Mark4Frame(VLBIFrameBase):
             # Note: Creating an empty array and setting part to invalid
             # is much faster than creating one pre-filled with invalid.
             data = np.empty(data_shape, self.dtype)
-            data[:ninvalid] = self.invalid_data_value
+            data[:ninvalid] = self.fill_value
             data[ninvalid:] = self.payload[payload_item]
 
         if sample_index is ():

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -659,7 +659,7 @@ class TestMark4(object):
             # write in bits and pieces and with some invalid data as well.
             fw.write(record[:11])
             fw.write(record[11:80000])
-            fw.write(record[80000:], invalid_data=True)
+            fw.write(record[80000:], valid=False)
             assert fw.tell(unit='time') == stop_time
 
         with mark4.open(rewritten_file, 'rs', sample_rate=32*u.MHz,

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -160,7 +160,7 @@ class Mark5BFileWriter(VLBIFileBase):
             Ignored if `data` is a `~baseband.mark5b.Mark5BFrame` instance.
             Default: 2.
         valid : bool, optional
-            Whether the data is valid; if `False`, a payload filled with an
+            Whether the data are valid; if `False`, a payload filled with an
             appropriate pattern will be crated.  Ignored if `data` is a
             `~baseband.mark5b.Mark5BFrame` instance.  Default: `True`.
         **kwargs
@@ -253,7 +253,7 @@ class Mark5BStreamReader(Mark5BStreamBase, VLBIStreamReaderBase):
         self.fh_raw.seek(index * self.header0.framesize)
         frame = self.fh_raw.read_frame()
         # Set decoded value for invalid data.
-        frame.invalid_data_value = self.fill_value
+        frame.fill_value = self.fill_value
         # TODO: OK to ignore leap seconds? Not sure what writer does.
         assert (self._framerate *
                 (frame.seconds - self.header0.seconds +

--- a/baseband/mark5b/frame.py
+++ b/baseband/mark5b/frame.py
@@ -32,11 +32,11 @@ class Mark5BFrame(VLBIFrameBase):
     payload : `~baseband.mark5b.Mark5BPayload`
         Wrapper around the payload, provding mechanisms to decode it.
     valid : bool or None
-        Whether the data is valid.  If `None` (default), the validity will be
+        Whether the data are valid.  If `None` (default), the validity will be
         determined by checking whether the payload consists of the fill pattern
         0x11223344.
     verify : bool
-        Whether to do basic verification of integrity (default: True)
+        Whether to do basic verification of integrity (default: `True`)
 
     Notes
     -----
@@ -53,10 +53,10 @@ class Mark5BFrame(VLBIFrameBase):
       data : property that yields full decoded payload
 
     A number of properties are defined: ``shape`` and ``dtype`` are the shape
-    and type of the data array, ``words`` the full encoded frame, and ``size``
-    the frame size in bytes.  Furthermore, the frame acts as a dictionary, with
-    keys those of the header. Any attribute that is not defined on the frame
-    itself, such as ``.time`` will be looked up on the header as well.
+    and type of the data array, and ``size`` the frame size in bytes.
+    Furthermore, the frame acts as a dictionary, with keys those of the header.
+    Any attribute that is not defined on the frame itself, such as ``.time``
+    will be looked up on the header as well.
     """
 
     _header_class = Mark5BHeader
@@ -114,7 +114,7 @@ class Mark5BFrame(VLBIFrameBase):
         bps : int
             Bits per elementary sample.  Default: 2.
         valid : bool
-            Whether the data is valid (default: `True`).  If not, the payload
+            Whether the data are valid (default: `True`).  If not, the payload
             will be set to a fill pattern.
         verify : bool
             Whether to do basic checks of frame integrity (default: `True`).

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -459,7 +459,7 @@ class TestMark5B(object):
             # And add in an invalid frame for good measure.
             fw.write(record[:11])
             fw.write(record[11:5000])
-            fw.write(record[5000:10000], invalid_data=True)
+            fw.write(record[5000:10000], valid=False)
             fw.write(record[10000:])
             assert fw.time == stop_time
 

--- a/baseband/tests/test_conversion.py
+++ b/baseband/tests/test_conversion.py
@@ -284,7 +284,7 @@ class TestMark4ToVDIF1(object):
                        nthread=data.shape[1]) as fw:
             assert (fw.tell(unit='time') - start_time) < 2. * u.ns
             # Write first VDIF frame, matching Mark 4 Header, hence invalid.
-            fw.write(data[:160], invalid_data=True)
+            fw.write(data[:160], valid=False)
             # Write remaining VDIF frames, with valid data.
             fw.write(data[160:])
             assert (fw.tell(unit='time') - time1) < 2. * u.ns

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -428,7 +428,7 @@ class VDIFStreamReader(VDIFStreamBase, VLBIStreamReaderBase):
         self.fh_raw.seek(index * self._framesetsize)
         frameset = self.fh_raw.read_frameset(self._thread_ids,
                                              edv=self.header0.edv)
-        frameset.invalid_data_value = self.fill_value
+        frameset.fill_value = self.fill_value
         assert ((frameset['seconds'] - self.header0['seconds']) *
                 self._framerate +
                 frameset['frame_nr'] - self.header0['frame_nr']) == index
@@ -469,7 +469,7 @@ class VDIFStreamWriter(VDIFStreamBase, VLBIStreamWriterBase):
         Number of channels (default: 1).  Note: different numbers of channels
         per thread is not supported.
     complex_data : bool, optional
-        Whether data is complex.  Default: `False`.
+        Whether data are complex.  Default: `False`.
     bps : int, optional
         Bits per elementary sample, i.e. per real or imaginary component for
         complex data.  Default: 1.

--- a/baseband/vdif/frame.py
+++ b/baseband/vdif/frame.py
@@ -33,8 +33,8 @@ class VDIFFrame(VLBIFrameBase):
     payload : `~baseband.vdif.VDIFPayload`
         Wrapper around the payload, provding mechanisms to decode it.
     valid : bool or None
-        Whether the data is valid.  If `None` (default), is inferred from
-        header.  Note that ``header`` is changed in-place if `True` or `False`.
+        Whether the data are valid.  If `None` (default), is inferred from
+        header.  Note that `header` is changed in-place if `True` or `False`.
     verify : bool
         Whether or not to do basic assertions that check the integrity
         (e.g., that channel information and whether or not data are complex
@@ -56,7 +56,7 @@ class VDIFFrame(VLBIFrameBase):
 
     One can decode part of the payload by indexing or slicing the frame.
     If the frame does not contain valid data, all values returned are set
-    to ``self.invalid_data_value``.
+    to ``self.fill_value``.
 
     A number of properties are defined: ``shape`` and ``dtype`` are the shape
     and type of the data array, and ``size`` the frame size in bytes.
@@ -188,7 +188,7 @@ class VDIFFrameSet(object):
 
     One can decode part of the payload by indexing or slicing the frame.
     If the frame does not contain valid data, all values returned are set
-    to ``self.invalid_data_value``.
+    to ``self.fill_value``.
 
     A number of properties are defined: ``shape`` and ``dtype`` are the shape
     and type of the data array, and ``size`` the total size in bytes.  Like a
@@ -343,13 +343,13 @@ class VDIFFrameSet(object):
             f.valid = v
 
     @property
-    def invalid_data_value(self):
-        return self.frames[0].invalid_data_value
+    def fill_value(self):
+        return self.frames[0].fill_value
 
-    @invalid_data_value.setter
-    def invalid_data_value(self, invalid_data_value):
+    @fill_value.setter
+    def fill_value(self, fill_value):
         for frame in self.frames:
-            frame.invalid_data_value = invalid_data_value
+            frame.fill_value = fill_value
 
     def _get_frames(self, item):
         """Get frames and other information required to obtain given item.

--- a/baseband/vdif/payload.py
+++ b/baseband/vdif/payload.py
@@ -113,13 +113,13 @@ class VDIFPayload(VLBIPayloadBase):
         encode the payload.
     header : `~baseband.vdif.VDIFHeader`
         If given, used to infer the number of channels, bps, and whether
-        the data is complex.
+        the data are complex.
     nchan : int, optional
         Number of channels, used if header is not given.  Default: 1.
     bps : int, optional
         Bits per elementary sample, used if header is not given.  Default: 2.
     complex_data : bool, optional
-        Whether the data is complex, used if header is not given.
+        Whether the data are complex, used if header is not given.
         Default: `False`.
     """
     _decoders = {2: decode_2bit,
@@ -157,7 +157,7 @@ class VDIFPayload(VLBIPayloadBase):
             To read data from.
         header : `~baseband.vdif.VDIFHeader`
             Used to infer the payloadsize, number of channels, bits per sample,
-            and whether the data is complex.
+            and whether the data are complex.
         """
         s = fh.read(header.payloadsize)
         if len(s) < header.payloadsize:
@@ -174,7 +174,7 @@ class VDIFPayload(VLBIPayloadBase):
             Values to be encoded.
         header : `~baseband.vdif.VDIFHeader`, optional
             If given, used to infer the encoding, and to verify the number of
-            channels and whether the data is complex.
+            channels and whether the data are complex.
         bps : int, optional
             Bits per elementary sample, used if header is `None`.  Default: 2.
         edv : int, optional
@@ -188,7 +188,7 @@ class VDIFPayload(VLBIPayloadBase):
                 raise ValueError("header is for {0} channels but data has {1}"
                                  .format(header.nchan, data.shape[-1]))
             if header['complex_data'] != complex_data:
-                raise ValueError("header is for {0} data but data is {1}"
+                raise ValueError("header is for {0} data but data are {1}"
                                  .format(*(('complex' if c else 'real') for c
                                            in (header['complex_data'],
                                                complex_data))))

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -720,7 +720,7 @@ class TestVDIF(object):
             for i in range(17):
                 fw.write(data)
             # Write an invalid frame.
-            fw.write(data, invalid_data=True)
+            fw.write(data, valid=False)
             # Write 3 frames using pieces.
             fw.write(data[:4])
             fw.write(np.concatenate((data[4:], data, data[:-4]), axis=0))

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -151,7 +151,7 @@ class VLBIStreamBase(object):
 
     @property
     def complex_data(self):
-        """Whether the data is complex."""
+        """Whether the data are complex."""
         return self._complex_data
 
     @property
@@ -527,7 +527,7 @@ class VLBIStreamWriterBase(VLBIStreamBase):
                 new_shape.insert(i + 1, 1)
         return data.reshape(new_shape)
 
-    def write(self, data, invalid_data=False):
+    def write(self, data, valid=True):
         """Write data, buffering by frames as needed.
 
         Parameters
@@ -536,8 +536,8 @@ class VLBIStreamWriterBase(VLBIStreamBase):
             Piece of data to be written, with sample dimensions as given by
             ``sample_shape``. This should be properly scaled to make best use
             of the dynamic range delivered by the encoding.
-        invalid_data : bool, optional
-            Whether the current data is invalid.  Default: `False`.
+        valid : bool, optional
+            Whether the current data are valid.  Default: `True`.
         """
         assert data.shape[1:] == self.sample_shape, (
             "'data' should have trailing shape {}".format(self.sample_shape))
@@ -554,9 +554,9 @@ class VLBIStreamWriterBase(VLBIStreamBase):
             if frame_index != self._frame_index:
                 self._frame = self._make_frame(frame_index)
                 self._frame_index = frame_index
-                self._valid = not invalid_data
+                self._valid = valid
             else:
-                self._valid &= not invalid_data
+                self._valid &= valid
 
             nsample = min(count, len(self._frame) - sample_offset)
             sample_end = sample_offset + nsample
@@ -586,7 +586,7 @@ class VLBIStreamWriterBase(VLBIStreamBase):
             warnings.warn("closing with partial buffer remaining.  "
                           "Writing padded frame, marked as invalid.")
             self.write(np.zeros((self.samples_per_frame - extra,) +
-                                self.sample_shape), invalid_data=True)
+                                self.sample_shape), valid=False)
             assert self.offset % self.samples_per_frame == 0
         return super(VLBIStreamWriterBase, self).close()
 

--- a/baseband/vlbi_base/frame.py
+++ b/baseband/vlbi_base/frame.py
@@ -26,9 +26,9 @@ class VLBIFrameBase(object):
     payload : `~baseband.vlbi_base.payload.VLBIPayloadBase`
         Wrapper around the payload, provding mechanisms to decode it.
     valid : bool
-        Whether this frame contains valid data (default: True).
+        Whether the data are valid.  Default: `True`.
     verify : bool
-        Whether to do basic verification of integrity (default: True)
+        Whether to do basic verification of integrity.  Default: `True`.
 
     Notes
     -----
@@ -46,7 +46,7 @@ class VLBIFrameBase(object):
 
     One can decode part of the payload by indexing or slicing the frame.
     If the frame does not contain valid data, all values returned are set
-    to ``self.invalid_data_value``.
+    to ``self.fill_value``.
 
     A number of properties are defined: ``shape`` and ``dtype`` are the shape
     and type of the data array, and ``size`` the frame size in bytes.
@@ -57,7 +57,7 @@ class VLBIFrameBase(object):
 
     _header_class = None
     _payload_class = None
-    invalid_data_value = 0.
+    fill_value = 0.
     """Value used to replace data if the frame does not contain valid data."""
 
     def __init__(self, header, payload, valid=True, verify=True):
@@ -164,7 +164,7 @@ class VLBIFrameBase(object):
             return self.payload.__getitem__(item)
         else:
             data_shape = np.empty(self.shape, dtype=bool)[item].shape
-            return np.full(data_shape, self.invalid_data_value,
+            return np.full(data_shape, self.fill_value,
                            dtype=self.dtype)
 
     data = property(__getitem__, doc="Full decoded frame.")

--- a/baseband/vlbi_base/payload.py
+++ b/baseband/vlbi_base/payload.py
@@ -34,7 +34,7 @@ class VLBIPayloadBase(object):
         Bits per elementary sample, i.e., per channel and per real or
         imaginary component.  Default: 2.
     complex_data : bool
-        Whether the data is complex.  Default: False.
+        Whether the data are complex.  Default: False.
     """
     # Possible fixed payload size.
     _size = None

--- a/baseband/vlbi_base/tests/test_vlbi_base.py
+++ b/baseband/vlbi_base/tests/test_vlbi_base.py
@@ -362,7 +362,7 @@ class TestVLBIBase(object):
         assert self.frame.valid is True
         frame = self.Frame(self.header, self.payload, valid=False)
         assert np.all(frame.data == 0.)
-        frame.invalid_data_value = 1.
+        frame.fill_value = 1.
         assert np.all(frame.data == 1.)
 
         assert 'x2_0_64' in self.frame

--- a/docs/tutorials/getting_started.rst
+++ b/docs/tutorials/getting_started.rst
@@ -418,7 +418,7 @@ We now write the data to file, manually flagging each invalid data frame::
 
     >>> while fr.tell() < fr.size:
     ...     d = fr.read(fr.samples_per_frame)
-    ...     fw.write(d[:640], invalid_data=True)
+    ...     fw.write(d[:640], valid=False)
     ...     fw.write(d[640:])
     >>> fr.close()
     >>> fw.close()


### PR DESCRIPTION
Replaces `invalid_data` with `valid` and `invalid_data_value` with `fill_value`.  Altered corresponding docstrings, correction a few issues in the process.

Addresses #177.