### PR TITLE
Change `size` to `nbytes`

### DIFF
--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -224,15 +224,15 @@ class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase):
     @lazyproperty
     def _last_header(self):
         """Header of the last file for this stream."""
-        self.fh_raw.seek(-self.header0.framesize, 2)
+        self.fh_raw.seek(-self.header0.frame_nbytes, 2)
         last_frame = self.fh_raw.read_frame(memmap=True)
         return last_frame.header
 
     def _read_frame(self, index):
-        self.fh_raw.seek(index * self.header0.framesize)
+        self.fh_raw.seek(index * self.header0.frame_nbytes)
         frame = self.fh_raw.read_frame(memmap=True)
         assert (frame.header['OBS_OFFSET'] - self.header0['OBS_OFFSET'] ==
-                index * self.header0.payloadsize)
+                index * self.header0.payload_nbytes)
         return frame
 
 
@@ -260,7 +260,7 @@ class DADAStreamWriter(DADAStreamBase, VLBIStreamWriterBase):
     def _make_frame(self, index):
         header = self.header0.copy()
         header.update(obs_offset=self.header0['OBS_OFFSET'] +
-                      index * self.header0.payloadsize)
+                      index * self.header0.payload_nbytes)
         return self.fh_raw.memmap_frame(header)
 
     def _write_frame(self, frame, valid=True):
@@ -373,7 +373,7 @@ def open(name, mode='rs', **kwargs):
             if 'r' in mode:
                 name = sf.open(name, 'rb')
             else:
-                name = sf.open(name, 'w+b', file_size=header0.framesize)
+                name = sf.open(name, 'w+b', file_size=header0.frame_nbytes)
 
         if header0 and 'w' in mode:
             kwargs['header0'] = header0

--- a/baseband/dada/frame.py
+++ b/baseband/dada/frame.py
@@ -44,11 +44,12 @@ class DADAFrame(VLBIFrameBase):
 
     One can decode part of the payload by indexing or slicing the frame.
 
-    A number of properties are defined: ``shape`` and ``dtype`` are the shape
-    and type of the data array, and ``size`` the frame size in bytes.
-    Furthermore, the frame acts as a dictionary, with keys those of the header.
-    Any attribute that is not defined on the frame itself, such as ``.time``
-    will be looked up on the header as well.
+    A number of properties are defined: ``shape``, ``dtype`` and ``size`` are
+    the shape, type and number of complete samples of the data array, and
+    ``nbytes`` the frame size in bytes.  Furthermore, the frame acts as a
+    dictionary, with keys those of the header.  Any attribute that is not
+    defined on the frame itself, such as ``.time`` will be looked up on the
+    header as well.
     """
     _header_class = DADAHeader
     _payload_class = DADAPayload

--- a/baseband/gsb/frame.py
+++ b/baseband/gsb/frame.py
@@ -49,17 +49,18 @@ class GSBFrame(VLBIFrameBase):
 
       data : property that yields full decoded payload
 
-    A number of properties are defined: ``shape`` and ``dtype`` are the shape
-    and type of the data array, and ``size`` the frame size in bytes.
-    Furthermore, the frame acts as a dictionary, with keys those of the header.
-    Any attribute that is not defined on the frame itself, such as ``.time``
-    will be looked up on the header as well.
+    A number of properties are defined: ``shape``, ``dtype`` and ``size`` are
+    the shape, type and number of complete samples of the data array, and
+    ``nbytes`` the frame size in bytes.  Furthermore, the frame acts as a
+    dictionary, with keys those of the header.  Any attribute that is not
+    defined on the frame itself, such as ``.time`` will be looked up on the
+    header as well.
     """
     _header_class = GSBHeader
     _payload_class = GSBPayload
 
     @classmethod
-    def fromfile(cls, fh_ts, fh_raw, payloadsize=1 << 24, nchan=1, bps=4,
+    def fromfile(cls, fh_ts, fh_raw, payload_nbytes=1 << 24, nchan=1, bps=4,
                  complex_data=False, valid=True, verify=True):
         """Read a frame from timestamp and raw data filehandles.
 
@@ -75,8 +76,8 @@ class GSBFrame(VLBIFrameBase):
             Should be a single handle for a rawdump data frame, or a tuple
             containing tuples with pairs of handles for a phased one.  E.g.,
             ``((L1, L2), (R1, R2))`` for left and right polarisations.
-        payloadsize : int, optional
-            Size of the individual payloads.  Default: 4 MiB.
+        payload_nbytes : int, optional
+            Size of the individual payloads in bytes.  Default: 2**24 (16 MB).
         nchan : int, optional
             Number of channels.  Default: 1.
         bps : int, optional
@@ -91,7 +92,8 @@ class GSBFrame(VLBIFrameBase):
             Whether to verify consistency of the frame parts.  Default: `True`.
         """
         header = cls._header_class.fromfile(fh_ts, verify=verify)
-        payload = cls._payload_class.fromfile(fh_raw, payloadsize=payloadsize,
+        payload = cls._payload_class.fromfile(fh_raw,
+                                              payload_nbytes=payload_nbytes,
                                               nchan=nchan, bps=bps,
                                               complex_data=complex_data)
         return cls(header, payload, valid=valid, verify=verify)
@@ -112,6 +114,6 @@ class GSBFrame(VLBIFrameBase):
         self.payload.tofile(fh_raw)
 
     @property
-    def size(self):
+    def nbytes(self):
         """Size of the encoded frame in the raw data file in bytes."""
-        return self.payload.size
+        return self.payload.nbytes

--- a/baseband/gsb/payload.py
+++ b/baseband/gsb/payload.py
@@ -88,7 +88,7 @@ class GSBPayload(VLBIPayloadBase):
             return cls._sample_shape_maker_nthread(*args)
 
     @classmethod
-    def fromfile(cls, fh, payloadsize=None, nchan=1, bps=4,
+    def fromfile(cls, fh, payload_nbytes=None, nchan=1, bps=4,
                  complex_data=False):
         """Read payloads from several threads.
 
@@ -99,7 +99,7 @@ class GSBPayload(VLBIPayloadBase):
             tuple holds distinct threads, while the inner ones holds parts of
             those threads.  Typically, these are the two polarisations and the
             two parts of each in which phased baseband data are stored.
-        payloadsize : int
+        payload_nbytes : int
             Number of bytes to read from each part.
         nchan : int, optional
             Number of channels.  Default: 1.
@@ -110,13 +110,13 @@ class GSBPayload(VLBIPayloadBase):
         """
         if hasattr(fh, 'read'):
             return super(GSBPayload,
-                         cls).fromfile(fh, payloadsize=payloadsize,
+                         cls).fromfile(fh, payload_nbytes=payload_nbytes,
                                        sample_shape=(nchan,), bps=bps,
                                        complex_data=complex_data)
 
         nthread = len(fh)
         payloads = [[super(GSBPayload,
-                           cls).fromfile(fh1, payloadsize=payloadsize,
+                           cls).fromfile(fh1, payload_nbytes=payload_nbytes,
                                          sample_shape=(nchan,), bps=bps,
                                          complex_data=complex_data)
                      for fh1 in fh_set] for fh_set in fh]

--- a/baseband/mark4/frame.py
+++ b/baseband/mark4/frame.py
@@ -58,11 +58,12 @@ class Mark4Frame(VLBIFrameBase):
     If the frame does not contain valid data, all values returned are set
     to ``self.fill_value``.
 
-    A number of properties are defined: ``shape`` and ``dtype`` are the shape
-    and type of the data array, and ``size`` the frame size in bytes.
-    Furthermore, the frame acts as a dictionary, with keys those of the header.
-    Any attribute that is not defined on the frame itself, such as ``.time``
-    will be looked up on the header as well.
+    A number of properties are defined: ``shape``, ``dtype`` and ``size`` are
+    the shape, type and number of complete samples of the data array, and
+    ``nbytes`` the frame size in bytes.  Furthermore, the frame acts as a
+    dictionary, with keys those of the header.  Any attribute that is not
+    defined on the frame itself, such as ``.time`` will be looked up on the
+    header as well.
     """
 
     _header_class = Mark4Header
@@ -141,7 +142,7 @@ class Mark4Frame(VLBIFrameBase):
         assert data.shape[0] == header.samples_per_frame
         # Start of part not overwritten by header
         # (see calculation of header.samples_per_frame)
-        start = header.size * 8 // (header.ntrack // header.fanout)
+        start = header.nbytes * 8 // (header.ntrack // header.fanout)
         payload = cls._payload_class.fromdata(data[start:], header=header)
 
         return cls(header, payload, verify=verify)

--- a/baseband/mark4/payload.py
+++ b/baseband/mark4/payload.py
@@ -260,7 +260,7 @@ class Mark4Payload(VLBIPayloadBase):
             nchan = header.nchan
             bps = header.bps
             fanout = header.fanout
-            self._size = header.payloadsize
+            self._nbytes = header.payload_nbytes
         self._dtype_word = MARK4_DTYPES[nchan * bps * fanout]
         self.fanout = fanout
         super(Mark4Payload, self).__init__(words, sample_shape=(nchan,),
@@ -271,11 +271,11 @@ class Mark4Payload(VLBIPayloadBase):
     def fromfile(cls, fh, header):
         """Read payload from filehandle and decode it into data.
 
-        The payloadsize, number of channels, bits per sample, and fanout ratio
-        are all taken from the header.
+        The payload_nbytes, number of channels, bits per sample, and fanout
+        ratio are all taken from the header.
         """
-        s = fh.read(header.payloadsize)
-        if len(s) < header.payloadsize:
+        s = fh.read(header.payload_nbytes)
+        if len(s) < header.payload_nbytes:
             raise EOFError("could not read full payload.")
         return cls(np.frombuffer(s, dtype=header.stream_dtype), header)
 

--- a/baseband/mark5b/frame.py
+++ b/baseband/mark5b/frame.py
@@ -52,11 +52,12 @@ class Mark5BFrame(VLBIFrameBase):
 
       data : property that yields full decoded payload
 
-    A number of properties are defined: ``shape`` and ``dtype`` are the shape
-    and type of the data array, and ``size`` the frame size in bytes.
-    Furthermore, the frame acts as a dictionary, with keys those of the header.
-    Any attribute that is not defined on the frame itself, such as ``.time``
-    will be looked up on the header as well.
+    A number of properties are defined: ``shape``, ``dtype`` and ``size`` are
+    the shape, type and number of complete samples of the data array, and
+    ``nbytes`` the frame size in bytes.  Furthermore, the frame acts as a
+    dictionary, with keys those of the header.  Any attribute that is not
+    defined on the frame itself, such as ``.time`` will be looked up on the
+    header as well.
     """
 
     _header_class = Mark5BHeader

--- a/baseband/mark5b/header.py
+++ b/baseband/mark5b/header.py
@@ -72,12 +72,12 @@ class Mark5BHeader(VLBIHeaderBase):
 
     _struct = four_word_struct
 
-    _properties = ('payloadsize', 'framesize', 'kday', 'jday', 'seconds',
+    _properties = ('payload_nbytes', 'frame_nbytes', 'kday', 'jday', 'seconds',
                    'fraction', 'time')
     """Properties accessible/usable in initialisation."""
 
     kday = None
-    _payloadsize = 10000  # 2500 words
+    _payload_nbytes = 10000  # 2500 words
 
     def __init__(self, words, kday=None, ref_time=None, verify=True, **kwargs):
         super(Mark5BHeader, self).__init__(words, verify=False, **kwargs)
@@ -182,24 +182,24 @@ class Mark5BHeader(VLBIHeaderBase):
         self.kday = np.round(ref_time.mjd - self.jday, decimals=-3).astype(int)
 
     @property
-    def payloadsize(self):
+    def payload_nbytes(self):
         """Size of the payload, in bytes."""
-        return self._payloadsize    # Hardcoded in class definition.
+        return self._payload_nbytes    # Hardcoded in class definition.
 
-    @payloadsize.setter
-    def payloadsize(self, payloadsize):
-        if payloadsize != self._payloadsize:  # 2500 words.
+    @payload_nbytes.setter
+    def payload_nbytes(self, payload_nbytes):
+        if payload_nbytes != self._payload_nbytes:  # 2500 words.
             raise ValueError("Mark 5B payload has a fixed size of 10000 bytes "
                              "(2500 words).")
 
     @property
-    def framesize(self):
+    def frame_nbytes(self):
         """Size of a frame, in bytes."""
-        return self.size + self.payloadsize
+        return self.nbytes + self.payload_nbytes
 
-    @framesize.setter
-    def framesize(self, framesize):
-        if framesize != self.size + self.payloadsize:
+    @frame_nbytes.setter
+    def frame_nbytes(self, frame_nbytes):
+        if frame_nbytes != self.nbytes + self.payload_nbytes:
             raise ValueError("Mark 5B frame has a fixed size of 10016 bytes "
                              "(4 header words plus 2500 payload words).")
 

--- a/baseband/mark5b/payload.py
+++ b/baseband/mark5b/payload.py
@@ -107,7 +107,7 @@ class Mark5BPayload(VLBIPayloadBase):
         Bits per elementary sample.  Default: 2.
     """
 
-    _size = 2500 * 4
+    _nbytes = 2500 * 4
     _encoders = {2: encode_2bit}
     _decoders = {2: decode_2bit}
 

--- a/baseband/tests/test_conversion.py
+++ b/baseband/tests/test_conversion.py
@@ -44,9 +44,9 @@ class TestVDIFMark5B(object):
             assert header.nchan == 8
             assert header.bps == 2
             assert not header['complex_data']
-            assert header.framesize == 10032
-            assert header.size == 32
-            assert header.payloadsize == m5h.payloadsize
+            assert header.frame_nbytes == 10032
+            assert header.nbytes == 32
+            assert header.payload_nbytes == m5h.payload_nbytes
             assert (header.samples_per_frame ==
                     10000 * 8 // m5pl.bps // m5pl.sample_shape.nchan)
 
@@ -108,7 +108,7 @@ class TestVDIFMark5B(object):
 
         assert m5f['frame_nr'] == 1
         frame = vdif.VDIFFrame.from_mark5b_frame(m5f)
-        assert frame.size == 10032
+        assert frame.nbytes == 10032
         assert frame.shape == (5000, 8)
         assert np.all(frame.data == m5f.data)
         assert frame.time == m5f.time
@@ -253,7 +253,7 @@ class TestMark4ToVDIF1(object):
         # Check that we have enough information to create VDIF EDV 1 header.
         header = vdif.VDIFHeader.fromvalues(
             edv=1, bps=m4h.bps, nchan=1, station='Ar', time=m4h.time,
-            sample_rate=32.*u.MHz, payloadsize=640*2//8, complex_data=False)
+            sample_rate=32.*u.MHz, payload_nbytes=640*2//8, complex_data=False)
         assert abs(header.time - m4h.time) < 2. * u.ns
 
     def test_stream(self, tmpdir):
@@ -264,7 +264,7 @@ class TestMark4ToVDIF1(object):
             vheader0 = vdif.VDIFHeader.fromvalues(
                 edv=1, bps=m4header0.bps, nchan=1, station='Ar',
                 time=start_time, sample_rate=32.*u.MHz,
-                payloadsize=640*2//8, complex_data=False)
+                payload_nbytes=640*2//8, complex_data=False)
             assert abs(vheader0.time - start_time) < 2. * u.ns
             data = fr.read(80000)  # full Mark 4 frame
             offset1 = fr.tell()
@@ -320,7 +320,7 @@ class TestDADAToVDIF1(object):
             edv=1, time=header.time, sample_rate=header.sample_rate,
             bps=header.bps, nchan=header['NCHAN'],
             complex_data=header.complex_data,
-            payloadsize=header.payloadsize // 2,
+            payload_nbytes=header.payload_nbytes // 2,
             station=header['TELESCOPE'][:2])
 
     def get_vdif_data(self, dada_data):
@@ -335,12 +335,12 @@ class TestDADAToVDIF1(object):
         # Check that we have enough information to create VDIF EDV 1 header.
         header = self.get_vdif_header(ddh)
         assert abs(header.time - ddh.time) < 2. * u.ns
-        assert header.payloadsize == ddh.payloadsize // 2
+        assert header.payload_nbytes == ddh.payload_nbytes // 2
 
     def test_payload(self):
         with open(SAMPLE_DADA, 'rb') as fh:
             fh.seek(4096)
-            ddp = dada.DADAPayload.fromfile(fh, payloadsize=64000,
+            ddp = dada.DADAPayload.fromfile(fh, payload_nbytes=64000,
                                             sample_shape=(2, 1),
                                             complex_data=True, bps=8)
         dada_data = ddp.data
@@ -394,7 +394,7 @@ class TestDADAToVDIF1(object):
         assert np.allclose(dv_data, dada_data)
         with dada.open(dada_file, 'ws', sample_rate=vh.sample_rate,
                        time=vh.time, npol=vnthread, bps=vh.bps,
-                       payloadsize=vh.payloadsize*2, nchan=vh.nchan,
+                       payload_nbytes=vh.payload_nbytes*2, nchan=vh.nchan,
                        telescope=vh.station,
                        complex_data=vh['complex_data']) as fw:
             new_header = fw.header0

--- a/baseband/tests/test_sequential_baseband.py
+++ b/baseband/tests/test_sequential_baseband.py
@@ -24,8 +24,9 @@ def test_sequentialfile_vdif_stream(tmpdir):
         complex_data=False, frame_nr=0, thread_id=0, samples_per_frame=16,
         station='me')
     with sequentialfile.open(vdif_sequencer, 'wb',
-                             file_size=4*header.framesize) as sfh, vdif.open(
-            sfh, 'ws', header0=header, nthread=2, sample_rate=256*u.Hz) as fw:
+                             file_size=4*header.frame_nbytes) as sfh, \
+            vdif.open(sfh, 'ws', header0=header, nthread=2,
+                      sample_rate=256*u.Hz) as fw:
         fw.write(data)
     # check that this wrote 8 frames
     files = [vdif_sequencer[i] for i in range(8)]

--- a/baseband/vdif/header.py
+++ b/baseband/vdif/header.py
@@ -99,7 +99,7 @@ class VDIFHeader(VLBIHeaderBase):
         As appropriate for the extended data version.
     """
 
-    _properties = ('framesize', 'payloadsize', 'bps', 'nchan',
+    _properties = ('frame_nbytes', 'payload_nbytes', 'bps', 'nchan',
                    'samples_per_frame', 'station', 'time')
     """Properties accessible/usable in initialisation for all VDIF headers."""
 
@@ -193,7 +193,7 @@ class VDIFHeader(VLBIHeaderBase):
         Values set by other keyword arguments (if present):
 
         bits_per_sample : from ``bps``
-        frame_length : from ``samples_per_frame`` or ``framesize``
+        frame_length : from ``samples_per_frame`` or ``frame_nbytes``
         lg2_nchan : from ``nchan``
         ref_epoch, seconds, frame_nr : from ``time`` (may need ``sample_rate``)
 
@@ -287,23 +287,23 @@ class VDIFHeader(VLBIHeaderBase):
         return self._edv
 
     @property
-    def framesize(self):
+    def frame_nbytes(self):
         """Size of a frame, in bytes."""
         return self['frame_length'] * 8
 
-    @framesize.setter
-    def framesize(self, size):
-        assert size % 8 == 0
-        self['frame_length'] = int(size) // 8
+    @frame_nbytes.setter
+    def frame_nbytes(self, nbytes):
+        assert nbytes % 8 == 0
+        self['frame_length'] = int(nbytes) // 8
 
     @property
-    def payloadsize(self):
+    def payload_nbytes(self):
         """Size of the payload, in bytes."""
-        return self.framesize - self.size
+        return self.frame_nbytes - self.nbytes
 
-    @payloadsize.setter
-    def payloadsize(self, size):
-        self.framesize = size + self.size
+    @payload_nbytes.setter
+    def payload_nbytes(self, nbytes):
+        self.frame_nbytes = nbytes + self.nbytes
 
     @property
     def bps(self):
@@ -332,7 +332,7 @@ class VDIFHeader(VLBIHeaderBase):
         # Values are not split over word boundaries.
         values_per_word = 32 // self.bps // (2 if self['complex_data'] else 1)
         # samples are not split over payload boundaries.
-        return self.payloadsize // 4 * values_per_word // self.nchan
+        return self.payload_nbytes // 4 * values_per_word // self.nchan
 
     @samples_per_frame.setter
     def samples_per_frame(self, samples_per_frame):
@@ -340,7 +340,7 @@ class VDIFHeader(VLBIHeaderBase):
         # units of frame length are 8 bytes, i.e., 2 words.
         values_per_long = values_per_word * 2
         longs = (samples_per_frame * self.nchan - 1) // values_per_long + 1
-        self['frame_length'] = int(longs) + self.size // 8
+        self['frame_length'] = int(longs) + self.nbytes // 8
 
     @property
     def station(self):

--- a/baseband/vdif/payload.py
+++ b/baseband/vdif/payload.py
@@ -137,7 +137,7 @@ class VDIFPayload(VLBIPayloadBase):
             nchan = header.nchan
             bps = header.bps
             complex_data = header['complex_data']
-            self._size = header.payloadsize
+            self._nbytes = header.payload_nbytes
             if header.edv == 0xab:  # Mark5B payload
                 from ..mark5b import Mark5BPayload
                 self._decoders = Mark5BPayload._decoders
@@ -156,11 +156,11 @@ class VDIFPayload(VLBIPayloadBase):
         fh : filehandle
             To read data from.
         header : `~baseband.vdif.VDIFHeader`
-            Used to infer the payloadsize, number of channels, bits per sample,
-            and whether the data are complex.
+            Used to infer the payload size, number of channels, bits per
+            sample, and whether the data are complex.
         """
-        s = fh.read(header.payloadsize)
-        if len(s) < header.payloadsize:
+        s = fh.read(header.payload_nbytes)
+        if len(s) < header.payload_nbytes:
             raise EOFError("could not read full payload.")
         return cls(np.frombuffer(s, dtype=cls._dtype_word), header)
 

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -360,12 +360,12 @@ class VLBIStreamReaderBase(VLBIStreamBase):
         header = header_template.fromfile(fh)
         frame_nr0 = header['frame_nr']
         while header['frame_nr'] == frame_nr0:
-            fh.seek(header.payloadsize, 1)
+            fh.seek(header.payload_nbytes, 1)
             header = header_template.fromfile(fh)
         max_frame = frame_nr0
         while header['frame_nr'] > 0:
             max_frame = max(header['frame_nr'], max_frame)
-            fh.seek(header.payloadsize, 1)
+            fh.seek(header.payload_nbytes, 1)
             header = header_template.fromfile(fh)
 
         fh.seek(oldpos)
@@ -375,12 +375,12 @@ class VLBIStreamReaderBase(VLBIStreamBase):
     def _last_header(self):
         """Last header of the file."""
         raw_offset = self.fh_raw.tell()
-        self.fh_raw.seek(-self.header0.framesize, 2)
+        self.fh_raw.seek(-self.header0.frame_nbytes, 2)
         last_header = self.fh_raw.find_header(forward=False)
         self.fh_raw.seek(raw_offset)
         if last_header is None:
             raise ValueError("corrupt VLBI frame? No frame in last {0} bytes."
-                             .format(10 * self.header0.framesize))
+                             .format(10 * self.header0.frame_nbytes))
         return last_header
 
     @lazyproperty

--- a/baseband/vlbi_base/frame.py
+++ b/baseband/vlbi_base/frame.py
@@ -49,7 +49,7 @@ class VLBIFrameBase(object):
     to ``self.fill_value``.
 
     A number of properties are defined: ``shape`` and ``dtype`` are the shape
-    and type of the data array, and ``size`` the frame size in bytes.
+    and type of the data array, and ``nbytes`` the frame size in bytes.
     Furthermore, the frame acts as a dictionary, with keys those of the header.
     Any attribute that is not defined on the frame itself, such as ``.time``
     will be looked up on the header as well.
@@ -71,10 +71,10 @@ class VLBIFrameBase(object):
         """Simple verification.  To be added to by subclasses."""
         assert isinstance(self.header, self._header_class)
         assert isinstance(self.payload, self._payload_class)
-        assert (self.payload.size ==
+        assert (self.payload.nbytes ==
                 self.payload.words.size * self.payload.words.dtype.itemsize)
-        assert (self.payload.size == getattr(self.header, 'payloadsize',
-                                             self.payload.size))
+        assert (self.payload.nbytes == getattr(self.header, 'payload_nbytes',
+                                               self.payload.nbytes))
 
     @property
     def valid(self):
@@ -144,9 +144,9 @@ class VLBIFrameBase(object):
         return self.payload.dtype
 
     @property
-    def size(self):
+    def nbytes(self):
         """Size of the encoded frame in bytes."""
-        return self.header.size + self.payload.size
+        return self.header.nbytes + self.payload.nbytes
 
     def __array__(self, dtype=None):
         """Interface to arrays."""

--- a/baseband/vlbi_base/header.py
+++ b/baseband/vlbi_base/header.py
@@ -258,9 +258,9 @@ class VLBIHeaderBase(object):
 
     It also should define properties (getters *and* setters):
 
-      payloadsize: number of bytes used by payload
+      payload_nbytes: number of bytes used by payload
 
-      framesize: total number of bytes for header + payload
+      frame_nbytes: total number of bytes for header + payload
 
       get_time, set_time, and a corresponding time property:
            time at start of payload
@@ -276,7 +276,7 @@ class VLBIHeaderBase(object):
         checks that the number of words is consistent with the struct size.
     """
 
-    _properties = ('payloadsize', 'framesize', 'time')
+    _properties = ('payload_nbytes', 'frame_nbytes', 'time')
     """Properties accessible/usable in initialisation for all headers."""
 
     def __init__(self, words, verify=True):
@@ -308,7 +308,7 @@ class VLBIHeaderBase(object):
         return self.copy()
 
     @property
-    def size(self):
+    def nbytes(self):
         """Size of the header in bytes."""
         return self._struct.size
 

--- a/baseband/vlbi_base/tests/test_vlbi_base.py
+++ b/baseband/vlbi_base/tests/test_vlbi_base.py
@@ -78,7 +78,7 @@ class TestVLBIBase(object):
         class Header(VLBIHeaderBase):
             _struct = four_word_struct
             _header_parser = self.header_parser
-            payloadsize = 8
+            payload_nbytes = 8
 
         self.Header = Header
         self.header = self.Header([0x12345678, 0xffff0000, 0x0, 0xffffffff])
@@ -206,7 +206,7 @@ class TestVLBIBase(object):
         assert self.payload.sample_shape == (2,)
         assert self.payload.bps == 8
         assert self.payload.shape == (4, 2)
-        assert self.payload.size == 8
+        assert self.payload.nbytes == 8
         assert np.all(self.payload.data.ravel() ==
                       self.payload.words.view(np.int8))
         assert np.all(np.array(self.payload).ravel() ==
@@ -226,7 +226,7 @@ class TestVLBIBase(object):
         assert self.payload1bit.sample_shape == (5,)
         assert self.payload1bit.bps == 1
         assert self.payload1bit.shape == (16, 5)
-        assert self.payload1bit.size == 20
+        assert self.payload1bit.nbytes == 20
         assert np.all(self.payload1bit.data.ravel() ==
                       np.unpackbits(self.payload1bit.words.view(np.uint8))
                       .astype(np.float32).view(np.complex64))
@@ -315,10 +315,10 @@ class TestVLBIBase(object):
             self.payload.tofile(s)
             s.seek(0)
             with pytest.raises(ValueError):
-                self.Payload.fromfile(s)  # no size given
+                self.Payload.fromfile(s)  # No size given.
             s.seek(0)
             payload = self.Payload.fromfile(
-                s, payloadsize=len(self.payload.words) * 4,
+                s, payload_nbytes=len(self.payload.words) * 4,
                 sample_shape=(2,), bps=8)
         assert payload == self.payload
 
@@ -331,7 +331,7 @@ class TestVLBIBase(object):
         assert payload.words.dtype is self.Payload._dtype_word
         assert len(payload.words) == 4
         assert len(payload) == len(data)
-        assert payload.size == 16
+        assert payload.nbytes == 16
         payload2 = self.Payload.fromdata(self.payload.data, self.payload.bps)
         assert payload2 == self.payload
         payload3 = self.Payload.fromdata(data.ravel(), bps=8)
@@ -388,7 +388,7 @@ class TestVLBIBase(object):
         with open(str(tmpdir.join('test.dat')), 'w+b') as s:
             self.frame.tofile(s)
             s.seek(0)
-            frame = self.Frame.fromfile(s, payloadsize=self.payload.size,
+            frame = self.Frame.fromfile(s, payload_nbytes=self.payload.nbytes,
                                         sample_shape=(2,), bps=8)
         assert frame == self.frame
 

--- a/docs/gsb/index.rst
+++ b/docs/gsb/index.rst
@@ -122,13 +122,13 @@ A single payload file can be opened with `~baseband.gsb.open` in binary mode.
 Here, for our sample file, we have to take into account that in order to keep
 these files small, their sample size has been reduced to only **4 or 8
 kilobytes** worth of samples per frame (for the default timespan).  So, we
-define their sample rate here, and use that to calculate ``payloadsize``,
+define their sample rate here, and use that to calculate ``payload_nbytes``,
 the size of one frame in bytes.  Since rawdump samples are 4 bits,
-``payloadsize`` is just ``samples_per_frame / 2``::
+``payload_nbytes`` is just ``samples_per_frame / 2``::
 
     >>> rawdump_samples_per_frame = 2**13
-    >>> payloadsize = rawdump_samples_per_frame // 2
-    >>> fb = gsb.open(SAMPLE_GSB_RAWDUMP, 'rb', payloadsize=payloadsize,
+    >>> payload_nbytes = rawdump_samples_per_frame // 2
+    >>> fb = gsb.open(SAMPLE_GSB_RAWDUMP, 'rb', payload_nbytes=payload_nbytes,
     ...               nchan=1, bps=4, complex_data=False)
     >>> payload = fb.read_payload()
     >>> payload[:4]
@@ -138,7 +138,7 @@ the size of one frame in bytes.  Since rawdump samples are 4 bits,
            [ 0.]], dtype=float32)
     >>> fb.close()
 
-(``payloadsize`` for phased data is the size of one frame *divided by the
+(``payload_nbytes`` for phased data is the size of one frame *divided by the
 number of binary files*.)
 
 Opening in stream mode allows timestamp and binary files to be read in


### PR DESCRIPTION
Working on #167.

Right now only GSB works, though it's the most tedious one, and the ugliest.  Two issues:

* GSB headers should technically have an `nchar` rather than `nbytes`.  The former is technically more accurate since Python 3 uses Unicode, but requires I overwrite methods solely to make that name change, which seems silly.
* Does `payloadnbytes` look ugly?