### PR TITLE
Framerate to frame rate

### DIFF
--- a/baseband/gsb/base.py
+++ b/baseband/gsb/base.py
@@ -202,7 +202,7 @@ class GSBStreamReader(GSBStreamBase, VLBIStreamReaderBase):
     sample_rate : `~astropy.units.Quantity`, optional
         Number of complete samples per second, i.e. the rate at which each
         channel of each polarization is sampled.  If `None`, will be
-        inferred assuming the framerate is exactly 0.25165824 s.
+        inferred assuming the frame rate is exactly 0.25165824 s.
     samples_per_frame : int, optional
         Number of complete samples per frame.  Can give ``payloadsize``
         instead.
@@ -318,7 +318,7 @@ class GSBStreamWriter(GSBStreamBase, VLBIStreamWriterBase):
     sample_rate : `~astropy.units.Quantity`, optional
         Number of complete samples per second, i.e. the rate at which each
         channel of each polarization is sampled.  If not given, will be
-        inferred assuming the framerate is exactly 0.25165824 s.
+        inferred assuming the frame rate is exactly 0.25165824 s.
     samples_per_frame : int, optional
         Number of complete samples per frame.  Can give ``payloadsize``
         instead.
@@ -432,7 +432,7 @@ def open(name, mode='rs', **kwargs):
     sample_rate : `~astropy.units.Quantity`, optional
         Number of complete samples per second, i.e. the rate at which each
         channel of each polarization is sampled.  If `None`, will be
-        inferred assuming the framerate is exactly 251.658240 ms.
+        inferred assuming the frame rate is exactly 251.658240 ms.
     samples_per_frame : int, optional
         Number of complete samples per frame.  Can give ``payloadsize``
         instead.

--- a/baseband/gsb/tests/test_gsb.py
+++ b/baseband/gsb/tests/test_gsb.py
@@ -22,7 +22,7 @@ class TestGSB(object):
 
     def setup(self):
         # For all sample files, each frame spans 0.25165824 sec.
-        self.framerate = (1e8 / 3) / 2**23 * u.Hz
+        self.frame_rate = (1e8 / 3) / 2**23 * u.Hz
         # Payload size for all sample files is 2**12 bytes.
         self.payloadsize = 2**12
 
@@ -436,7 +436,7 @@ class TestGSB(object):
 
     def test_raw_stream(self, tmpdir):
         bps = 4
-        sample_rate = self.framerate * self.payloadsize * (8 // bps)
+        sample_rate = self.frame_rate * self.payloadsize * (8 // bps)
         # Open here with payloadsize given, below with samples_per_frame.
         with gsb.open(SAMPLE_RAWDUMP_HEADER, 'rs', raw=SAMPLE_RAWDUMP,
                       sample_rate=sample_rate, payloadsize=self.payloadsize,
@@ -585,7 +585,7 @@ class TestGSB(object):
     def test_phased_stream(self, tmpdir):
         bps = 8
         nchan = 512
-        sample_rate = self.framerate * self.payloadsize * (8 // bps) / nchan
+        sample_rate = self.frame_rate * self.payloadsize * (8 // bps) / nchan
         # Open here with payloadsize given, below with samples_per_frame.
         with gsb.open(SAMPLE_PHASED_HEADER, 'rs', raw=SAMPLE_PHASED,
                       sample_rate=sample_rate, payloadsize=self.payloadsize,

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -271,8 +271,8 @@ class Mark4StreamBase(VLBIStreamBase):
             unsliced_shape=(header0.nchan,),
             bps=header0.bps, complex_data=False, squeeze=squeeze,
             subset=subset, fill_value=fill_value)
-        self._framerate = int(round((self.sample_rate /
-                                     self.samples_per_frame).to_value(u.Hz)))
+        self._frame_rate = int(round((self.sample_rate /
+                                      self.samples_per_frame).to_value(u.Hz)))
 
 
 class Mark4StreamReader(Mark4StreamBase, VLBIStreamReaderBase):
@@ -348,7 +348,7 @@ class Mark4StreamReader(Mark4StreamBase, VLBIStreamReaderBase):
 
         Returns
         -------
-        framerate : `~astropy.units.Quantity`
+        frame_rate : `~astropy.units.Quantity`
             Frames per second.
 
         Notes
@@ -444,7 +444,7 @@ class Mark4StreamWriter(Mark4StreamBase, VLBIStreamWriterBase):
     def _make_frame(self, frame_index):
         header = self.header0.copy()
         header.update(time=self.start_time + frame_index /
-                      self._framerate * u.s)
+                      self._frame_rate * u.s)
         # Reuse payload.
         return Mark4Frame(header, self._payload)
 

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -367,8 +367,8 @@ class Mark4StreamReader(Mark4StreamBase, VLBIStreamReaderBase):
         fh.seek(oldpos)
         # Mark 4 specification states frames-lengths range from 1.25 ms
         # to 160 ms.
-        tdelta = header1.ms[0] - header0.ms[0]
-        return np.round(1000. / tdelta) * u.Hz
+        tdelta = header1.fraction[0] - header0.fraction[0]
+        return np.round(1 / tdelta) * u.Hz
 
     @lazyproperty
     def _last_header(self):

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -182,8 +182,8 @@ class Mark5BStreamBase(VLBIStreamBase):
             samples_per_frame=header0.payloadsize * 8 // bps // nchan,
             unsliced_shape=(nchan,), bps=bps, complex_data=False,
             squeeze=squeeze, subset=subset, fill_value=fill_value)
-        self._framerate = int(round((self.sample_rate /
-                                     self.samples_per_frame).to_value(u.Hz)))
+        self._frame_rate = int(round((self.sample_rate /
+                                      self.samples_per_frame).to_value(u.Hz)))
 
 
 class Mark5BStreamReader(Mark5BStreamBase, VLBIStreamReaderBase):
@@ -255,7 +255,7 @@ class Mark5BStreamReader(Mark5BStreamBase, VLBIStreamReaderBase):
         # Set decoded value for invalid data.
         frame.fill_value = self.fill_value
         # TODO: OK to ignore leap seconds? Not sure what writer does.
-        assert (self._framerate *
+        assert (self._frame_rate *
                 (frame.seconds - self.header0.seconds +
                  86400 * (frame.kday + frame.jday -
                           self.header0.kday - self.header0.jday)) +
@@ -303,7 +303,7 @@ class Mark5BStreamWriter(Mark5BStreamBase, VLBIStreamWriterBase):
         samples_per_frame = Mark5BHeader._payloadsize * 8 // bps // nchan
         if header0 is None:
             if 'time' in kwargs:
-                kwargs['framerate'] = sample_rate / samples_per_frame
+                kwargs['frame_rate'] = sample_rate / samples_per_frame
             header0 = Mark5BHeader.fromvalues(**kwargs)
 
         fh_raw = Mark5BFileWriter(fh_raw)
@@ -319,9 +319,9 @@ class Mark5BStreamWriter(Mark5BStreamBase, VLBIStreamWriterBase):
         # Set up header for new frame.
         header = self.header0.copy()
         # Update time and frame_nr in one go.
-        framerate = self._framerate * u.Hz
-        header.set_time(time=self.start_time + index / framerate,
-                        framerate=framerate)
+        frame_rate = self._frame_rate * u.Hz
+        header.set_time(time=self.start_time + index / frame_rate,
+                        frame_rate=frame_rate)
         # Recalculate CRC.
         header.update()
         # Reuse payload.

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -103,7 +103,7 @@ class TestMark5B(object):
         assert header7.kday == header.kday
         # Check ns rounding works correctly.
         header7.time = Time('2016-09-10T12:26:40.000000000')
-        assert header7.ns == 0
+        assert header7.fraction == 0.
         # Check that passing exact MJD to kday gives an error.
         with pytest.raises(AssertionError):
             mark5b.Mark5BHeader.fromkeys(56821, **header)

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -283,38 +283,38 @@ class TestMark5B(object):
         header['bcd_fraction'] = 0
         # So, now recover first header time, which started on the second.
         assert header.time == header0.time
-        # But if we pass in the correct framerate, it uses the frame_nr.
+        # But if we pass in the correct frame rate, it uses the frame_nr.
         assert abs(header.get_time(frame_rate) - frame.header.time) < 1. * u.ns
 
-        # Check setting time using framerate.
+        # Check setting time using frame rate.
         sample_rate = 128. * u.MHz
         samples_per_frame = 5000
         # Max frame_nr is 2**15; this sets it to 25600.
         frame_rate = sample_rate / samples_per_frame
         header.set_time(time=(start_time + 1. / frame_rate),
-                        framerate=frame_rate)
+                        frame_rate=frame_rate)
         header.get_time(frame_rate)
         assert abs(header.get_time(frame_rate) -
                    start_time - 1. / frame_rate) < 1. * u.ns
         header.set_time(time=(start_time + 3921. / frame_rate),
-                        framerate=frame_rate)
+                        frame_rate=frame_rate)
         assert abs(header.get_time(frame_rate) -
                    start_time - 3921. / frame_rate) < 1. * u.ns
         # Test using bcd_fraction gives us within 0.1 ms accuracy.
         assert abs(header.time - start_time - 3921. / frame_rate) < 0.1 * u.ms
         header.set_time(time=(start_time + 25599. / frame_rate),
-                        framerate=frame_rate)
+                        frame_rate=frame_rate)
         assert abs(header.get_time(frame_rate) -
                    start_time - 25599. / frame_rate) < 1. * u.ns
         # Check rounding when using passing fractional frametimes.
         header.set_time(time=(start_time + 25598.53 / frame_rate),
-                        framerate=frame_rate)
+                        frame_rate=frame_rate)
         assert abs(header.get_time(frame_rate) -
                    start_time - 25599. / frame_rate) < 1. * u.ns
         # Check rounding to the nearest second when less than 2 ns away.
-        header.set_time(time=(start_time + 0.9 * u.ns), framerate=frame_rate)
+        header.set_time(time=(start_time + 0.9 * u.ns), frame_rate=frame_rate)
         assert header.seconds == header0.seconds
-        header.set_time(time=(start_time - 0.9 * u.ns), framerate=frame_rate)
+        header.set_time(time=(start_time - 0.9 * u.ns), frame_rate=frame_rate)
         assert header.seconds == header0.seconds
 
     def test_find_header(self, tmpdir):

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -252,8 +252,8 @@ class VDIFStreamBase(VLBIStreamBase):
             complex_data=header0['complex_data'], squeeze=squeeze,
             subset=subset, fill_value=fill_value)
 
-        self._framerate = int(round((self.sample_rate /
-                                     self.samples_per_frame).to_value(u.Hz)))
+        self._frame_rate = int(round((self.sample_rate /
+                                      self.samples_per_frame).to_value(u.Hz)))
 
     def _get_time(self, header):
         """Get time from a header.
@@ -368,7 +368,7 @@ class VDIFStreamReader(VDIFStreamBase, VLBIStreamReaderBase):
 
         Returns
         -------
-        framerate : `~astropy.units.Quantity`
+        frame_rate : `~astropy.units.Quantity`
             Frames per second.
 
         Notes
@@ -430,7 +430,7 @@ class VDIFStreamReader(VDIFStreamBase, VLBIStreamReaderBase):
                                              edv=self.header0.edv)
         frameset.fill_value = self.fill_value
         assert ((frameset['seconds'] - self.header0['seconds']) *
-                self._framerate +
+                self._frame_rate +
                 frameset['frame_nr'] - self.header0['frame_nr']) == index
         return frameset
 
@@ -521,7 +521,7 @@ class VDIFStreamWriter(VDIFStreamBase, VLBIStreamWriterBase):
 
     def _make_frame(self, index):
         dt, frame_nr = divmod(index + self.header0['frame_nr'],
-                              self._framerate)
+                              self._frame_rate)
         seconds = self.header0['seconds'] + dt
         # Reuse frameset.
         self._frameset['seconds'] = seconds

--- a/baseband/vdif/header.py
+++ b/baseband/vdif/header.py
@@ -438,9 +438,9 @@ class VDIFHeader(VLBIHeaderBase):
                 except (AttributeError, AssertionError):
                     raise ValueError("cannot calculate sample rate for "
                                      "this header. Pass it in explicitly.")
-            framerate = sample_rate / self.samples_per_frame
-            frame_nr = int(round((frac_sec * framerate).to_value(u.one)))
-            if abs(frame_nr / framerate - 1. * u.s) < 1. * u.ns:
+            frame_rate = sample_rate / self.samples_per_frame
+            frame_nr = int(round((frac_sec * frame_rate).to_value(u.one)))
+            if abs(frame_nr / frame_rate - 1. * u.s) < 1. * u.ns:
                 frame_nr = 0
                 int_sec += 1
 
@@ -694,9 +694,9 @@ class VDIFMark5BHeader(VDIFBaseHeader, Mark5BHeader):
                           format='sec', scale='tai'))
 
     def set_time(self, time, sample_rate=None):
-        framerate = None if sample_rate is None else (sample_rate /
-                                                      self.samples_per_frame)
-        Mark5BHeader.set_time(self, time, framerate)
+        frame_rate = None if sample_rate is None else (sample_rate /
+                                                       self.samples_per_frame)
+        Mark5BHeader.set_time(self, time, frame_rate)
         super(VDIFMark5BHeader, self).set_time(time, sample_rate)
 
     time = property(get_time, set_time)

--- a/baseband/vdif/header.py
+++ b/baseband/vdif/header.py
@@ -676,21 +676,22 @@ class VDIFMark5BHeader(VDIFBaseHeader, Mark5BHeader):
         """
         if sample_rate is None:
             # Get fractional second from the Mark 5B part of the header.
-            offset = self.ns * 1.e-9
+            fraction = self.fraction
         else:
             frame_nr = self['frame_nr']
             if frame_nr == 0:
-                offset = 0.
+                fraction = 0.
             else:
                 if sample_rate is None:
                     raise ValueError("calculating the time for a non-zero "
                                      "frame number requires a sample rate. "
                                      "Pass it in explicitly.")
-                offset = (frame_nr * self.samples_per_frame /
-                          sample_rate).to_value(u.s)
+                fraction = (frame_nr * self.samples_per_frame /
+                            sample_rate).to_value(u.s)
 
         return (ref_epochs[self['ref_epoch']] +
-                TimeDelta(self['seconds'], offset, format='sec', scale='tai'))
+                TimeDelta(self['seconds'], fraction,
+                          format='sec', scale='tai'))
 
     def set_time(self, time, sample_rate=None):
         framerate = None if sample_rate is None else (sample_rate /

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -116,15 +116,15 @@ class TestVDIF(object):
             header['thread_id'] = 0
         # Also test time setting.
         header5.time = header.time + 1.*u.s
-        framerate = header.sample_rate / header.samples_per_frame
+        frame_rate = header.sample_rate / header.samples_per_frame
         assert abs(header5.time - header.time - 1.*u.s) < 1.*u.ns
         assert header5['frame_nr'] == header['frame_nr']
-        header5.time = header.time + 1.*u.s + 1.1/framerate
+        header5.time = header.time + 1.*u.s + 1.1/frame_rate
         assert abs(header5.time - header.time - 1.*u.s -
-                   1./framerate) < 1.*u.ns
+                   1./frame_rate) < 1.*u.ns
         assert header5['frame_nr'] == header['frame_nr'] + 1
         # Check rounding in corner case.
-        header5.time = header.time + 1.*u.s - 0.01/framerate
+        header5.time = header.time + 1.*u.s - 0.01/frame_rate
         assert abs(header5.time - header.time - 1.*u.s) < 1.*u.ns
         assert header5['frame_nr'] == header['frame_nr']
         # Check requesting non-existent EDV returns VDIFBaseHeader instance
@@ -134,7 +134,7 @@ class TestVDIF(object):
 
         # Make a new header to test passing time/sample rate.
         headerT = header.copy()
-        headerT.time = header.time + 1. / framerate
+        headerT.time = header.time + 1. / frame_rate
 
         # Test initializing EDV 0 with properties, but off of 1 second mark so
         # frame_nr is used.

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -340,7 +340,7 @@ class VLBIStreamReaderBase(VLBIStreamBase):
 
         Returns
         -------
-        framerate : `~astropy.units.Quantity`
+        frame_rate : `~astropy.units.Quantity`
             Frames per second.
 
         Notes

--- a/docs/gsb/index.rst
+++ b/docs/gsb/index.rst
@@ -108,7 +108,7 @@ of Fourier channels.  The samples per frame for both rawdump and phased is::
     ``timespan_of_frame`` with ``sample_rate`` in order to avoid rounding
     issues.
 
-Alternatively, if the size of the frame buffer and the framerate are known, the
+Alternatively, if the size of the frame buffer and the frame rate are known, the
 former can be used to determine ``samples_per_frame``, and the latter used to
 determine ``sample_rate`` by inverting the above equation.
 


### PR DESCRIPTION
It bugged me that we use `sample_rate` throughout yet not `frame_rate` but `framerate` (except in some tests). So I changed it. Perhaps going a bit too far, but especially now that we also have `payload_nbytes`, etc., it seems more consistent. And I now know how to do multiple-file query-replace in emacs...