### PR TITLE
Move get_frame_rate to the readers.

### DIFF
--- a/baseband/dada/tests/test_dada.py
+++ b/baseband/dada/tests/test_dada.py
@@ -166,6 +166,16 @@ class TestDADA(object):
         assert not isinstance(payload.words, np.memmap)
         assert payload == payload4
 
+    def test_file_reader(self):
+        with dada.open(SAMPLE_FILE, 'rb') as fh:
+            header = fh.read_header()
+            assert header == self.header
+            current_pos = fh.tell()
+            frame_rate = fh.get_frame_rate()
+            assert frame_rate == header.sample_rate / header.samples_per_frame
+            assert fh.tell() == current_pos
+            # Frame is done below, as is writing in binary.
+
     def test_frame(self, tmpdir):
         with dada.open(SAMPLE_FILE, 'rb') as fh:
             frame = fh.read_frame(memmap=False)

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -308,8 +308,19 @@ class TestMark4(object):
         assert np.all(payload2[item] == sel_data)
         assert payload2 == payload
 
-    def test_binary_file_repr(self):
+    def test_binary_file_reader(self):
         with mark4.open(SAMPLE_FILE, 'rb', decade=2010, ntrack=64) as fh:
+            fh.locate_frame()
+            assert fh.tell() == 0xa88
+            header = mark4.Mark4Header.fromfile(fh, decade=2010, ntrack=64)
+            fh.seek(0xa88)
+            header2 = fh.read_header()
+            current_pos = fh.tell()
+            assert header2 == header
+            frame_rate = fh.get_frame_rate()
+            assert abs(frame_rate -
+                       32 * u.MHz / header.samples_per_frame) < 1 * u.nHz
+            assert fh.tell() == current_pos
             repr_fh = repr(fh)
 
         assert repr_fh.startswith('Mark4FileReader')

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -356,6 +356,19 @@ class TestVDIF(object):
         assert np.all(payload2[item] == sel_data)
         assert payload2 == payload
 
+    def test_filereader(self):
+        with vdif.open(SAMPLE_FILE, 'rb') as fh:
+            header = vdif.VDIFHeader.fromfile(fh)
+            fh.seek(0)
+            header2 = fh.read_header()
+            assert header2 == header
+            current_pos = fh.tell()
+            frame_rate = fh.get_frame_rate()
+            assert abs(frame_rate - 32. * u.MHz /
+                       header.samples_per_frame) < 1. * u.nHz
+            assert fh.tell() == current_pos
+            # The read_frame method is tested below, as is mode='wb'.
+
     def test_frame(self, tmpdir):
         with vdif.open(SAMPLE_FILE, 'rb') as fh:
             header = vdif.VDIFHeader.fromfile(fh)


### PR DESCRIPTION
This seems more logical, since it doesn't need information from the stream readers, and is needed to make file_info work more sensibly.

I think it would be good to still have this in 1.0 (but `file_info` probably not).