### PR TITLE
Ensure mark5b header fractional times are checked.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,9 @@ Bug Fixes
 - Fixed a bug in `~baseband.dada.open` where passing a `squeeze` setting is
   ignored when also passing header keywords in 'ws' mode. [#211]
 
+- Raise an exception rather than return incorrect times for Mark 5B files
+  in which the fractional seconds are not set. [#216]
+
 Other Changes and Additions
 ---------------------------
 

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -366,13 +366,13 @@ class TestMark5B(object):
                             frame.header['frame_nr'] * frame_duration)
                 assert abs(header_time - expected) < 1. * u.ns
 
-        # On the last frame, also check one can recover the time if 'frac_sec'
-        # is not set.
+        # Some files have headers in which the fraction is not set.
+        # Check that those raise an error, but that one can get the right
+        # time still by passing a frame rate.
         header = frame.header.copy()
         header['bcd_fraction'] = 0
-        # So, now recover first header time, which started on the second.
-        assert header.time == header0.time
-        # But if we pass in the correct frame rate, it uses the frame_nr.
+        with pytest.raises(ValueError):
+            header.time
         assert abs(header.get_time(frame_rate) - frame.header.time) < 1. * u.ns
 
         # Check setting time using frame rate.

--- a/baseband/tests/test_conversion.py
+++ b/baseband/tests/test_conversion.py
@@ -69,7 +69,10 @@ class TestVDIFMark5B(object):
         header_copy['bcd_fraction'] = 0
         # This is common enough that we should not fail verification.
         header_copy.verify()
-        assert abs(header_copy.time - m5h2.time) > 1.*u.ns
+        # However, it should also cause just getting the time to fail
+        # unless we pass in a frame rate.
+        with pytest.raises(ValueError):
+            header_copy.time
         assert abs(header_copy.get_time(sample_rate=32*u.MHz) -
                    m5h2.time) < 1.*u.ns
 

--- a/baseband/vdif/header.py
+++ b/baseband/vdif/header.py
@@ -674,20 +674,20 @@ class VDIFMark5BHeader(VDIFBaseHeader, Mark5BHeader):
         -------
         time : `~astropy.time.Time`
         """
-        if sample_rate is None:
-            # Get fractional second from the Mark 5B part of the header.
+        frame_nr = self['frame_nr']
+        if frame_nr == 0:
+            fraction = 0.
+        elif sample_rate is None:
+            # Get fractional second from the Mark 5B part of the header,
+            # but check it is non-zero (it doesn't always seem to be set).
             fraction = self.fraction
+            if fraction == 0.:
+                raise ValueError('header does not provide correct fractional '
+                                 'second (it is zero for non-zero frame '
+                                 'number). Please pass in a frame_rate.')
         else:
-            frame_nr = self['frame_nr']
-            if frame_nr == 0:
-                fraction = 0.
-            else:
-                if sample_rate is None:
-                    raise ValueError("calculating the time for a non-zero "
-                                     "frame number requires a sample rate. "
-                                     "Pass it in explicitly.")
-                fraction = (frame_nr * self.samples_per_frame /
-                            sample_rate).to_value(u.s)
+            fraction = (frame_nr * self.samples_per_frame /
+                        sample_rate).to_value(u.s)
 
         return (ref_epochs[self['ref_epoch']] +
                 TimeDelta(self['seconds'], fraction,


### PR DESCRIPTION
If they are zero while the frame number is zero, we know something is wrong, so we should not just ignore it.