### PR TITLE
Modifications to DADA stream reader to read partial last frame.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ New Features
 
 - Added support for the GUPPI format. [#212]
 
+- Enabled `baseband.dada.open` to read streams where the last frame has an
+  incomplete payload. [#228]
+
 API Changes
 -----------
 

--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -13,6 +13,7 @@ from ..helpers import sequentialfile as sf
 from ..vlbi_base.base import (make_opener, VLBIFileBase, VLBIFileReaderBase,
                               VLBIStreamBase,
                               VLBIStreamReaderBase, VLBIStreamWriterBase)
+from ..vlbi_base.utils import lcm
 from .header import DADAHeader
 from .payload import DADAPayload
 from .frame import DADAFrame
@@ -259,14 +260,23 @@ class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase):
                                                squeeze=squeeze, subset=subset)
         # Store number of frames, for finding last header.
         raw_offset = self.fh_raw.tell()
-        self._nframes, self._pframe_nbytes = divmod(self.fh_raw.seek(0, 2),
-                                                    self.header0.frame_nbytes)
-        if self._pframe_nbytes > 0:
-            self._nframes += 1
-            # If there's only one frame and it's incomplete.
-            if self._nframes == 1:
-                self._header0 = self._last_header
-                self.samples_per_frame = self.header0.samples_per_frame
+        self._nframes, self._partial_frame_nbytes = divmod(
+            self.fh_raw.seek(0, 2), self.header0.frame_nbytes)
+        # If there is a partial last frame.
+        if self._partial_frame_nbytes > 0:
+            # If partial last frame contains payload bytes.
+            if self._partial_frame_nbytes > self.header0.nbytes:
+                self._nframes += 1
+                # If there's only one frame and it's incomplete.
+                if self._nframes == 1:
+                    self._header0 = self._last_header
+                    self.samples_per_frame = self.header0.samples_per_frame
+            # Otherwise, ignore the partial frame unless it's the only frame,
+            # in which case raise an EOFError.
+            elif self._nframes == 0:
+                raise EOFError('file (of {0} bytes) appears to end without'
+                               'any payload.'.format(
+                                   self._partial_frame_nbytes))
         self.fh_raw.seek(raw_offset)
 
     @lazyproperty
@@ -281,15 +291,17 @@ class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase):
         raw_offset = self.fh_raw.tell()
         self.fh_raw.seek((self._nframes - 1) * self.header0.frame_nbytes)
         header = self.fh_raw.read_header()
-        if self._pframe_nbytes > 0:
+        if self._partial_frame_nbytes > self.header0.nbytes:
             header.mutable = True
-            # Payload should have integer number of words and complete samples.
-            payload_block = max(
+            # Payload should have integer number of both words and complete
+            # samples.
+            payload_block = lcm(
                 DADAPayload._dtype_word.itemsize,
                 self.header0.bps * (2 if self.header0.complex_data else 1) *
                 np.prod(self.sample_shape) // 8)
             header.payload_nbytes = payload_block * (
-                (self._pframe_nbytes - header.nbytes) // payload_block)
+                (self._partial_frame_nbytes - header.nbytes) // payload_block)
+            header.mutable = False
         self.fh_raw.seek(raw_offset)
         return header
 
@@ -305,15 +317,16 @@ class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase):
                  self.sample_rate).to(u.s))
 
     def _read_frame(self, index):
-        if index == self._nframes - 1:
-            self.fh_raw.seek(index * self.header0.frame_nbytes +
-                             self.header0.nbytes)
-            last_payload = DADAPayload.fromfile(self.fh_raw, memmap=True,
-                                                header=self._last_header)
-            frame = DADAFrame(self._last_header, last_payload)
-        else:
+        if index < self._nframes - 1:
             self.fh_raw.seek(index * self.header0.frame_nbytes)
             frame = self.fh_raw.read_frame(memmap=True)
+        else:
+            self.fh_raw.seek(index * self.header0.frame_nbytes +
+                             self.header0.nbytes)
+            last_header = self._last_header
+            last_payload = DADAPayload.fromfile(self.fh_raw, memmap=True,
+                                                header=last_header)
+            frame = DADAFrame(last_header, last_payload)
         assert (frame.header['OBS_OFFSET'] - self.header0['OBS_OFFSET'] ==
                 index * self.header0.payload_nbytes)
         return frame

--- a/baseband/dada/tests/test_dada.py
+++ b/baseband/dada/tests/test_dada.py
@@ -436,9 +436,10 @@ class TestDADA(object):
             assert np.all(fhs.read() == self.payload)
             assert np.all(fhns.read() == self.payload)
 
-    # Test that writing an incomplete stream is possible, and that frame set is
-    # valid but invalid samples use the fill value.
     def test_incomplete_stream(self, tmpdir):
+        """Test that writing an incomplete stream is possible, and that frame
+        set is valid but invalid samples use the fill value.
+        """
         filename = str(tmpdir.join('a.dada'))
         with catch_warnings(UserWarning) as w:
             with dada.open(filename, 'ws', header0=self.header,
@@ -493,6 +494,58 @@ class TestDADA(object):
                 dada.open(fraw, 'rs') as fr:
             data3 = fr.read()
         assert np.all(data3 == data)
+
+    def test_partial_last_frame(self, tmpdir):
+        """Test reading an incomplete frame from one or a sequence of files."""
+        # Prepare file sequence.
+        header = self.header.copy()
+        data = self.payload.data.squeeze()
+        data = np.r_[data, data, data]
+        filenames = [str(tmpdir.join('a.dada')),
+                     str(tmpdir.join('b.dada')),
+                     str(tmpdir.join('c.dada'))]
+        with dada.open(filenames, 'ws', header0=header) as fw:
+            fw.write(data)
+
+        # Replace c.dada with partially complete file.
+        with dada.open(str(tmpdir.join('c.dada')), 'rb') as fh, \
+                dada.open(str(tmpdir.join('c_partial.dada')), 'wb') as fw:
+            full_filesize = fh.seek(0, 2)
+            fh.seek(0)
+            fw.write(fh.read(full_filesize // 2 - 37))
+
+        filenames[-1] = str(tmpdir.join('c_partial.dada'))
+
+        # Check reading single partial frame.
+        with dada.open(filenames[-1], 'rs') as fh:
+            # Check that we've written the right number of bytes to file.
+            filesize = fh.fh_raw.seek(0, 2)
+            fh.fh_raw.seek(0)
+            assert filesize == full_filesize // 2 - 37
+            # Payload truncates 3 bytes so there is an integer number of
+            # complete samples.
+            assert fh.header0.frame_nbytes == filesize - 3
+            assert fh.header0.nbytes == self.header.nbytes
+            assert fh.samples_per_frame == (
+                (filesize - self.header.nbytes) * 8 // fh.header0.bps // 2 //
+                np.prod(fh.header0.sample_shape))
+            assert fh.header0 == fh._last_header
+            assert (fh.stop_time - fh.start_time - 7478 / fh.sample_rate <
+                    1 * u.ns)
+            assert fh.shape == (7478, 2)
+            # Taking advantage of data being repeated 3 times.
+            assert np.all(fh.read() == data[:7478])
+
+        # Check reading sequence of files.
+        with dada.open(filenames) as fh:
+            assert fh.samples_per_frame == header.samples_per_frame
+            assert (fh.stop_time - fh.start_time - 39478 / fh.sample_rate <
+                    1 * u.ns)
+            assert fh.shape == (39478, 2)
+            assert np.all(fh.read() == data[:39478])
+            fh.seek(-29, 2)
+            assert np.all(fh.read() == data[7478 - 29:7478])
+            assert fh.tell() == 39478
 
     def test_template_stream(self, tmpdir):
         start_time = self.header.time

--- a/baseband/vlbi_base/tests/test_vlbi_base.py
+++ b/baseband/vlbi_base/tests/test_vlbi_base.py
@@ -8,7 +8,7 @@ import pytest
 import astropy.units as u
 from astropy.tests.helper import catch_warnings
 from collections import namedtuple
-from ..utils import bcd_encode, bcd_decode, CRC
+from ..utils import bcd_encode, bcd_decode, CRC, gcd, lcm
 from ..header import HeaderParser, VLBIHeaderBase, four_word_struct
 from ..payload import VLBIPayloadBase
 from ..frame import VLBIFrameBase
@@ -596,3 +596,26 @@ def test_crc():
     assert '{:03x}'.format(crc) == crc_expected
     fullstream = np.hstack((bitstream, crcstream))
     assert crc12.check(fullstream)
+
+
+# PY2
+@pytest.mark.parametrize(
+    ('a', 'b', 'gcd_out'),
+    ((7, 14, 7),
+     (2712341, 234243, 1),
+     (0, 5, 5),
+     (4, -12, 4),
+     (-4, -12, 4)))
+def test_gcd(a, b, gcd_out):
+    assert gcd(a, b) == gcd_out
+
+
+@pytest.mark.parametrize(
+    ('a', 'b', 'lcm_out'),
+    ((7, 14, 14),
+     (7853, 6199, 48680747),
+     (0, 5, 0),
+     (4, -12, 12),
+     (-4, -12, 12)))
+def test_lcm(a, b, lcm_out):
+    assert lcm(a, b) == lcm_out

--- a/baseband/vlbi_base/utils.py
+++ b/baseband/vlbi_base/utils.py
@@ -2,6 +2,7 @@
 from __future__ import division, unicode_literals, print_function
 
 import numpy as np
+import six
 
 __all__ = ['bcd_decode', 'bcd_encode', 'CRC']
 
@@ -122,3 +123,17 @@ class CRC(object):
         for i in range(0, len(stream) - len(self)):
             stream[i:i+pol_bin.size] ^= (pol_bin & stream[i])
         return stream[-len(self):]
+
+
+if not six.PY2:  # ignoring python < 3.5; could add if you wish
+    from math import gcd
+else:
+    from fractions import gcd as fgcd
+
+    def gcd(a, b):
+        return abs(fgcd(a, b))
+
+
+def lcm(a, b):
+    """Calculate the least common multiple of a and b."""
+    return abs(a * b) // gcd(a, b)


### PR DESCRIPTION
Allows DADA to read a single incomplete frame (i.e. a file that's been truncated), or a sequence of frames where the last is incomplete.

Not sure how happy I am that `self._nframes` and `self._pframe_nbytes` are calculated in `__init__`.  Also not certain if, when initializing a `DADAFrame`, I should pass a copy of the header rather than the header itself.

Addresses #149.