### PR TITLE
Further standardized docstrings

### DIFF
--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -106,7 +106,7 @@ class DADAFileNameSequencer:
 class DADAFileReader(VLBIFileBase):
     """Simple reader for DADA files.
 
-    Adds a ``read_frame`` method to the basic VLBI binary file wrapper. By
+    Adds a `read_frame` method to the basic VLBI binary file wrapper. By
     default, the payload is mapped rather than fully read into physical memory.
     """
     def read_frame(self, memmap=True):
@@ -132,7 +132,7 @@ class DADAFileReader(VLBIFileBase):
 class DADAFileWriter(VLBIFileBase):
     """Simple writer/mapper for DADA files.
 
-    Adds ``write_frame`` and ``memmap_frame`` methods to the VLBI binary file
+    Adds `write_frame` and `memmap_frame` methods to the VLBI binary file
     wrapper.  The latter allows one to encode data in pieces, writing to disk
     as needed.
     """
@@ -149,7 +149,7 @@ class DADAFileWriter(VLBIFileBase):
             Can instead give keyword arguments to construct a header.  Ignored
             if ``data`` is a `~baseband.dada.DADAFrame` instance.
         **kwargs
-            If `header` is not given, these are used to initialize one.
+            If ``header`` is not given, these are used to initialize one.
         """
         if not isinstance(data, DADAFrame):
             data = DADAFrame.fromdata(data, header, **kwargs)
@@ -167,7 +167,7 @@ class DADAFileWriter(VLBIFileBase):
             Written to disk immediately.  Can instead give keyword arguments to
             construct a header.
         **kwargs
-            If `header` is not given, these are used to initialize one.
+            If ``header`` is not given, these are used to initialize one.
 
         Returns
         -------
@@ -248,7 +248,7 @@ class DADAStreamWriter(DADAStreamBase, VLBIStreamWriterBase):
     header0 : :class:`~baseband.dada.DADAHeader`
         Header for the first frame, holding time information, etc.
     squeeze : bool, optional
-        If `True` (default), ``write`` accepts squeezed arrays as input,
+        If `True` (default), `write` accepts squeezed arrays as input,
         and adds any dimensions of length unity.
     """
     def __init__(self, fh_raw, header0, squeeze=True):
@@ -292,7 +292,7 @@ header0 : `~baseband.dada.DADAHeader`
     Header for the first frame, holding time information, etc.  Can instead
     give keyword arguments to construct a header (see ``**kwargs``).
 squeeze : bool, optional
-    If `True` (default), ``write`` accepts squeezed arrays as input, and adds
+    If `True` (default), writer accepts squeezed arrays as input, and adds
     any dimensions of length unity.
 **kwargs
     If the header is not given, an attempt will be made to construct one
@@ -314,7 +314,7 @@ npol : int, optional
 nchan : int, optional
     Number of channels (default: 1).
 complex_data : bool, optional
-    Whether data are complex (default: False).
+    Whether data are complex (default: `False`).
 bps : int, optional
     Bits per elementary sample, i.e. per real or imaginary component for
     complex data (default: 8).

--- a/baseband/dada/frame.py
+++ b/baseband/dada/frame.py
@@ -44,9 +44,9 @@ class DADAFrame(VLBIFrameBase):
 
     One can decode part of the payload by indexing or slicing the frame.
 
-    A number of properties are defined: ``shape``, ``dtype`` and ``size`` are
+    A number of properties are defined: `shape`, `dtype` and `size` are
     the shape, type and number of complete samples of the data array, and
-    ``nbytes`` the frame size in bytes.  Furthermore, the frame acts as a
+    `nbytes` the frame size in bytes.  Furthermore, the frame acts as a
     dictionary, with keys those of the header.  Any attribute that is not
     defined on the frame itself, such as ``.time`` will be looked up on the
     header as well.
@@ -97,7 +97,7 @@ class DADAFrame(VLBIFrameBase):
             Whether or not to do basic assertions that check the integrity.
             Default: `True`.
         **kwargs
-            If `header` is not given, these are used to initialize one.
+            If ``header`` is not given, these are used to initialize one.
         """
         if header is None:
             header = cls._header_class.fromvalues(verify=verify, **kwargs)

--- a/baseband/dada/header.py
+++ b/baseband/dada/header.py
@@ -102,7 +102,7 @@ class DADAHeader(OrderedDict):
                                            'DADA_VERSION'))
 
     def copy(self):
-        """Create a mutable and independent copy."""
+        """Create a mutable and independent copy of the header."""
         # Cannot do super(DADAHeader, self).copy(), since this first
         # initializes an empty header, which does not pass verification.
         new = self.__class__(self)
@@ -233,7 +233,7 @@ class DADAHeader(OrderedDict):
         any ``header``, ``cls.fromvalues(**header) == header``.
 
         However, unlike for the ``fromkeys`` class method, data can also be set
-        using arguments named after header methods such as ``time``.
+        using arguments named after header methods, such as ``time``.
 
         Furthermore, some header defaults are set in ``DADAHeader._defaults``.
         """
@@ -279,12 +279,12 @@ class DADAHeader(OrderedDict):
 
     @property
     def nbytes(self):
-        """Size in bytes of the header."""
+        """Size of the header in bytes."""
         return self['HDR_SIZE']
 
     @property
     def payload_nbytes(self):
-        """Size in bytes of the payload part of the file."""
+        """Size of the payload in bytes."""
         return self['FILE_SIZE']
 
     @payload_nbytes.setter
@@ -293,7 +293,7 @@ class DADAHeader(OrderedDict):
 
     @property
     def frame_nbytes(self):
-        """Size in bytes of the full file, header plus payload."""
+        """Size of the frame in bytes."""
         return self.nbytes + self.payload_nbytes
 
     @frame_nbytes.setter
@@ -319,7 +319,7 @@ class DADAHeader(OrderedDict):
 
     @property
     def sample_shape(self):
-        """Shape of a single payload sample: (npol, nchan)."""
+        """Shape of a sample in the payload (npol, nchan)."""
         return self['NPOL'], self['NCHAN']
 
     @sample_shape.setter
@@ -352,7 +352,7 @@ class DADAHeader(OrderedDict):
 
     @property
     def samples_per_frame(self):
-        """Complete samples per frame (i.e., each having ``sample_shape``)."""
+        """Number of complete samples in the frame."""
         return (self.payload_nbytes * 8 //
                 self.bps // (2 if self.complex_data else 1) // self['NPOL'] //
                 self['NCHAN'])
@@ -403,7 +403,7 @@ class DADAHeader(OrderedDict):
 
     @property
     def time(self):
-        """Start time the part of the observation covered by this header."""
+        """Start time of the part of the observation covered by this header."""
         return self.start_time + self.offset
 
     @time.setter

--- a/baseband/gsb/base.py
+++ b/baseband/gsb/base.py
@@ -19,7 +19,7 @@ __all__ = ['GSBFileReader', 'GSBFileWriter', 'GSBStreamReader',
 class GSBTimeStampIO(VLBIFileBase):
     """Simple reader/writer for GSB time stamp files.
 
-    Adds ``read_timestamp`` and ``write_timestamp`` methods to the basic VLBI
+    Adds `read_timestamp` and `write_timestamp` methods to the basic VLBI
     file wrapper. To be used with a text file.
     """
 
@@ -46,7 +46,7 @@ class GSBTimeStampIO(VLBIFileBase):
             Header holding time to be written to disk.  Can instead give
             keyword arguments to construct a header.
         **kwargs :
-            If `header` is not given, these are used to initialize one.
+            If ``header`` is not given, these are used to initialize one.
         """
         if header is None:
             header = GSBHeader.fromvalues(**kwargs)
@@ -56,7 +56,7 @@ class GSBTimeStampIO(VLBIFileBase):
 class GSBFileReader(VLBIFileBase):
     """Simple reader for GSB data files.
 
-    Adds ``read_payload`` method to the basic VLBI binary file wrapper.
+    Adds `read_payload` method to the basic VLBI binary file wrapper.
 
     Parameters
     ----------
@@ -68,7 +68,7 @@ class GSBFileReader(VLBIFileBase):
         Bits per elementary sample, i.e. per real or imaginary component
         for complex data.  Default: 4.
     complex_data : bool, optional
-        Whether data are complex.  Default: False.
+        Whether data are complex.  Default: `False`.
     """
     def __init__(self, fh_raw, payload_nbytes, nchan=1, bps=4,
                  complex_data=False):
@@ -100,7 +100,7 @@ class GSBFileReader(VLBIFileBase):
 class GSBFileWriter(VLBIFileBase):
     """Simple writer for GSB data files.
 
-    Adds ``write_payload`` method to the basic VLBI binary file wrapper.
+    Adds `write_payload` method to the basic VLBI binary file wrapper.
     """
 
     def write_payload(self, data, bps=4):
@@ -112,7 +112,7 @@ class GSBFileWriter(VLBIFileBase):
             If an array, ``bps`` needs to be passed in.
         bps : int, optional
             Bits per elementary sample, to use when encoding the payload.
-            Ignored if `data` is a GSB payload.  Default: 4.
+            Ignored if ``data`` is a GSB payload.  Default: 4.
         """
         if not isinstance(data, GSBPayload):
             data = GSBPayload.fromdata(data, bps=bps)
@@ -202,21 +202,22 @@ class GSBStreamReader(GSBStreamBase, VLBIStreamReaderBase):
         Raw binary data filehandle(s).  A single file is needed for rawdump,
         and a tuple for phased.  For a nested tuple, the outer tuple determines
         the number of polarizations, and the inner tuple(s) the number of
-        streams per polarization.  E.g., ((polL1, polL2), (polR1, polR2)) for
-        two streams per polarization.  A single tuple is interpreted as
+        streams per polarization.  E.g., ``((polL1, polL2), (polR1, polR2))``
+        for two streams per polarization.  A single tuple is interpreted as
         streams of a single polarization.
     sample_rate : `~astropy.units.Quantity`, optional
         Number of complete samples per second, i.e. the rate at which each
         channel of each polarization is sampled.  If `None`, will be
         inferred assuming the frame rate is exactly 0.25165824 s.
     samples_per_frame : int, optional
-        Number of complete samples per frame.  Can give `payload_nbytes`
+        Number of complete samples per frame.  Can give ``payload_nbytes``
         instead.
     payload_nbytes : int, optional
         Number of bytes per payload, divided by the number of raw files.
         If both ``samples_per_frame`` and ``payload_nbytes`` are `None`,
-        ``payload_nbytes`` is set to 2**22 (4 MB) for rawdump, and 2**23 (8 MB)
-        divided by the number of streams per polarization for phased.
+        ``payload_nbytes`` is set to ``2**22`` (4 MB) for rawdump, and
+        ``2**23`` (8 MB) divided by the number of streams per polarization for
+        phased.
     nchan : int, optional
         Number of channels. Default: 1 for rawdump, 512 for phased.
     bps : int, optional
@@ -315,8 +316,8 @@ class GSBStreamWriter(GSBStreamBase, VLBIStreamWriterBase):
         For writing raw binary data to storage.  A single file is needed for
         rawdump, and a tuple for phased.  For a nested tuple, the outer
         tuple determines the number of polarizations, and the inner tuple(s)
-        the number of streams per polarization.  E.g., ((polL1, polL2), (polR1,
-        polR2)) for two streams per polarization.  A single tuple is
+        the number of streams per polarization.  E.g., ``((polL1, polL2),
+        (polR1, polR2))`` for two streams per polarization.  A single tuple is
         interpreted as streams of a single polarization.
     header0 : `~baseband.gsb.GSBHeader`
         Header for the first frame, holding time information, etc.  Can instead
@@ -331,8 +332,9 @@ class GSBStreamWriter(GSBStreamBase, VLBIStreamWriterBase):
     payload_nbytes : int, optional
         Number of bytes per payload, divided by the number of raw files.
         If both ``samples_per_frame`` and ``payload_nbytes`` are `None`,
-        ``payload_nbytes`` is set to 2**22 (4 MB) for rawdump, and 2**23 (8 MB)
-        divided by the number of streams per polarization for phased.
+        ``payload_nbytes`` is set to ``2**22`` (4 MB) for rawdump, and
+        ``2**23`` (8 MB) divided by the number of streams per polarization for
+        phased.
     nchan : int, optional
         Number of channels. Default: 1 for rawdump, 512 for phased.
     bps : int, optional
@@ -342,7 +344,7 @@ class GSBStreamWriter(GSBStreamBase, VLBIStreamWriterBase):
         Whether data are complex.  Default: `False` for rawdump, `True` for
         phased.
     squeeze : bool, optional
-        If `True` (default), ``write`` accepts squeezed arrays as input, and
+        If `True` (default), `write` accepts squeezed arrays as input, and
         adds any dimensions of length unity.
     **kwargs
         If no header is given, an attempt is made to construct one from these.
@@ -423,7 +425,7 @@ def open(name, mode='rs', **kwargs):
     mode : {'rb', 'wb', 'rt', 'wt', 'rs', or 'ws'}, optional
         Whether to open for reading or writing, and as a regular text or binary
         file (for timestamps and data, respectively) or as a stream.
-        Default: ``rs``, for reading a stream.
+        Default: 'rs', for reading a stream.
     **kwargs
         Additional arguments when opening the file as a stream.
 
@@ -433,8 +435,8 @@ def open(name, mode='rs', **kwargs):
         Name of files holding payload data.  A single file is needed for
         rawdump, and a tuple for phased.  For a nested tuple, the outer tuple
         determines the number of polarizations, and the inner tuple(s) the
-        number of streams per polarization.  E.g.,
-        ((polL1, polL2), (polR1, polR2)) for two streams per polarization.  A
+        number of streams per polarization.  E.g.,  ``((polL1, polL2),
+        (polR1, polR2))`` for two streams per polarization.  A
         single tuple is interpreted as streams of a single polarization.
     sample_rate : `~astropy.units.Quantity`, optional
         Number of complete samples per second, i.e. the rate at which each
@@ -446,8 +448,9 @@ def open(name, mode='rs', **kwargs):
     payload_nbytes : int, optional
         Number of bytes per payload, divided by the number of raw files.
         If both ``samples_per_frame`` and ``payload_nbytes`` are `None`,
-        ``payload_nbytes`` is set to 2**22 (4 MB) for rawdump, and 2**23 (8 MB)
-        divided by the number of streams per polarization for phased.
+        ``payload_nbytes`` is set to ``2**22`` (4 MB) for rawdump, and
+        ``2**23`` (8 MB) divided by the number of streams per polarization for
+        phased.
     nchan : int, optional
         Number of channels. Default: 1 for rawdump, 512 for phased.
     bps : int, optional

--- a/baseband/gsb/frame.py
+++ b/baseband/gsb/frame.py
@@ -49,9 +49,9 @@ class GSBFrame(VLBIFrameBase):
 
       data : property that yields full decoded payload
 
-    A number of properties are defined: ``shape``, ``dtype`` and ``size`` are
+    A number of properties are defined: `shape`, `dtype` and `size` are
     the shape, type and number of complete samples of the data array, and
-    ``nbytes`` the frame size in bytes.  Furthermore, the frame acts as a
+    `nbytes` the frame size in bytes.  Furthermore, the frame acts as a
     dictionary, with keys those of the header.  Any attribute that is not
     defined on the frame itself, such as ``.time`` will be looked up on the
     header as well.
@@ -77,7 +77,8 @@ class GSBFrame(VLBIFrameBase):
             containing tuples with pairs of handles for a phased one.  E.g.,
             ``((L1, L2), (R1, R2))`` for left and right polarisations.
         payload_nbytes : int, optional
-            Size of the individual payloads in bytes.  Default: 2**24 (16 MB).
+            Size of the individual payloads in bytes.  Default: ``2**24``
+            (16 MB).
         nchan : int, optional
             Number of channels.  Default: 1.
         bps : int, optional

--- a/baseband/gsb/header.py
+++ b/baseband/gsb/header.py
@@ -22,9 +22,10 @@ __all__ = ['TimeGSB', 'GSBHeader', 'GSBRawdumpHeader', 'GSBPhasedHeader']
 
 
 class TimeGSB(TimeString):
-    """GSB header date-time format ``'YYYY MM DD HH MM SS 0.SSSSSS'``.
+    """GSB header date-time format ``YYYY MM DD HH MM SS 0.SSSSSSSSS``.
 
-    For example, 2000 01 01 00 00 00 0.000000 is midnight on January 1, 2000.
+    For example, ``2000 01 01 00 00 00 0.000000000`` is midnight on
+    January 1, 2000.
     """
     # Implicitly uses the metaclass astropy.time.formats.TimeFormatMeta to
     # register with astropy.Time.
@@ -100,7 +101,7 @@ def get_default(index, length, forward, backward, default=None):
 
 
 class GSBHeader(VLBIHeaderBase):
-    """GSB Header, based on a line from a time-stamp file.
+    """GSB Header, based on a line from a timestamp file.
 
     Parameters
     ----------
@@ -158,6 +159,7 @@ class GSBHeader(VLBIHeaderBase):
 
     @property
     def mode(self):
+        """Mode in which data was taken: 'phased' or 'rawdump'."""
         return self._mode
 
     @property

--- a/baseband/gsb/payload.py
+++ b/baseband/gsb/payload.py
@@ -106,7 +106,7 @@ class GSBPayload(VLBIPayloadBase):
         bps : int, optional
             Bits per elementary sample.  Default: 4.
         complex_data : bool, optional
-            Whether data are complex.  Default: False.
+            Whether data are complex.  Default: `False`.
         """
         if hasattr(fh, 'read'):
             return super(GSBPayload,

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -23,7 +23,7 @@ nbits = ((np.arange(256)[:, np.newaxis] >> np.arange(8) & 1)
 class Mark4FileReader(VLBIFileBase):
     """Simple reader for Mark 4 files.
 
-    Adds ``read_frame`` and ``locate_frame`` methods to the VLBI file wrapper.
+    Adds `read_frame` and `locate_frame` methods to the VLBI file wrapper.
 
     Parameters
     ----------
@@ -32,10 +32,10 @@ class Mark4FileReader(VLBIFileBase):
         part of locating the first frame.
     decade : int or None
         Decade in which the observations were taken.  Can instead pass an
-        approximate `ref_time`.
+        approximate ``ref_time``.
     ref_time : `~astropy.time.Time` or None
         Reference time within 4 years of the observation time.  Used only
-        if `decade` is not given.
+        if ``decade`` is not given.
     """
     def __init__(self, fh_raw, ntrack=None, decade=None, ref_time=None):
         self.ntrack = ntrack
@@ -82,7 +82,7 @@ class Mark4FileReader(VLBIFileBase):
             Whether to search forwards or backwards.  Default: `True`.
         maximum : int, optional
             Maximum number of bytes forward to search through.
-            Default: twice the frame size (of 20000 * ntrack // 8).
+            Default: twice the frame size (``20000 * ntrack // 8``).
 
         Returns
         -------
@@ -180,9 +180,9 @@ class Mark4FileReader(VLBIFileBase):
     def determine_ntrack(self, maximum=None):
         """Determines the number of tracks, by seeking the next frame.
 
-        Uses ``find_frame`` to look for the first occurrence of a frame from
+        Uses `find_frame` to look for the first occurrence of a frame from
         the current position for all supported ``ntrack`` values.  Returns the
-        first ``ntrack`` for which ``find_frame`` is successful, setting
+        first ``ntrack`` for which `find_frame` is successful, setting
         the file's ``ntrack`` property appropriately, and leaving the
         file pointer at the start of the frame.
 
@@ -190,7 +190,7 @@ class Mark4FileReader(VLBIFileBase):
         ----------
         maximum : int, optional
             Maximum number of bytes forward to search through.
-            Default: twice the frame size (of 20000 * ntrack // 8).
+            Default: twice the frame size (``20000 * ntrack // 8``).
 
         Returns
         -------
@@ -212,9 +212,9 @@ class Mark4FileReader(VLBIFileBase):
         return None
 
     def find_header(self, forward=True, maximum=None):
-        """Read header at the frame nearest the current position.
+        """Find the nearest header from the current position.
 
-        The file pointer is left at the start of the header.
+        If successful, the file pointer is left at the start of the header.
 
         Parameters
         ----------
@@ -222,7 +222,7 @@ class Mark4FileReader(VLBIFileBase):
             Seek forward if `True` (default), backward if `False`.
         maximum : int, optional
             Maximum number of bytes forward to search through.
-            Default: twice the frame size (of 20000 * ntrack // 8).
+            Default: twice the frame size (``20000 * ntrack // 8``).
 
         Returns
         -------
@@ -242,7 +242,7 @@ class Mark4FileReader(VLBIFileBase):
 class Mark4FileWriter(VLBIFileBase):
     """Simple writer for Mark 4 files.
 
-    Adds ``write_frame`` method to the VLBI binary file wrapper.
+    Adds `write_frame` method to the VLBI binary file wrapper.
     """
 
     def write_frame(self, data, header=None, **kwargs):
@@ -258,7 +258,7 @@ class Mark4FileWriter(VLBIFileBase):
             Can instead give keyword arguments to construct a header.  Ignored
             if payload is a :class:`~baseband.mark4.Mark4Frame` instance.
         **kwargs :
-            If `header` is not given, these are used to initialize one.
+            If ``header`` is not given, these are used to initialize one.
         """
         if not isinstance(data, Mark4Frame):
             data = Mark4Frame.fromdata(data, header, **kwargs)
@@ -300,10 +300,10 @@ class Mark4StreamReader(Mark4StreamBase, VLBIStreamReaderBase):
     decade : int or None
         Decade of the observation start time (eg. ``2010`` for 2018), needed to
         remove ambiguity in the Mark 4 time stamp.  Can instead pass an
-        approximate `ref_time`.
+        approximate ``ref_time``.
     ref_time : `~astropy.time.Time` or None
         Reference time within 4 years of the start time of the observations.
-        Used only if `decade` is not given.
+        Used only if ``decade`` is not given.
     squeeze : bool, optional
         If `True` (default), remove any dimensions of length unity from
         decoded data.
@@ -358,7 +358,7 @@ class Mark4StreamReader(Mark4StreamBase, VLBIStreamReaderBase):
 
         Notes
         -----
-        Unlike `VLBIStreamReaderBase._get_frame_rate`, this function reads
+        Unlike `VLBIStreamReaderBase._get_frame_rate`, this method reads
         only two consecutive frames, extracting their timestamps to determine
         how much time has elapsed.  It will return an `EOFError` if there is
         only one frame.
@@ -409,7 +409,7 @@ class Mark4StreamWriter(Mark4StreamBase, VLBIStreamWriterBase):
         Number of complete samples per second, i.e. the rate at which each
         channel is sampled.  Needed to calculate header timestamps.
     squeeze : bool, optional
-        If `True` (default), ``write`` accepts squeezed arrays as input, and
+        If `True` (default), `write` accepts squeezed arrays as input, and
         adds any dimensions of length unity.
     **kwargs
         If no header is given, an attempt is made to construct one from these.
@@ -467,10 +467,10 @@ ntrack : int, optional
 decade : int or None
     Decade of the observation start time (eg. ``2010`` for 2018), needed to
     remove ambiguity in the Mark 4 time stamp (default: `None`).  Can instead
-    pass an approximate `ref_time`.
+    pass an approximate ``ref_time``.
 ref_time : `~astropy.time.Time` or None
     Reference time within 4 years of the start time of the observations.  Used
-    only if `decade` is not given.
+    only if ``decade`` is not given.
 squeeze : bool, optional
     If `True` (default), remove any dimensions of length unity from
     decoded data.
@@ -489,7 +489,7 @@ sample_rate : `~astropy.units.Quantity`
     Number of complete samples per second, i.e. the rate at which each channel
     is sampled.  Needed to calculate header timestamps.
 squeeze : bool, optional
-    If `True` (default), ``write`` accepts squeezed arrays as input, and adds
+    If `True` (default), writer accepts squeezed arrays as input, and adds
     any dimensions of length unity.
 **kwargs
     If the header is not given, an attempt will be made to construct one

--- a/baseband/mark4/frame.py
+++ b/baseband/mark4/frame.py
@@ -58,9 +58,9 @@ class Mark4Frame(VLBIFrameBase):
     If the frame does not contain valid data, all values returned are set
     to ``self.fill_value``.
 
-    A number of properties are defined: ``shape``, ``dtype`` and ``size`` are
+    A number of properties are defined: `shape`, `dtype` and `size` are
     the shape, type and number of complete samples of the data array, and
-    ``nbytes`` the frame size in bytes.  Furthermore, the frame acts as a
+    `nbytes` the frame size in bytes.  Furthermore, the frame acts as a
     dictionary, with keys those of the header.  Any attribute that is not
     defined on the frame itself, such as ``.time`` will be looked up on the
     header as well.
@@ -110,10 +110,10 @@ class Mark4Frame(VLBIFrameBase):
             Number of Mark 4 bitstreams.
         decade : int or None
             Decade in which the observations were taken.  Can instead pass an
-            approximate `ref_time`.
+            approximate ``ref_time``.
         ref_time : `~astropy.time.Time` or None
             Reference time within 4 years of the observation time.  Used only
-            if `decade` is not given.
+            if ``decade`` is not given.
         verify : bool, optional
             Whether to do basic verification of integrity.  Default: `True`.
         """

--- a/baseband/mark4/header.py
+++ b/baseband/mark4/header.py
@@ -96,14 +96,15 @@ class Mark4TrackHeader(VLBIHeaderBase):
     Parameters
     ----------
     words : tuple of int, or None
-        Five 32-bit unsigned int header words.  If `None`, set to a list
-        of zeros for later initialisation.
+        Five 32-bit unsigned int header words.  If `None`, set to a list of
+        zeros for later initialisation.
     decade : int or None
         Decade in which the observations were taken (needed to remove ambiguity
-        in the Mark 4 time stamp).  Can instead pass an approximate `ref_time`.
+        in the Mark 4 time stamp).  Can instead pass an approximate
+        ``ref_time``.
     ref_time : `~astropy.time.Time` or None
         Reference time within 4 years of the observation time, used to infer
-        the full Mark 4 timestamp.  Used only if `decade` is not given.
+        the full Mark 4 timestamp.  Used only if ``decade`` is not given.
     verify : bool, optional
         Whether to do basic verification of integrity.  Default: `True`.
 
@@ -213,7 +214,7 @@ class Mark4TrackHeader(VLBIHeaderBase):
 
         Calculate time using bcd-encoded 'bcd_unit_year', 'bcd_day',
         'bcd_hour', 'bcd_minute', 'bcd_second' header items, as well as
-        the ``fraction`` property (inferred from 'bcd_frac_sec') and
+        the ``fraction`` property (inferred from 'bcd_fraction') and
         ``decade`` from the initialisation.  See
         See http://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
         """
@@ -257,16 +258,17 @@ class Mark4Header(Mark4TrackHeader):
         Number of Mark 4 bitstreams, to help initialize ``words`` if needed.
     decade : int or None
         Decade in which the observations were taken (needed to remove ambiguity
-        in the Mark 4 time stamp).  Can instead pass an approximate `ref_time`.
+        in the Mark 4 time stamp).  Can instead pass an approximate
+        ``ref_time``.
     ref_time : `~astropy.time.Time` or None
         Reference time within 4 years of the observation time, used to infer
-        the full Mark 4 timestamp.  Used only if `decade` is not given.
+        the full Mark 4 timestamp.  Used only if ``decade`` is not given.
     verify : bool, optional
         Whether to do basic verification of integrity.  Default: `True`.
 
     Returns
     -------
-    header : `~baseband.mark4.Mark4Header` instance.
+    header : `~baseband.mark4.Mark4Header`
     """
 
     _track_header = Mark4TrackHeader
@@ -413,8 +415,8 @@ class Mark4Header(Mark4TrackHeader):
         Here, the parsed values must be given as keyword arguments, i.e., for
         any ``header = cls(<words>)``, ``cls.fromvalues(**header) == header``.
 
-        However, unlike for the ``fromkeys`` class method, data can also be set
-        using arguments named after header methods such as ``time``.
+        However, unlike for the `fromkeys` class method, data can also be set
+        using arguments named after header methods, such as ``time``.
 
         Parameters
         ----------
@@ -425,7 +427,7 @@ class Mark4Header(Mark4TrackHeader):
             approximate ``ref_time``.  Not needed if ``time`` is given.
         ref_time : `~astropy.time.Time` or None, optional
             Reference time within 4 years of the observation time.  Used only
-            if `decade` is not given, and not needed if ``time`` is given.
+            if ``decade`` is not given, and not needed if ``time`` is given.
         **kwargs :
             Values used to initialize header keys or methods.
 
@@ -484,7 +486,7 @@ class Mark4Header(Mark4TrackHeader):
 
     @property
     def ntrack(self):
-        """Number of tracks of the stream described by this header."""
+        """Number of Mark 4 bitstreams."""
         return self.words.shape[1]
 
     @property
@@ -494,7 +496,7 @@ class Mark4Header(Mark4TrackHeader):
 
     @property
     def frame_nbytes(self):
-        """Size of the whole frame (header + payload) in bytes."""
+        """Size of the frame in bytes."""
         return self.ntrack * PAYLOAD_NBITS // 8
 
     @property
@@ -509,7 +511,7 @@ class Mark4Header(Mark4TrackHeader):
     def fanout(self):
         """Number of samples stored in one payload item of size ntrack.
 
-        If set, will update ``fan_out`` for each track.
+        If set, will update 'fan_out' for each track.
         """
         return np.max(self['fan_out']) + 1
 
@@ -532,9 +534,9 @@ class Mark4Header(Mark4TrackHeader):
 
     @property
     def samples_per_frame(self):
-        """Number of samples per channel encoded in frame.
+        """Number of complete samples in the frame.
 
-        If set, this uses the number of tracks to infer and set ``fanout``.
+        If set, this uses the number of tracks to infer and set `fanout`.
         """
         # Header overwrites part of payload, so we need
         # frame_nbytes * 8 // bps // nchan, but use ntrack and fanout, as these
@@ -549,8 +551,8 @@ class Mark4Header(Mark4TrackHeader):
     def bps(self):
         """Bits per elementary sample (either 1 or 2).
 
-        If set, combined with ``fanout`` and ``ntrack`` to updates
-        ``magnitude_bit`` for all tracks.
+        If set, combined with `fanout` and `ntrack` to update 'magnitude_bit'
+        for all tracks.
         """
         return 2 if self['magnitude_bit'].any() else 1
 
@@ -570,9 +572,9 @@ class Mark4Header(Mark4TrackHeader):
 
     @property
     def nchan(self):
-        """Number of independent baseband channels.
+        """Number of channels (``ntrack * fanout``) in the frame.
 
-        If set, it is combined with ``ntrack`` and ``fanout`` to infer ``bps``.
+        If set, it is combined with `ntrack` and `fanout` to infer `bps`.
         """
         return self.ntrack // (self.fanout * self.bps)
 
@@ -606,7 +608,7 @@ class Mark4Header(Mark4TrackHeader):
         else:
             raise ValueError("number of sidebands can only be 1 or 2.")
 
-        # set default converters; can be overridden if needed.
+        # Set default converters; can be overridden if needed.
         nconverter = self.ntrack // (self.fanout * self.bps * self.nsb)
         converters = np.arange(nconverter)
         if nconverter > 2:
@@ -623,7 +625,7 @@ class Mark4Header(Mark4TrackHeader):
 
         Can be set with a similar structured array or a `dict`; if just an
         an array is passed in, it will be assumed that the sideband has been
-        set beforehand (e.g., by setting ``nsb``) and that the array holds
+        set beforehand (e.g., by setting `nsb`) and that the array holds
         the converter IDs.
         """
         ta_ch = self.track_assignment[0, :, 0]
@@ -634,7 +636,7 @@ class Mark4Header(Mark4TrackHeader):
 
     @converters.setter
     def converters(self, converters):
-        # set converters, duplicating over fanout, lsb, magnitude bit.
+        # Set converters, duplicating over fanout, lsb, magnitude bit.
         ta = self.track_assignment
         ta_ch = ta[0, :, 0]
         nchan = len(ta_ch)

--- a/baseband/mark4/payload.py
+++ b/baseband/mark4/payload.py
@@ -230,16 +230,17 @@ class Mark4Payload(VLBIPayloadBase):
     header : `~baseband.mark4.Mark4Header`, optional
         If given, used to infer the number of channels, bps, and fanout.
     nchan : int, optional
-        Number of channels, used if header is not given.  Default: 1.
+        Number of channels, used if ``header`` is not given.  Default: 1.
     bps : int, optional
-        Number of bits per sample, used if header is not given.  Default: 2.
+        Number of bits per sample, used if ``header`` is not given.
+        Default: 2.
     fanout : int, optional
-        Number of tracks every bit stream is spread over, used if header is
+        Number of tracks every bit stream is spread over, used if ``header`` is
         not given.  Default: 1.
 
     Notes
     -----
-    The total number of tracks is `nchan` * `bps` * `fanout`.
+    The total number of tracks is ``nchan * bps * fanout``.
     """
 
     _dtype_word = None

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -20,16 +20,16 @@ __all__ = ['Mark5BFileReader', 'Mark5BFileWriter', 'Mark5BStreamReader',
 class Mark5BFileReader(VLBIFileBase):
     """Simple reader for Mark 5B files.
 
-    Adds ``read_frame`` and ``find_header`` methods to the VLBI file wrapper.
+    Adds `read_frame` and `find_header` methods to the VLBI file wrapper.
 
     Parameters
     ----------
     kday : int or None
         Explicit thousands of MJD of the observation time.  Can instead
-        pass an approximate `ref_time`.
+        pass an approximate ``ref_time``.
     ref_time : `~astropy.time.Time` or None
         Reference time within 500 days of the observation time, used to
-        infer the full MJD.  Used only if `kday` is not given.
+        infer the full MJD.  Used only if ``kday`` is not given.
     nchan : int, optional
         Number of channels.   Default: 1.
     bps : int, optional
@@ -65,9 +65,9 @@ class Mark5BFileReader(VLBIFileBase):
                                     bps=self.bps)
 
     def find_header(self, forward=True, maximum=None):
-        """Look for the first occurrence of a frame.
+        """Find the nearest header from the current position.
 
-        Search is from the current position.
+        If successful, the file pointer is left at the start of the header.
 
         Parameters
         ----------
@@ -149,7 +149,7 @@ class Mark5BFileReader(VLBIFileBase):
 class Mark5BFileWriter(VLBIFileBase):
     """Simple writer for Mark 5B files.
 
-    Adds ``write_frame`` method to the VLBI binary file wrapper.
+    Adds `write_frame` method to the VLBI binary file wrapper.
     """
     def write_frame(self, data, header=None, bps=2, valid=True, **kwargs):
         """Write a single frame (header plus payload).
@@ -157,22 +157,22 @@ class Mark5BFileWriter(VLBIFileBase):
         Parameters
         ----------
         data : `~numpy.ndarray` or :`~baseband.mark5b.Mark5BFrame`
-            If an array, a `header` should be given, which will be used to
+            If an array, ``header`` should be given, which will be used to
             get the information needed to encode the array, and to construct
             the Mark 5B frame.
         header : `~baseband.mark5b.Mark5BHeader`
             Can instead give keyword arguments to construct a header.  Ignored
-            if `data` is a `~baseband.mark5b.Mark5BFrame` instance.
+            if ``data`` is a `~baseband.mark5b.Mark5BFrame` instance.
         bps : int, optional
             Bits per elementary sample, to use when encoding the payload.
-            Ignored if `data` is a `~baseband.mark5b.Mark5BFrame` instance.
+            Ignored if ``data`` is a `~baseband.mark5b.Mark5BFrame` instance.
             Default: 2.
         valid : bool, optional
             Whether the data are valid; if `False`, a payload filled with an
-            appropriate pattern will be crated.  Ignored if `data` is a
+            appropriate pattern will be crated.  Ignored if ``data`` is a
             `~baseband.mark5b.Mark5BFrame` instance.  Default: `True`.
         **kwargs
-            If `header` is not given, these are used to initialize one.
+            If ``header`` is not given, these are used to initialize one.
         """
         if not isinstance(data, Mark5BFrame):
             data = Mark5BFrame.fromdata(data, header, bps=bps, valid=valid,
@@ -210,10 +210,10 @@ class Mark5BStreamReader(Mark5BStreamBase, VLBIStreamReaderBase):
     kday : int or None
         Explicit thousands of MJD of the observation start time (eg. ``57000``
         for MJD 57999), used to infer the full MJD from the header's time
-        information.  Can instead pass an approximate `ref_time`.
+        information.  Can instead pass an approximate ``ref_time``.
     ref_time : `~astropy.time.Time` or None
         Reference time within 500 days of the observation start time, used
-        to infer the full MJD.  Only used if `kday` is not given.
+        to infer the full MJD.  Only used if ``kday`` is not given.
     nchan : int
         Number of channels.  Needs to be explicitly passed in.
     bps : int, optional
@@ -295,7 +295,7 @@ class Mark5BStreamWriter(Mark5BStreamBase, VLBIStreamWriterBase):
     bps : int, optional
         Bits per elementary sample.  Default: 2.
     squeeze : bool, optional
-        If `True` (default), ``write`` accepts squeezed arrays as input, and
+        If `True` (default), `write` accepts squeezed arrays as input, and
         adds any dimensions of length unity.
     **kwargs
         If no header is given, an attempt is made to construct one from these.
@@ -303,7 +303,7 @@ class Mark5BStreamWriter(Mark5BStreamBase, VLBIStreamWriterBase):
 
     --- Header kwargs : (see :meth:`~baseband.mark5b.Mark5BHeader.fromvalues`)
 
-    time : `~astropy.time.Time` instance
+    time : `~astropy.time.Time`
         Start time of the file.  Sets bcd-encoded unit day, hour, minute,
         second, and fraction, as well as the frame number, in the header.
     """
@@ -350,10 +350,10 @@ sample_rate : `~astropy.units.Quantity`, optional
 kday : int or None
     Explicit thousands of MJD of the observation start time (eg. ``57000`` for
     MJD 57999), used to infer the full MJD from the header's time information.
-    Can instead pass an approximate `ref_time`.
+    Can instead pass an approximate ``ref_time``.
 ref_time : `~astropy.time.Time` or None
     Reference time within 500 days of the observation start time, used to infer
-    the full MJD.  Only used if `kday` is not given.
+    the full MJD.  Only used if ``kday`` is not given.
 nchan : int, optional
     Number of channels.  Default: 1.
 bps : int, optional
@@ -380,7 +380,7 @@ nchan : int, optional
 bps : int, optional
     Bits per elementary sample.  Default: 2.
 squeeze : bool, optional
-    If `True` (default), ``write`` accepts squeezed arrays as input,
+    If `True` (default), writer accepts squeezed arrays as input,
     and adds channel and thread dimensions if they have length unity.
 **kwargs
     If no header is given, an attempt is made to construct one with any further

--- a/baseband/mark5b/frame.py
+++ b/baseband/mark5b/frame.py
@@ -52,9 +52,9 @@ class Mark5BFrame(VLBIFrameBase):
 
       data : property that yields full decoded payload
 
-    A number of properties are defined: ``shape``, ``dtype`` and ``size`` are
+    A number of properties are defined: `shape`, `dtype` and `size` are
     the shape, type and number of complete samples of the data array, and
-    ``nbytes`` the frame size in bytes.  Furthermore, the frame acts as a
+    `nbytes` the frame size in bytes.  Furthermore, the frame acts as a
     dictionary, with keys those of the header.  Any attribute that is not
     defined on the frame itself, such as ``.time`` will be looked up on the
     header as well.
@@ -85,10 +85,10 @@ class Mark5BFrame(VLBIFrameBase):
             To read the header and payload from.
         kday : int or None
             Explicit thousands of MJD of the observation time.  Can instead
-            pass an approximate `ref_time`.
+            pass an approximate ``ref_time``.
         ref_time : `~astropy.time.Time` or None
             Reference time within 500 days of the observation time, used to
-            infer the full MJD.  Used only if `kday` is not given.
+            infer the full MJD.  Used only if ``kday`` is not given.
         nchan : int, optional
             Number of channels.   Default: 1.
         bps : int, optional

--- a/baseband/mark5b/header.py
+++ b/baseband/mark5b/header.py
@@ -48,11 +48,11 @@ class Mark5BHeader(VLBIHeaderBase):
     kday : int or None
         Explicit thousands of MJD of the observation time (needed to remove
         ambiguity in the Mark 5B time stamp).  Can instead pass an approximate
-        `ref_time`.
+        ``ref_time``.
     ref_time : `~astropy.time.Time` or None
         Reference time within 500 days of the observation time, used to infer
         the full MJD.  Used only if ``kday`` is not given.
-    verify : bool
+    verify : bool, optional
         Whether to do basic verification of integrity.  Default: `True`.
 
     Returns
@@ -108,7 +108,7 @@ class Mark5BHeader(VLBIHeaderBase):
         any ``header = cls(<data>)``, ``cls.fromvalues(**header) == header``.
 
         However, unlike for the :meth:`Mark5BHeader.fromkeys` class method,
-        data can also be set using arguments named after methods such as
+        data can also be set using arguments named after methods, such as
         ``jday`` and ``seconds``.
 
         Given defaults:
@@ -183,7 +183,7 @@ class Mark5BHeader(VLBIHeaderBase):
 
     @property
     def payload_nbytes(self):
-        """Size of the payload, in bytes."""
+        """Size of the payload in bytes."""
         return self._payload_nbytes    # Hardcoded in class definition.
 
     @payload_nbytes.setter
@@ -194,7 +194,7 @@ class Mark5BHeader(VLBIHeaderBase):
 
     @property
     def frame_nbytes(self):
-        """Size of a frame, in bytes."""
+        """Size of the frame in bytes."""
         return self.nbytes + self.payload_nbytes
 
     @frame_nbytes.setter
@@ -249,12 +249,12 @@ class Mark5BHeader(VLBIHeaderBase):
     def get_time(self, frame_rate=None):
         """Convert year, BCD time code to Time object.
 
-        Calculate time using ``jday``, ``seconds``, and ``fraction`` properties
+        Calculate time using `jday`, `seconds`, and `fraction` properties
         (which reflect the bcd-encoded 'bcd_jday', 'bcd_seconds' and
-        'bcd_frac_sec' header items), plus `kday` from the initialisation.  See
+        'bcd_fraction' header items), plus `kday` from the initialisation.  See
         http://www.haystack.edu/tech/vlbi/mark5/docs/Mark%205B%20users%20manual.pdf
 
-        Note that some non-compliant files do not have 'bcd_frac_sec` set.
+        Note that some non-compliant files do not have 'bcd_fraction' set.
         For those, the time can still be retrieved using 'frame_nr' given a
         frame rate.
 
@@ -268,7 +268,7 @@ class Mark5BHeader(VLBIHeaderBase):
         ----------
         frame_rate : `~astropy.units.Quantity`, optional
             Used to calculate the fractional second from the frame number
-            instead of from the header's ``fraction``.
+            instead of from the header's `fraction`.
 
         Returns
         -------
@@ -289,17 +289,17 @@ class Mark5BHeader(VLBIHeaderBase):
 
     def set_time(self, time, frame_rate=None):
         """
-        Convert Time object to BCD timestamp elements and frame_nr.
+        Convert Time object to BCD timestamp elements and 'frame_nr'.
 
-        For non-integer seconds, the frame_nr will be calculated if not given
-        explicitly. Doing so requires the frame rate.
+        For non-integer seconds, the frame number will be calculated if not
+        given explicitly. Doing so requires the frame rate.
 
         Parameters
         ----------
         time : `~astropy.time.Time`
             The time to use for this header.
         frame_rate : `~astropy.units.Quantity`, optional
-            For calculating the ``frame_nr`` from the fractional seconds.
+            For calculating 'frame_nr' from the fractional seconds.
         """
         self.kday = int(time.mjd // 1000) * 1000
         self.jday = int(time.mjd - self.kday)

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -65,7 +65,7 @@ __all__ = ['VDIFFileReader', 'VDIFFileWriter', 'VDIFStreamBase',
 class VDIFFileReader(VLBIFileBase):
     """Simple reader for VDIF files.
 
-    Adds ``read_frame`` and ``read_frameset`` methods on top of a binary
+    Adds `read_frame` and `read_frameset` methods on top of a binary
     file reader (which is wrapped as ``self.fh_raw``).
     """
     def read_frame(self):
@@ -93,7 +93,7 @@ class VDIFFileReader(VLBIFileBase):
             use that of the first frame.  (Passing it in slightly improves file
             integrity checking.)
         verify : bool, optional
-            Whether to do (light) sanity checks on the header. Default: True.
+            Whether to do (light) sanity checks on the header. Default: `True`.
 
         Returns
         -------
@@ -107,11 +107,13 @@ class VDIFFileReader(VLBIFileBase):
 
     def find_header(self, template_header=None, frame_nbytes=None, edv=None,
                     maximum=None, forward=True):
-        """Look for the first occurrence of a header, from the current position.
+        """Find the nearest header from the current position.
 
         Search for a valid header at a given position which is consistent with
         ``template_header`` or with a header a frame size ahead.   Note that
         the latter turns out to be an unexpectedly weak check on real data!
+
+        If successful, the file pointer is left at the start of the header.
 
         Parameters
         ----------
@@ -210,7 +212,7 @@ class VDIFFileReader(VLBIFileBase):
 class VDIFFileWriter(VLBIFileBase):
     """Simple writer for VDIF files.
 
-    Adds ``write_frame`` and ``write_frameset`` methods to the basic VLBI
+    Adds `write_frame` and `write_frameset` methods to the basic VLBI
     binary file wrapper.
     """
 
@@ -220,21 +222,21 @@ class VDIFFileWriter(VLBIFileBase):
         Parameters
         ----------
         data : `~numpy.ndarray` or `~baseband.vdif.VDIFFrame`
-            If an array, a `header` should be given, which will be used to
+            If an array, a ``header`` should be given, which will be used to
             get the information needed to encode the array, and to construct
             the VDIF frame.
         header : `~baseband.vdif.VDIFHeader`
             Can instead give keyword arguments to construct a header.  Ignored
             if `data` is a `~baseband.vdif.VDIFFrame` instance.
         **kwargs
-            If `header` is not given, these are used to initialize one.
+            If ``header`` is not given, these are used to initialize one.
         """
         if not isinstance(data, VDIFFrame):
             data = VDIFFrame.fromdata(data, header, **kwargs)
         return data.tofile(self.fh_raw)
 
     def write_frameset(self, data, header=None, **kwargs):
-        """Write a frame set (headers plus payloads).
+        """Write a single frame set (headers plus payloads).
 
         Parameters
         ----------
@@ -249,7 +251,7 @@ class VDIFFileWriter(VLBIFileBase):
             `data`; if a single header, ``thread_ids`` corresponding
             to the number of threads are generated automatically.
         **kwargs
-            If `header` is not given, these are used to initialize one.
+            If ``header`` is not given, these are used to initialize one.
         """
         if not isinstance(data, VDIFFrameSet):
             data = VDIFFrameSet.fromdata(data, header, **kwargs)
@@ -393,7 +395,7 @@ class VDIFStreamReader(VDIFStreamBase, VLBIStreamReaderBase):
 
         Notes
         -----
-        This function defaults to using `VLBIStreamReaderBase._get_frame_rate`.
+        This method defaults to using `VLBIStreamReaderBase._get_frame_rate`.
         If that leads to an Exception, it attempts to extract the sample rate
         from the header, and passes the Exception on if this too is impossible.
         """
@@ -470,11 +472,11 @@ class VDIFStreamWriter(VDIFStreamBase, VLBIStreamWriterBase):
     sample_rate : `~astropy.units.Quantity`
         Number of complete samples per second, i.e. the rate at which each
         channel in each thread is sampled.  For EDV 1 and 3, can
-        alternatively set `sample_rate` within the header.
+        alternatively set ``sample_rate`` within the header.
     nthread : int, optional
         Number of threads (e.g., 2 for 2 polarisations).  Default: 1.
     squeeze : bool, optional
-        If `True` (default), ``write`` accepts squeezed arrays as input, and
+        If `True` (default), `write` accepts squeezed arrays as input, and
         adds any dimensions of length unity.
     **kwargs
         If no header is given, an attempt is made to construct one from these.
@@ -579,8 +581,8 @@ sample_rate : `~astropy.units.Quantity`
 nthread : int, optional
     Number of threads (e.g., 2 for 2 polarisations).  Default: 1.
 squeeze : bool, optional
-    If `True` (default), ``write`` accepts squeezed arrays as input, and adds
-    any dimensions of length unity.
+    If `True` (default), writer accepts squeezed arrays as input, and adds any
+    dimensions of length unity.
 **kwargs
     If the header is not given, an attempt will be made to construct one
     with any further keyword arguments.  See

--- a/baseband/vdif/frame.py
+++ b/baseband/vdif/frame.py
@@ -38,7 +38,7 @@ class VDIFFrame(VLBIFrameBase):
     verify : bool
         Whether or not to do basic assertions that check the integrity
         (e.g., that channel information and whether or not data are complex
-        are consistent between header and data).  Default: `True`
+        are consistent between header and data).  Default: `True`.
 
     Notes
     -----
@@ -58,9 +58,9 @@ class VDIFFrame(VLBIFrameBase):
     If the frame does not contain valid data, all values returned are set
     to ``self.fill_value``.
 
-    A number of properties are defined: ``shape``, ``dtype`` and ``size`` are
+    A number of properties are defined: `shape`, `dtype` and `size` are
     the shape, type and number of complete samples of the data array, and
-    ``nbytes`` the frame size in bytes.  Furthermore, the frame acts as a
+    `nbytes` the frame size in bytes.  Furthermore, the frame acts as a
     dictionary, with keys those of the header.  Any attribute that is not
     defined on the frame itself, such as ``.time`` will be looked up on the
     header as well.
@@ -136,7 +136,7 @@ class VDIFFrame(VLBIFrameBase):
             (e.g., that channel information and whether or not data are complex
             are consistent between header and data). Default: `True`.
         **kwargs
-            If `header` is not given, these are used to initialize one.
+            If ``header`` is not given, these are used to initialize one.
         """
         if header is None:
             header = cls._header_class.fromvalues(verify=verify, **kwargs)
@@ -171,7 +171,7 @@ class VDIFFrameSet(object):
         Should all cover the same time span.
     header0 : `~baseband.vdif.VDIFHeader`
         First header of the frame set.  If `None` (default), is extracted from
-        `frames[0]`.
+        ``frames[0]``.
 
     Notes
     -----
@@ -191,9 +191,9 @@ class VDIFFrameSet(object):
     If the frame does not contain valid data, all values returned are set
     to ``self.fill_value``.
 
-    A number of properties are defined: ``shape``, ``dtype`` and ``size`` are
+    A number of properties are defined: `shape`, `dtype` and `size` are
     the shape, type and number of complete samples of the data array, and
-    ``nbytes`` the frame size in bytes.  Like a VDIFFrame, the frame set acts
+    `nbytes` the frame size in bytes.  Like a VDIFFrame, the frame set acts
     as a dictionary, with keys those of the header of the first frame
     (available via ``.header0``).  Any attribute that is not defined on the
     frame set itself, such as ``.time`` will also be looked up on the header.
@@ -222,14 +222,14 @@ class VDIFFrameSet(object):
             (default), use that of the first frame.  (Passing it in slightly
             improves file integrity checking.)
         verify : bool, optional
-            Whether to do (light) sanity checks on the header. Default: True.
+            Whether to do (light) sanity checks on the header. Default: `True`.
 
         Returns
         -------
         frameset : `~baseband.vdif.VDIFFrameSet`
             Its ``frames`` property holds a list of frames (in order of either
             their ``thread_id`` or following the input ``thread_ids`` list).
-            Use the ``data`` attribute to convert to an array.
+            Use the `data` attribute to convert to an array.
         """
         header0 = VDIFHeader.fromfile(fh, edv, verify)
         edv = header0.edv
@@ -289,11 +289,11 @@ class VDIFFrameSet(object):
             (e.g., that channel information and whether or not data are complex
             are consistent between header and data).  Default: `True`.
         **kwargs
-            If `header` is not given, these are used to initialize one.
+            If ``header`` is not given, these are used to initialize one.
 
         Returns
         -------
-        frameset : VDIFFrameSet instance.
+        frameset : `~baseband.vdif.VDIFFrameSet`
         """
         assert data.ndim == 3
         if not isinstance(headers, (list, tuple)):
@@ -315,10 +315,12 @@ class VDIFFrameSet(object):
 
     @property
     def nbytes(self):
+        """Size of the encoded frame in bytes."""
         return len(self.frames) * self.frames[0].nbytes
 
     @property
     def sample_shape(self):
+        """Shape of a sample in the frameset (nthread, nchan)."""
         return (len(self.frames),) + self.frames[0].sample_shape
 
     def __len__(self):
@@ -345,10 +347,12 @@ class VDIFFrameSet(object):
 
     @property
     def dtype(self):
+        """Numeric type of the frameset data."""
         return self.frames[0].dtype
 
     @property
     def valid(self):
+        """Whether frameset contains valid data."""
         valid = np.array([frame.valid for frame in self.frames])
         return valid[0] if len(np.unique(valid)) == 1 else valid
 
@@ -360,6 +364,7 @@ class VDIFFrameSet(object):
 
     @property
     def fill_value(self):
+        """Value to replace invalid data in the frameset."""
         return self.frames[0].fill_value
 
     @fill_value.setter

--- a/baseband/vdif/header.py
+++ b/baseband/vdif/header.py
@@ -179,7 +179,7 @@ class VDIFHeader(VLBIHeaderBase):
         any ``header = cls(<data>)``, ``cls.fromvalues(**header) == header``.
 
         However, unlike for the :meth:`~baseband.vdif.VDIFHeader.fromkeys`
-        class method, data can also be set using arguments named after methods
+        class method, data can also be set using arguments named after methods,
         such as ``bps`` and ``time``.
 
         Given defaults for standard header keywords:
@@ -247,7 +247,7 @@ class VDIFHeader(VLBIHeaderBase):
         Note that the Mark 5B header does not encode the bits-per-sample and
         the number of channels used in the payload, so these need to be given
         separately.  A complete frame can be encapsulated with
-        VDIFFrame.from_mark5b_frame.
+        `~baseband.vdif.VDIFFrame.from_mark5b_frame`.
 
         Parameters
         ----------
@@ -288,7 +288,7 @@ class VDIFHeader(VLBIHeaderBase):
 
     @property
     def frame_nbytes(self):
-        """Size of a frame, in bytes."""
+        """Size of the frame in bytes."""
         return self['frame_length'] * 8
 
     @frame_nbytes.setter
@@ -298,7 +298,7 @@ class VDIFHeader(VLBIHeaderBase):
 
     @property
     def payload_nbytes(self):
-        """Size of the payload, in bytes."""
+        """Size of the payload in bytes."""
         return self.frame_nbytes - self.nbytes
 
     @payload_nbytes.setter
@@ -366,7 +366,7 @@ class VDIFHeader(VLBIHeaderBase):
 
         Uses 'ref_epoch', which stores the number of half-years from 2000,
         and 'seconds'.  By default, it also calculates the offset using
-        the current frame number.  For non-zero frame_nr, this requires the
+        the current frame number.  For non-zero 'frame_nr', this requires the
         frame rate, which is calculated from the sample rate in the header.
         The latter can be passed on if it is not available (e.g., for a legacy
         VDIF header).
@@ -374,7 +374,7 @@ class VDIFHeader(VLBIHeaderBase):
         Parameters
         ----------
         sample_rate : `~astropy.units.Quantity`, optional
-            For non-zero `frame_nr`, this is used to calculate the
+            For non-zero 'frame_nr', this is used to calculate the
             corresponding offset.  If not given, an attempt will be made to
             calculate it from the sampling rate given in the header (but not
             all EDV contain this).
@@ -403,7 +403,7 @@ class VDIFHeader(VLBIHeaderBase):
         """
         Converts Time object to ref_epoch, seconds, and frame_nr.
 
-        For non-integer seconds, the frame_nr will be calculated if not given
+        For non-integer seconds, 'frame_nr' will be calculated if not given
         explicitly. This requires the frame rate, which is calculated from the
         sample rate in the header.  The latter can be passed on if it is not
         available (e.g., for a legacy VDIF header).
@@ -413,9 +413,9 @@ class VDIFHeader(VLBIHeaderBase):
         time : `~astropy.time.Time`
             The time to use for this header.
         sample_rate : `~astropy.units.Quantity`, optional
-            For calculating the ``frame_nr`` from the fractional seconds.
-            If not given, will try to calculate it from the sampling rate
-            given in the header (but not all EDV contain this).
+            For calculating 'frame_nr' from the fractional seconds.  If not
+            given, will try to calculate it from the sampling rate given in the
+            header (but not all EDV contain this).
         """
         assert time > ref_epochs[0]
         ref_index = np.searchsorted((ref_epochs - time).sec, 0) - 1
@@ -597,7 +597,7 @@ class VDIFHeader2(VDIFBaseHeader):
     Notes
     -----
     This header is untested.  It may need to have subclasses, based on possible
-    differentsync values.
+    different sync values.
     """
     _edv = 2
     _header_parser = VDIFBaseHeader._header_parser + HeaderParser(
@@ -634,7 +634,7 @@ class VDIFMark5BHeader(VDIFBaseHeader, Mark5BHeader):
         super(VDIFMark5BHeader, self).verify()
         assert self['frame_length'] == 1254  # payload+header=10000+32 bytes/8
         assert self['frame_nr'] == self['mark5b_frame_nr']
-        # check consistency of time down to the second (since some Mark 5B
+        # Check consistency of time down to the second (since some Mark 5B
         # headers do not store 'bcd_fraction').
         day, seconds = divmod(self['seconds'], 86400)
         assert seconds == self.seconds  # Latter decodes 'bcd_seconds'
@@ -667,7 +667,7 @@ class VDIFMark5BHeader(VDIFBaseHeader, Mark5BHeader):
         Parameters
         ----------
         sample_rate : `~astropy.units.Quantity`, optional
-            For non-zero `frame_nr`, this is used to calculate the
+            For non-zero 'frame_nr', this is used to calculate the
             corresponding offset.
 
         Returns

--- a/baseband/vdif/payload.py
+++ b/baseband/vdif/payload.py
@@ -115,11 +115,12 @@ class VDIFPayload(VLBIPayloadBase):
         If given, used to infer the number of channels, bps, and whether
         the data are complex.
     nchan : int, optional
-        Number of channels, used if header is not given.  Default: 1.
+        Number of channels, used if ``header`` is not given.  Default: 1.
     bps : int, optional
-        Bits per elementary sample, used if header is not given.  Default: 2.
+        Bits per elementary sample, used if ``header`` is not given.
+        Default: 2.
     complex_data : bool, optional
-        Whether the data are complex, used if header is not given.
+        Whether the data are complex, used if ``header`` is not given.
         Default: `False`.
     """
     _decoders = {2: decode_2bit,
@@ -176,10 +177,11 @@ class VDIFPayload(VLBIPayloadBase):
             If given, used to infer the encoding, and to verify the number of
             channels and whether the data are complex.
         bps : int, optional
-            Bits per elementary sample, used if header is `None`.  Default: 2.
+            Bits per elementary sample, used if ``header`` is `None`.
+            Default: 2.
         edv : int, optional
-            Should be given if the header is `None` and the payload is encoded
-            as Mark 5 data (i.e., edv=0xab).
+            Should be given if ``header`` is `None` and the payload is encoded
+            as Mark 5 data (i.e., ``edv=0xab``).
         """
         nchan = data.shape[-1]
         complex_data = (data.dtype.kind == 'c')

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -88,10 +88,11 @@ class VLBIStreamBase(object):
 
     @property
     def subset(self):
-        """Specific components (e.g. threads, channels) of the sample to read.
+        """Specific components (e.g. threads, channels) of the complete sample
+        to decode.
 
-        The order of dimensions is the same as for `sample_shape`.  Set by the
-        class initializer.
+        The order of dimensions is the same as for `sample_shape`.  Set by
+        the class initializer.
         """
         return self._subset
 
@@ -350,7 +351,7 @@ class VLBIStreamReaderBase(VLBIStreamBase):
         current position, to find the next frame whose frame number is zero
         while keeping track of the largest frame number yet found.
 
-        ``_get_frame_rate`` is called when the sample rate is not user-provided
+        This method is called when the sample rate is not user-provided
         or deducible from header information.  If less than one second of data
         exists in the file, the function will raise an EOFError.  It also
         returns an error if any header cannot be read or does not verify as
@@ -415,12 +416,12 @@ class VLBIStreamReaderBase(VLBIStreamBase):
         offset : int, `~astropy.units.Quantity`, or `~astropy.time.Time`
             Offset to move to.  Can be an (integer) number of samples,
             an offset in time units, or an absolute time.
-        whence : int
+        whence : {0, 1, 2, 'start', 'current', or 'end'}, optional
             Like regular seek, the offset is taken to be from the start if
-            ``whence=0`` (default), from the current position if ``1``,
-            and from the end if ``2``.  One can use ``'start'``, ``'current'``,
-            or ``'end'`` for ``0``, ``1``, or ``2``, respectively.  Ignored if
-            ``offset`` is a time.`
+            ``whence=0`` (default), from the current position if 1,
+            and from the end if 2.  One can alternativey use 'start',
+            'current', or 'end' for 0, 1, or 2, respectively.  Ignored if
+            ``offset`` is a time.
         """
         try:
             offset = offset.__index__()
@@ -463,13 +464,13 @@ class VLBIStreamReaderBase(VLBIStreamBase):
         out : None or array, optional
             Array to store the data in. If given, ``count`` will be inferred
             from the first dimension; the other dimension should equal
-            ``sample_shape``.
+            `sample_shape`.
 
         Returns
         -------
         out : `~numpy.ndarray` of float or complex
             The first dimension is sample-time, and the remainder given by
-            ``sample_shape``.
+            `sample_shape`.
         """
         if out is None:
             if count is None or count < 0:
@@ -534,7 +535,7 @@ class VLBIStreamWriterBase(VLBIStreamBase):
         ----------
         data : `~numpy.ndarray`
             Piece of data to be written, with sample dimensions as given by
-            ``sample_shape``. This should be properly scaled to make best use
+            `sample_shape`. This should be properly scaled to make best use
             of the dynamic range delivered by the encoding.
         valid : bool, optional
             Whether the current data are valid.  Default: `True`.
@@ -604,7 +605,7 @@ name : str or filehandle
     File name or handle.
 mode : {'rb', 'wb', 'rs', or 'ws'}, optional
     Whether to open for reading or writing, and as a regular binary
-    file or as a stream. Default: ``rs``, for reading a stream.
+    file or as a stream. Default: 'rs', for reading a stream.
 **kwargs
     Additional arguments when opening the file as a stream.
 """

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -88,8 +88,7 @@ class VLBIStreamBase(object):
 
     @property
     def subset(self):
-        """Specific components (e.g. threads, channels) of the complete sample
-        to decode.
+        """Specific components of the complete sample to decode.
 
         The order of dimensions is the same as for `sample_shape`.  Set by
         the class initializer.

--- a/baseband/vlbi_base/frame.py
+++ b/baseband/vlbi_base/frame.py
@@ -48,8 +48,8 @@ class VLBIFrameBase(object):
     If the frame does not contain valid data, all values returned are set
     to ``self.fill_value``.
 
-    A number of properties are defined: ``shape`` and ``dtype`` are the shape
-    and type of the data array, and ``nbytes`` the frame size in bytes.
+    A number of properties are defined: `shape` and `dtype` are the shape
+    and type of the data array, and `nbytes` the frame size in bytes.
     Furthermore, the frame acts as a dictionary, with keys those of the header.
     Any attribute that is not defined on the frame itself, such as ``.time``
     will be looked up on the header as well.
@@ -57,8 +57,7 @@ class VLBIFrameBase(object):
 
     _header_class = None
     _payload_class = None
-    fill_value = 0.
-    """Value used to replace data if the frame does not contain valid data."""
+    _fill_value = 0.
 
     def __init__(self, header, payload, valid=True, verify=True):
         self.header = header
@@ -126,7 +125,7 @@ class VLBIFrameBase(object):
 
     @property
     def sample_shape(self):
-        """Shape of the samples held in the frame (nchan,)."""
+        """Shape of a sample in the frame (nchan,)."""
         return self.payload.sample_shape
 
     def __len__(self):
@@ -153,13 +152,22 @@ class VLBIFrameBase(object):
 
     @property
     def dtype(self):
-        """Numeric type of the payload."""
+        """Numeric type of the frame data."""
         return self.payload.dtype
 
     @property
     def nbytes(self):
         """Size of the encoded frame in bytes."""
         return self.header.nbytes + self.payload.nbytes
+
+    @property
+    def fill_value(self):
+        """Value to replace invalid data in the frame."""
+        return self._fill_value
+
+    @fill_value.setter
+    def fill_value(self, fill_value):
+        self._fill_value = fill_value
 
     def __array__(self, dtype=None):
         """Interface to arrays."""

--- a/baseband/vlbi_base/header.py
+++ b/baseband/vlbi_base/header.py
@@ -295,7 +295,7 @@ class VLBIHeaderBase(object):
         assert len(self.words) == (self._struct.size // 4)
 
     def copy(self, **kwargs):
-        """Return a mutable copy of the header.
+        """Create a mutable and independent copy of the header.
 
         Keyword arguments can be passed on as needed by possible subclasses.
         """
@@ -363,8 +363,8 @@ class VLBIHeaderBase(object):
         Here, the parsed values must be given as keyword arguments, i.e., for
         any ``header = cls(<words>)``, ``cls.fromvalues(**header) == header``.
 
-        However, unlike for the ``fromkeys`` class method, data can also be set
-        using arguments named after header methods such as ``time``.
+        However, unlike for the `fromkeys` class method, data can also be set
+        using arguments named after header methods, such as ``time``.
 
         Parameters
         ----------

--- a/baseband/vlbi_base/payload.py
+++ b/baseband/vlbi_base/payload.py
@@ -34,7 +34,7 @@ class VLBIPayloadBase(object):
         Bits per elementary sample, i.e., per channel and per real or
         imaginary component.  Default: 2.
     complex_data : bool
-        Whether the data are complex.  Default: False.
+        Whether the data are complex.  Default: `False`.
     """
     # Possible fixed payload size in bytes.
     _nbytes = None
@@ -126,7 +126,7 @@ class VLBIPayloadBase(object):
 
     @property
     def nbytes(self):
-        """Size in bytes of payload."""
+        """Size of the payload in bytes."""
         return self.words.size * self.words.dtype.itemsize
 
     def __len__(self):
@@ -153,7 +153,7 @@ class VLBIPayloadBase(object):
 
     @property
     def dtype(self):
-        """Type of the decoded data array."""
+        """Numeric type of the decoded data array."""
         return np.dtype(np.complex64 if self.complex_data else np.float32)
 
     def _item_to_slices(self, item):

--- a/baseband/vlbi_base/utils.py
+++ b/baseband/vlbi_base/utils.py
@@ -58,7 +58,7 @@ class CRC(object):
     See https://en.wikipedia.org/wiki/Cyclic_redundancy_check
 
     Once initialised, the instance can be used as a function that calculates
-    the CRC, or one can use the `.check` method to check that the CRC at the
+    the CRC, or one can use the `check` method to check that the CRC at the
     end of a stream is correct.
 
     Parameters

--- a/docs/mark5b/index.rst
+++ b/docs/mark5b/index.rst
@@ -42,7 +42,7 @@ Usage
 This section covers reading and writing Mark 5B files with Baseband; general
 usage can be found under the :ref:`Getting Started <getting_started>` section.
 The examples below use the small sample file ``baseband/data/sample.m5b``, and
-the `numpy`, `astropy.units`, `astropy.time.Time`, and `baseband.mark5`
+the `numpy`, `astropy.units`, `astropy.time.Time`, and `baseband.mark5b`
 modules::
 
     >>> import numpy as np


### PR DESCRIPTION
Unified docstrings of common properties across all formats with each other and with their corresponding stream classes (eg. `nchan`, `payload_nbytes`).  Added single, double backquotes to objects, and modified existing backquotes, to enable linking to related methods or for proper typesetting.

The only code modification is the promotion of `frame.fill_value` to property status.  This is done to give it a docstring in ReadtheDocs, and to make it consistent with `VDIFFrameset.fill_value`.

Certainly this doesn't mean the documentation is clear of irregularities, but trying to root them all out is a quixotic process.

(Apologies for making you read through a whole bunch of docstring syntax and punctuation edits!)