### PR TITLE
Also require setting nchan for Mark5BFileReader.read_frame()

### DIFF
--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -35,7 +35,7 @@ class Mark5BFileReader(VLBIFileBase):
     bps : int, optional
         Bits per elementary sample.  Default: 2.
     """
-    def __init__(self, fh_raw, kday=None, ref_time=None, nchan=1, bps=2):
+    def __init__(self, fh_raw, kday=None, ref_time=None, nchan=None, bps=2):
         self.kday = kday
         self.ref_time = ref_time
         self.nchan = nchan
@@ -57,6 +57,9 @@ class Mark5BFileReader(VLBIFileBase):
             `~baseband.mark5b.Mark5BHeader` and data encoded in the frame,
             respectively.
         """
+        if self.nchan is None:
+            raise TypeError("In order to read frames, the file handle should "
+                            "be initialized with nchan set.")
         return Mark5BFrame.fromfile(self.fh_raw, kday=self.kday,
                                     ref_time=self.ref_time, nchan=self.nchan,
                                     bps=self.bps)

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -608,6 +608,10 @@ class TestMark5B(object):
 
     def test_stream_missing_nchan(self):
         with pytest.raises(TypeError):
+            with mark5b.open(SAMPLE_FILE, 'rb') as fh:
+                fh.read_frame()
+
+        with pytest.raises(TypeError):
             mark5b.open(SAMPLE_FILE, 'rs', sample_rate=32*u.MHz, kday=56000)
 
     def test_stream_missing_kday(self):


### PR DESCRIPTION
Guessing is really problematic for making a sensible frame inspection routine.

Also, easier to become more accepting than less.