### PR TITLE
DADA stream reader no longer reads entire last frame for its header.

### DIFF
--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -260,8 +260,7 @@ class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase):
     def _last_header(self):
         """Header of the last file for this stream."""
         self.fh_raw.seek(-self.header0.frame_nbytes, 2)
-        last_frame = self.fh_raw.read_frame(memmap=True)
-        return last_frame.header
+        return self.fh_raw.read_header()
 
     def _read_frame(self, index):
         self.fh_raw.seek(index * self.header0.frame_nbytes)

--- a/baseband/dada/tests/test_dada.py
+++ b/baseband/dada/tests/test_dada.py
@@ -437,7 +437,7 @@ class TestDADA(object):
             assert np.all(fhns.read() == self.payload)
 
     # Test that writing an incomplete stream is possible, and that frame set is
-    # valid but invalid samples are appropriately marked.
+    # valid but invalid samples use the fill value.
     def test_incomplete_stream(self, tmpdir):
         filename = str(tmpdir.join('a.dada'))
         with catch_warnings(UserWarning) as w:


### PR DESCRIPTION
Mini-change addressing comment in #212 that also applies to DADA.

Also changed the wording of a comment in the tests to be consistent with #212.