### PR TITLE
General opener, using file info.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ New Features
 - Added a new ``baseband.file_info`` function, which can be used to inpect
   data files. [#200]
 
+- Added a general file opener, ``baseband.open`` which for a set of formats
+  will check whether the file is of that format, and then load it using the
+  corresponding module. [#198]
+
 API Changes
 -----------
 
@@ -19,6 +23,8 @@ Bug Fixes
 Other Changes and Additions
 ---------------------------
 
+- The ``data`` module with sample data files now has an explicit entry in the
+  documentation. [#198]
 
 1.0.1 (unreleased)
 ==================

--- a/baseband/__init__.py
+++ b/baseband/__init__.py
@@ -17,4 +17,4 @@ if not _ASTROPY_SETUP_:
     pass
 
 
-from .core import file_info
+from .core import file_info, open

--- a/baseband/__init__.py
+++ b/baseband/__init__.py
@@ -1,9 +1,5 @@
 # Licensed under the GPLv3 - see LICENSE
-"""
-Reading and writing VLBI and other radio baseband files.
-
-It relies on numpy and astropy.
-"""
+"""Radio baseband I/O."""
 
 # Affiliated packages may add whatever they like to this file, but
 # should keep this content at the top.

--- a/baseband/tests/test_core.py
+++ b/baseband/tests/test_core.py
@@ -1,0 +1,32 @@
+# Licensed under the GPLv3 - see LICENSE
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import pytest
+from astropy.time import Time
+import astropy.units as u
+
+from .. import open as baseband_open, file_info
+from ..data import (SAMPLE_MARK4 as SAMPLE_M4, SAMPLE_MARK5B as SAMPLE_M5B,
+                    SAMPLE_VDIF, SAMPLE_MWA_VDIF as SAMPLE_MWA, SAMPLE_DADA)
+
+
+@pytest.mark.parametrize(
+    ('sample', 'fmt'),
+    ((SAMPLE_M4, 'mark4'),
+     (SAMPLE_M5B, 'mark5b'),
+     (SAMPLE_VDIF, 'vdif')))
+def test_open(sample, fmt):
+    # Use extra arguments that allow all formats to succeed.
+    extra_args = {'nchan': 8,
+                  'ref_time': Time('2014-01-01'),
+                  'sample_rate': 32.*u.MHz}
+    info = file_info(sample, fmt, **extra_args)
+    with baseband_open(sample, 'rs', **extra_args) as fh:
+        assert fh.start_time == info.start_time
+
+
+def test_open_write_checks():
+    # Cannot have multiple formats for writing.
+    with pytest.raises(ValueError):
+        baseband_open('a.a', 'wb', fmt=('dada', 'mark4'))

--- a/baseband/tests/test_core.py
+++ b/baseband/tests/test_core.py
@@ -26,6 +26,43 @@ def test_open(sample, fmt):
         assert fh.start_time == info.start_time
 
 
+@pytest.mark.parametrize('sample', (SAMPLE_M4, SAMPLE_M5B))
+def test_open_missing_args(sample):
+    with pytest.raises(TypeError) as exc:
+        baseband_open(sample, 'rs')
+    assert "missing required arguments" in str(exc.value)
+
+
+def test_open_wrong_args():
+    # Use extra arguments that allow formats to succeed up to the stream
+    # reader, but then fail on an incorrect sample rate.
+    mark4_args = {'nchan': 8,
+                  'ref_time': Time('2014-01-01')}
+    with pytest.raises(ValueError) as exc:  # wrong sample_rate
+        baseband_open(SAMPLE_M4, 'rs', sample_rate=31*u.MHz, **mark4_args)
+    assert "inconsistent" in str(exc.value)
+
+    with pytest.raises(TypeError) as exc:  # extraneous argument
+        baseband_open(SAMPLE_M4, 'rs', life=42, **mark4_args)
+    assert "unexpected" in str(exc.value)
+
+    with pytest.raises(ValueError) as exc:  # wrong decade
+        baseband_open(SAMPLE_VDIF, 'rs', decade=2000)
+    assert "inconsistent" in str(exc.value)
+
+    with pytest.raises(ValueError) as exc:  # wrong kday
+        baseband_open(SAMPLE_VDIF, 'rs', kday=55000)
+    assert "inconsistent" in str(exc.value)
+
+    with pytest.raises(ValueError) as exc:  # ref_time too far off.
+        baseband_open(SAMPLE_VDIF, 'rs', ref_time=Time('J2000'))
+    assert "inconsistent" in str(exc.value)
+
+    with pytest.raises(ValueError) as exc:  # inconsistent nchan.
+        baseband_open(SAMPLE_DADA, 'rs', nchan=8)
+    assert "inconsistent" in str(exc.value)
+
+
 def test_open_write_checks():
     # Cannot have multiple formats for writing.
     with pytest.raises(ValueError):

--- a/baseband/tests/test_file_info.py
+++ b/baseband/tests/test_file_info.py
@@ -47,13 +47,12 @@ def test_open_missing_args(sample, missing):
 
 
 @pytest.mark.parametrize(
-    ('sample', 'format_', 'used', 'consistent', 'inconsistent', 'irrelevant'),
-    ((SAMPLE_M4, 'mark4', ('ref_time',), ('nchan',), (), ()),
-     (SAMPLE_M5B, 'mark5b', ('ref_time', 'nchan'), (), (), ()),
-     (SAMPLE_VDIF, 'vdif', (), ('nchan',), (), ('ref_time',)),
-     (SAMPLE_DADA, 'dada', (), (), ('nchan',), ('ref_time',))))
-def test_file_info(sample, format_, used, consistent, inconsistent,
-                   irrelevant):
+    ('sample', 'format_', 'used', 'consistent', 'inconsistent'),
+    ((SAMPLE_M4, 'mark4', ('ref_time',), ('nchan',), ()),
+     (SAMPLE_M5B, 'mark5b', ('ref_time', 'nchan'), (), ()),
+     (SAMPLE_VDIF, 'vdif', (), ('nchan', 'ref_time'), ()),
+     (SAMPLE_DADA, 'dada', (), ('ref_time',), ('nchan',))))
+def test_file_info(sample, format_, used, consistent, inconsistent):
     # Pass on extra arguments needed to get Mark4 and Mark5B to pass.
     # For GSB, we also need raw files, so we omit them.
     extra_args = {'ref_time': Time('2014-01-01'),
@@ -68,12 +67,18 @@ def test_file_info(sample, format_, used, consistent, inconsistent,
     assert set(info.used_kwargs.keys()) == set(used)
     assert set(info.consistent_kwargs.keys()) == set(consistent)
     assert set(info.inconsistent_kwargs.keys()) == set(inconsistent)
-    assert set(info.irrelevant_kwargs.keys()) == set(irrelevant)
-    # Check we can indeed open a file with those extra arguments.
+    assert set(info.irrelevant_kwargs.keys()) == set()
+    # Check that extraneous arguments get classified correctly.
+    info2 = file_info(sample, life=42, **extra_args)
+    assert info2.used_kwargs == info.used_kwargs
+    assert info2.consistent_kwargs == info.consistent_kwargs
+    assert info2.inconsistent_kwargs == info.inconsistent_kwargs
+    assert info2.irrelevant_kwargs == {'life': 42}
+    # Check we can indeed open a file with the extra arguments.
     module = importlib.import_module('.' + info.format, package='baseband')
     with module.open(sample, mode='rs', **info.used_kwargs) as fh:
-        info2 = fh.info
-    assert info2() == info_dict
+        info3 = fh.info
+    assert info3() == info_dict
 
 
 @pytest.mark.parametrize(

--- a/baseband/vlbi_base/file_info.py
+++ b/baseband/vlbi_base/file_info.py
@@ -6,7 +6,6 @@ Loosely based on `~astropy.utils.data_info.DataInfo`.
 from __future__ import division, unicode_literals, print_function
 
 import astropy.units as u
-from astropy.utils.compat.misc import override__dir__
 from astropy.extern import six
 
 
@@ -68,10 +67,6 @@ class VLBIInfoBase(object):
         # if "info" is present in instance.__dict__; see
         # https://docs.python.org/3/howto/descriptor.html
         raise AttributeError("can't set info attribute.")
-
-    @override__dir__
-    def __dir__(self):
-        return self.attr_names
 
     def __bool__(self):
         return self.format is not None

--- a/docs/data/index.rst
+++ b/docs/data/index.rst
@@ -1,0 +1,8 @@
+.. _data:
+
+*****************
+Sample Data Files
+*****************
+
+.. automodapi:: baseband.data
+   :include-all-objects:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,6 @@ Overview
    install
    tutorials/getting_started
    tutorials/glossary
-   authors_for_sphinx
 
 .. _specific_file_formats_toc:
 
@@ -51,15 +50,17 @@ troubleshooting help and APIs for each.
 Core framework and utilities
 ============================
 
-These sections contain APIs and usage notes for the sequential file opener, and
+These sections contain APIs and usage notes for the sequential file opener,
 the API for the set of core utility functions and classes located in
-:mod:`~baseband.vlbi_base`.
+:mod:`~baseband.vlbi_base`, and sample data that come with baseband (mostly
+used for testing).
 
 .. toctree::
    :maxdepth: 1
 
    helpers/index
    vlbi_base/index
+   data/index
 
 .. _dev_docs_toc:
 
@@ -94,3 +95,7 @@ Project details
    authors_for_sphinx
    changelog
    license
+
+Reference/API
+=============
+.. automodapi:: baseband


### PR DESCRIPTION
My fun project for the evening. It does somewhat work, though clearly at least the sample rate should be checked:
```
In [1]: from baseband.data import SAMPLE_DADA, SAMPLE_VDIF, SAMPLE_MARK4, SAMPLE_MARK5B; import baseband

In [2]: baseband.file_info(SAMPLE_DADA)
Out[2]: 
{'fmt': 'dada',
 'sample_shape': SampleShape(npol=2, nchan=1),
 'start_time': <Time object: scale='utc' format='mjd' value=56475.06898148148>}

In [3]: baseband.open(SAMPLE_MARK4)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-3-e1748998f20e> in <module>()
----> 1 baseband.open(SAMPLE_MARK4)

/home/mhvk/packages/baseband/baseband/core.py in open(name, mode, fmt, **kwargs)
     38         if 'missing' in info and 's' in mode:
     39             raise ValueError("file format is {}, but required arguments {} "
---> 40                              "are missing.".format(fmt, info['missing']))
     41 
     42     module = importlib.import_module('.' + fmt, package='baseband')

ValueError: file format is mark4, but required arguments ['decade', 'ref_time'] are missing.

In [4]: baseband.open(SAMPLE_MARK4, decade=2010)
Out[4]: 
<Mark4StreamReader name=/home/mhvk/packages/baseband/baseband/data/sample.m4 offset=0
    sample_rate=32.0 MHz, samples_per_frame=80000,
    sample_shape=SampleShape(nchan=8), bps=2,
    start_time=2014-06-16T07:38:12.47500>
```