### PR TITLE
Extend shape/size/ndim standard to stream readers.

### DIFF
--- a/baseband/dada/tests/test_dada.py
+++ b/baseband/dada/tests/test_dada.py
@@ -277,7 +277,10 @@ class TestDADA(object):
         start_time = self.header.time
         with dada.open(SAMPLE_FILE, 'rs') as fh:
             assert fh.header0 == self.header
-            assert fh.size == 16000
+            assert fh.sample_shape == (2,)
+            assert fh.shape == (16000,) + fh.sample_shape
+            assert fh.size == np.prod(fh.shape)
+            assert fh.ndim == len(fh.shape)
             assert fh.start_time == start_time
             assert fh.sample_rate == 16 * u.MHz
             record1 = fh.read(12)

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -607,7 +607,10 @@ class TestMark4(object):
                         ntrack=64, decade=2010) as fh:
             assert header == fh.header0
             assert fh.samples_per_frame == 80000
-            assert fh.size == 2 * fh.samples_per_frame
+            assert fh.sample_shape == (8,)
+            assert fh.shape == (2 * fh.samples_per_frame,) + fh.sample_shape
+            assert fh.size == np.prod(fh.shape)
+            assert fh.ndim == len(fh.shape)
             assert fh.sample_rate == 32 * u.MHz
             record = fh.read(642)
             assert fh.tell() == 642

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -393,7 +393,10 @@ class TestMark5B(object):
             assert fh.samples_per_frame == 5000
             assert fh.sample_rate == 32 * u.MHz
             last_header = fh._last_header
-            assert fh.size == 20000
+            assert fh.sample_shape == (8,)
+            assert fh.shape == (20000,) + fh.sample_shape
+            assert fh.size == np.prod(fh.shape)
+            assert fh.ndim == len(fh.shape)
             record = fh.read(12)
             assert fh.tell() == 12
             fh.seek(10000)
@@ -406,7 +409,7 @@ class TestMark5B(object):
             fh.seek(fh.start_time + 1000 / (32 * u.MHz))
             assert fh.tell() == 1000
             fh.seek(-10, 2)
-            assert fh.tell() == fh.size - 10
+            assert fh.tell() == fh.shape[0] - 10
             record3 = fh.read()
             # Test seeker works with both int and str values for whence.
             assert fh.seek(13, 0) == fh.seek(13, 'start')

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -688,11 +688,14 @@ class TestVDIF(object):
             assert fhseek_int == fhseek_str
             with pytest.raises(ValueError):
                 fh.seek(0, 'last')
-            assert fh.size == 40000
+            assert fh.sample_shape == (8,)
+            assert fh.shape == (40000,) + fh.sample_shape
+            assert fh.size == np.prod(fh.shape)
+            assert fh.ndim == len(fh.shape)
             assert abs(fh.stop_time - fh._last_header.time - (
                 fh.samples_per_frame / fh.sample_rate)) < 1. * u.ns
             assert abs(fh.stop_time - fh.start_time -
-                       (fh.size / fh.sample_rate)) < 1. * u.ns
+                       (fh.shape[0] / fh.sample_rate)) < 1. * u.ns
             fh.seek(1, 'end')
             with pytest.raises(EOFError):
                 fh.read()
@@ -934,11 +937,11 @@ def test_vlbi_vdif():
         assert fh.sample_rate == 32*u.MHz
         assert fh.start_time == fh.header0.time
         assert fh.start_time == fhc.start_time
-        assert fh.size == 40000
+        assert fh.shape == (40000,) + fh.sample_shape
         assert abs(fh.stop_time - fh._last_header.time - (
             fh.samples_per_frame / fh.sample_rate)) < 1. * u.ns
         assert abs(fh.stop_time - fh.start_time -
-                   (fh.size / fh.sample_rate)) < 1. * u.ns
+                   (fh.shape[0] / fh.sample_rate)) < 1. * u.ns
         assert np.all(fh.read() == fhc.read())
 
 
@@ -979,13 +982,13 @@ def test_arochime_vdif():
         assert abs(t0 - Time('2016-04-22T08:45:31.788759040')) < 1. * u.ns
         assert abs(t0 - fh.start_time) < 1. * u.ns
         assert fh.header0.edv == 0
-        assert fh.size == 5
+        assert fh.shape == (5,) + fh.sample_shape
         d = fh.read()
         assert d.shape == (5, 2, 1024)
         assert d.dtype.kind == 'c'
         t1 = fh.time
         assert abs(t1 - fh.stop_time) < 1. * u.ns
-        assert abs(t1 - t0 - fh.size / fh.sample_rate) < 1. * u.ns
+        assert abs(t1 - t0 - fh.shape[0] / fh.sample_rate) < 1. * u.ns
 
     # For this file, we cannot find a frame rate, so opening it without
     # should fail.

--- a/docs/helpers/index.rst
+++ b/docs/helpers/index.rst
@@ -80,7 +80,7 @@ We can also open the second file on its own and confirm it contains the second
 frameset of the sample file::
 
     >>> fsf = vdif.open(filenames[1], mode='rs', sample_rate=fh.sample_rate)
-    >>> fh.seek(fh.size // 2)    # Seek to start of second frameset.
+    >>> fh.seek(fh.shape[0] // 2)    # Seek to start of second frameset.
     20000
     >>> fsf.header0.time == fh.time
     True


### PR DESCRIPTION
Stream readers now have shape, size and ndim properties that work the same way as their frame and payload counterparts, except that these values may change due to squeezing and subseting (and so are not directly taken from `frame.shape`, etc.).