### PR TITLE
Allow passing of header in place of bps to VLBIPayloadBase.fromdata.

### DIFF
--- a/baseband/dada/frame.py
+++ b/baseband/dada/frame.py
@@ -101,5 +101,5 @@ class DADAFrame(VLBIFrameBase):
         """
         if header is None:
             header = cls._header_class.fromvalues(verify=verify, **kwargs)
-        payload = cls._payload_class.fromdata(data, header.bps)
+        payload = cls._payload_class.fromdata(data, header=header)
         return cls(header, payload, valid=valid, verify=verify)

--- a/baseband/vdif/payload.py
+++ b/baseband/vdif/payload.py
@@ -177,11 +177,11 @@ class VDIFPayload(VLBIPayloadBase):
             If given, used to infer the encoding, and to verify the number of
             channels and whether the data are complex.
         bps : int, optional
-            Bits per elementary sample, used if ``header`` is `None`.
+            Bits per elementary sample, used if ``header`` is not given.
             Default: 2.
         edv : int, optional
-            Should be given if ``header`` is `None` and the payload is encoded
-            as Mark 5 data (i.e., ``edv=0xab``).
+            Should be given if ``header`` is not given and the payload is
+            encoded as Mark 5 data (i.e., ``edv=0xab``).
         """
         nchan = data.shape[-1]
         complex_data = (data.dtype.kind == 'c')

--- a/baseband/vlbi_base/payload.py
+++ b/baseband/vlbi_base/payload.py
@@ -92,7 +92,7 @@ class VLBIPayloadBase(object):
         return fh.write(self.words.tostring())
 
     @classmethod
-    def fromdata(cls, data, bps=2):
+    def fromdata(cls, data, header=None, bps=2):
         """Encode data as a payload.
 
         Parameters
@@ -100,12 +100,16 @@ class VLBIPayloadBase(object):
         data : `~numpy.ndarray`
             Data to be encoded. The last dimension is taken as the number of
             channels.
+        header : header instance, optional
+            If given, used to infer the bps.
         bps : int, optional
             Bits per elementary sample, i.e., per channel and per real or
-            imaginary component.  Default: 2.
+            imaginary component, used if header is not given.  Default: 2.
         """
         sample_shape = data.shape[1:]
         complex_data = data.dtype.kind == 'c'
+        if header:
+            bps = header.bps
         try:
             encoder = cls._encoders[bps]
         except KeyError:

--- a/baseband/vlbi_base/tests/test_vlbi_base.py
+++ b/baseband/vlbi_base/tests/test_vlbi_base.py
@@ -334,22 +334,28 @@ class TestVLBIBase(object):
         assert len(payload.words) == 4
         assert len(payload) == len(data)
         assert payload.nbytes == 16
-        payload2 = self.Payload.fromdata(self.payload.data, self.payload.bps)
+        payload2 = self.Payload.fromdata(self.payload.data,
+                                         bps=self.payload.bps)
         assert payload2 == self.payload
-        payload3 = self.Payload.fromdata(data.ravel(), bps=8)
-        assert payload3.sample_shape == ()
-        assert payload3.shape == (16,)
-        assert payload3 != payload
-        assert np.all(payload3.data == payload.data.ravel())
+        header = self.header.copy()
+        header.bps = 8
+        payload3 = self.Payload.fromdata(self.payload.data,
+                                         header=header)
+        assert payload3 == self.payload
+        payload4 = self.Payload.fromdata(data.ravel(), bps=8)
+        assert payload4.sample_shape == ()
+        assert payload4.shape == (16,)
+        assert payload4 != payload
+        assert np.all(payload4.data == payload.data.ravel())
         with pytest.raises(ValueError):  # don't have relevant encoder.
             self.Payload.fromdata(data, bps=4)
-        payload4 = self.Payload.fromdata(data[::2, 0] + 1j * data[1::2, 0],
+        payload5 = self.Payload.fromdata(data[::2, 0] + 1j * data[1::2, 0],
                                          bps=8)
-        assert payload4.complex_data is True
-        assert payload4.sample_shape == ()
-        assert payload4.shape == (8,)
-        assert payload4 != payload
-        assert np.all(payload4.words == payload.words)
+        assert payload5.complex_data is True
+        assert payload5.sample_shape == ()
+        assert payload5.shape == (8,)
+        assert payload5 != payload
+        assert np.all(payload5.words == payload.words)
 
     def test_frame_basics(self):
         assert self.frame.header is self.header


### PR DESCRIPTION
Fixed some related docstring inconsistencies (there are no more  `if \`\`header\`\` is \`None\``).

Do tiny things like this warrant inclusion in the changelog?

Addresses #222