### PR TITLE
Minor DADA bugfixes.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,8 +20,13 @@ Other Changes and Additions
 Bug Fixes
 ---------
 
+- Fixed a bug in `~baseband.dada.open` where passing a `squeeze` setting is
+  ignored when also passing header keywords in 'ws' mode. [#211]
+
 Other Changes and Additions
 ---------------------------
+
+- Fixed broken links and typos in the documentation. [#211]
 
 
 1.0.0 (2018-04-09)

--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -367,6 +367,7 @@ Filehandle
 # TODO: move this up to the opener??
 def open(name, mode='rs', **kwargs):
     header0 = kwargs.get('header0', None)
+    squeeze = kwargs.pop('squeeze', None)
     # If sequentialfile object, check that it's opened properly.
     if isinstance(name, sf.SequentialFileBase):
         assert (('r' in mode and name.mode == 'rb') or
@@ -411,6 +412,9 @@ def open(name, mode='rs', **kwargs):
 
         if header0 and 'w' in mode:
             kwargs['header0'] = header0
+
+    if squeeze is not None:
+        kwargs['squeeze'] = squeeze
 
     return opener(name, mode, **kwargs)
 

--- a/baseband/dada/frame.py
+++ b/baseband/dada/frame.py
@@ -72,7 +72,7 @@ class DADAFrame(VLBIFrameBase):
         verify : bool, optional
             Whether to do basic verification of integrity.  Default: `True`.
         """
-        header = cls._header_class.fromfile(fh, verify)
+        header = cls._header_class.fromfile(fh, verify=verify)
         payload = cls._payload_class.fromfile(fh, header=header, memmap=memmap)
         return cls(header, payload, valid=valid, verify=verify)
 
@@ -82,7 +82,7 @@ class DADAFrame(VLBIFrameBase):
 
         Note that since DADA files are generally very large, one would normally
         map the file, and then set pieces of it by assigning to slices of the
-        frame.  See `~baseband.base.DADAFileWriter.memmap_frame`.
+        frame.  See `~baseband.dada.base.DADAFileWriter.memmap_frame`.
 
         Parameters
         ----------
@@ -93,7 +93,7 @@ class DADAFrame(VLBIFrameBase):
         valid : bool, optional
             Whether the data are valid (default: `True`). Note that this
             information cannot be written to disk.
-        verify : bool
+        verify : bool, optional
             Whether or not to do basic assertions that check the integrity.
             Default: `True`.
         **kwargs

--- a/baseband/dada/header.py
+++ b/baseband/dada/header.py
@@ -256,10 +256,10 @@ class DADAHeader(OrderedDict):
             Arguments used to set keywords and properties.
         """
         verify = kwargs.pop('verify', True)
-        # remove kwargs that set properties, in correct order.
+        # Remove kwargs that set properties, in correct order.
         extras = [(key, kwargs.pop(key)) for key in self._properties
                   if key in kwargs]
-        # update the normal keywords.
+        # Update the normal keywords.
         super(DADAHeader, self).update(**kwargs)
         # Now set the properties.
         for attr, value in extras:
@@ -311,6 +311,7 @@ class DADAHeader(OrderedDict):
 
     @property
     def complex_data(self):
+        """Whether the data are complex."""
         return self['NDIM'] == 2
 
     @complex_data.setter

--- a/baseband/dada/tests/test_dada.py
+++ b/baseband/dada/tests/test_dada.py
@@ -417,6 +417,25 @@ class TestDADA(object):
             assert np.all(fhs.read() == self.payload)
             assert np.all(fhns.read() == self.payload)
 
+        # Test passing squeeze=False along with header keywords (otherwise
+        # identical to test above).
+        h = self.header
+
+        with dada.open(filename, 'ws', time=h.time,
+                       payload_nbytes=h.payload_nbytes,
+                       sample_rate=h.sample_rate, complex_data=h.complex_data,
+                       sample_shape=h.sample_shape, bps=h.bps,
+                       squeeze=False) as fw:
+            assert fw.sample_shape == (2, 1)
+            assert fw.sample_shape.npol == 2
+            assert fw.sample_shape.nchan == 1
+            fw.write(self.payload.data)
+
+        with dada.open(dada_test_squeeze, 'rs', squeeze=False) as fhs, \
+                dada.open(dada_test_nosqueeze, 'rs', squeeze=False) as fhns:
+            assert np.all(fhs.read() == self.payload)
+            assert np.all(fhns.read() == self.payload)
+
     # Test that writing an incomplete stream is possible, and that frame set is
     # valid but invalid samples are appropriately marked.
     def test_incomplete_stream(self, tmpdir):


### PR DESCRIPTION
Fixed passing squeeze to DADA opener; minor docs fixes.  Found these while making GUPPI.

Happy to propagate these to 1.0.1 as well if approved (though they're small enough that maybe it doesn't matter).