### PR TITLE
Remove the frame_nr option in get_time and set_time.

### DIFF
--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -319,10 +319,9 @@ class Mark5BStreamWriter(Mark5BStreamBase, VLBIStreamWriterBase):
         # Set up header for new frame.
         header = self.header0.copy()
         # Update time and frame_nr in one go.
-        # (Note: could also pass on frame rate instead of explicit frame)
-        header.set_time(time=self.start_time + index / self._framerate * u.s,
-                        frame_nr=((self.header0['frame_nr'] + index) %
-                                  self._framerate))
+        framerate = self._framerate * u.Hz
+        header.set_time(time=self.start_time + index / framerate,
+                        framerate=framerate)
         # Recalculate CRC.
         header.update()
         # Reuse payload.

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -285,14 +285,6 @@ class TestMark5B(object):
         assert header.time == header0.time
         # But if we pass in the correct framerate, it uses the frame_nr.
         assert abs(header.get_time(frame_rate) - frame.header.time) < 1. * u.ns
-        assert abs(header.get_time(frame_rate, frame_nr=header['frame_nr']) -
-                   frame.header.time) < 1. * u.ns
-        # And if we pass in a frame_nr of zero, we get the integer second.
-        assert header.get_time(frame_rate, frame_nr=0) == header0.time
-        # Finally, without a frame rate we can only do it for frame_nr=0.
-        assert header.get_time(frame_nr=0) == header0.time
-        with pytest.raises(ValueError):
-            header.get_time(frame_nr=1)
 
         # Check setting time using framerate.
         sample_rate = 128. * u.MHz
@@ -320,9 +312,9 @@ class TestMark5B(object):
         assert abs(header.get_time(frame_rate) -
                    start_time - 25599. / frame_rate) < 1. * u.ns
         # Check rounding to the nearest second when less than 2 ns away.
-        header.set_time(time=(start_time + 0.9 * u.ns), frame_nr=0)
+        header.set_time(time=(start_time + 0.9 * u.ns), framerate=frame_rate)
         assert header.seconds == header0.seconds
-        header.set_time(time=(start_time - 0.9 * u.ns), frame_nr=0)
+        header.set_time(time=(start_time - 0.9 * u.ns), framerate=frame_rate)
         assert header.seconds == header0.seconds
 
     def test_find_header(self, tmpdir):

--- a/baseband/tests/test_conversion.py
+++ b/baseband/tests/test_conversion.py
@@ -72,10 +72,6 @@ class TestVDIFMark5B(object):
         assert abs(header_copy.time - m5h2.time) > 1.*u.ns
         assert abs(header_copy.get_time(sample_rate=32*u.MHz) -
                    m5h2.time) < 1.*u.ns
-        # Also check two special cases:
-        assert abs(header_copy.get_time(frame_nr=0) == m5h1.time)
-        with pytest.raises(ValueError):  # needs frame rate
-            header_copy.get_time(frame_nr=1)
 
     def test_payload(self):
         """Check Mark 5B payloads can used in a Mark5B VDIF payload."""

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -169,10 +169,10 @@ class TestVDIF(object):
                 bps=headerT.bps, complex_data=headerT['complex_data'],
                 thread_id=headerT['thread_id'])
 
-        # Check rounding in corner case when passing explicit frame_nr.
+        # Check rounding in corner case.
         header9 = headerT.copy()
         header9.set_time(Time('2018-01-01T00:34:07.999999999996'),
-                         frame_nr=0)
+                         sample_rate=32*u.MHz)
         assert header9['seconds'] == 2048
         assert header9['frame_nr'] == 0
 


### PR DESCRIPTION
It was always a bit unclear what this was good for, and it was used only in from_mark5b_header, where it can easily be circumvented.

fixes #178.