### PR TITLE
Changed __index__ to operator.index

### DIFF
--- a/baseband/mark4/frame.py
+++ b/baseband/mark4/frame.py
@@ -12,6 +12,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import numpy as np
+import operator
 from astropy.extern import six
 
 from ..vlbi_base.frame import VLBIFrameBase
@@ -218,7 +219,7 @@ class Mark4Frame(VLBIFrameBase):
         else:
             # Not a slice. Maybe an index?
             try:
-                item = item.__index__()
+                item = operator.index(item)
             except Exception:
                 raise TypeError("{0} object can only be indexed or sliced."
                                 .format(type(self)))

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -4,6 +4,7 @@ from __future__ import division, unicode_literals, print_function
 import io
 import warnings
 import numpy as np
+import operator
 from collections import namedtuple
 import astropy.units as u
 from astropy.utils import lazyproperty
@@ -222,7 +223,7 @@ class VLBIStreamBase(object):
     @samples_per_frame.setter
     def samples_per_frame(self, samples_per_frame):
         try:
-            self._samples_per_frame = samples_per_frame.__index__()
+            self._samples_per_frame = operator.index(samples_per_frame)
         except Exception:
             raise TypeError("samples per frame must have an integer value.")
 
@@ -461,7 +462,7 @@ class VLBIStreamReaderBase(VLBIStreamBase):
             ``offset`` is a time.
         """
         try:
-            offset = offset.__index__()
+            offset = operator.index(offset)
         except Exception:
             try:
                 offset = offset - self.start_time

--- a/baseband/vlbi_base/payload.py
+++ b/baseband/vlbi_base/payload.py
@@ -200,7 +200,7 @@ class VLBIPayloadBase(object):
                 step = None
         else:
             try:
-                item = item.__index__()
+                item = operator.index(item)
             except Exception:
                 raise TypeError("{0} object can only be indexed or sliced."
                                 .format(type(self)))


### PR DESCRIPTION
Here is a simple change from  __index__ to operator.index for mark4/frame.py, vlbi_base/base.py, and vlbi_base/payload.py . This was to fix issue #220," so one reliably gets a TypeError (instead of possibly an AttributeError)."