### PR TITLE
Minor doc and docstring changes.

### DIFF
--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -251,7 +251,8 @@ class Mark5BStreamReader(Mark5BStreamBase, VLBIStreamReaderBase):
     sample_rate : `~astropy.units.Quantity`, optional
         Number of complete samples per second, i.e. the rate at which each
         channel is sampled.  If `None` (default), will be inferred from
-        scanning one second of the file.
+        scanning one second of the file or, failing that, using the time
+        difference between two consecutive frames.
     kday : int or None
         Explicit thousands of MJD of the observation start time (eg. ``57000``
         for MJD 57999), used to infer the full MJD from the header's time
@@ -391,7 +392,8 @@ open = make_opener('Mark5B', globals(), doc="""
 sample_rate : `~astropy.units.Quantity`, optional
     Number of complete samples per second, i.e. the rate at which each channel
     is sampled.  If `None` (default), will be inferred from scanning one
-    second of the file.
+    second of the file or, failing that, using the time difference between two
+    consecutive frames.
 kday : int or None
     Explicit thousands of MJD of the observation start time (eg. ``57000`` for
     MJD 57999), used to infer the full MJD from the header's time information.

--- a/docs/dada/index.rst
+++ b/docs/dada/index.rst
@@ -14,16 +14,19 @@ Usage
 =====
 
 This section covers reading and writing DADA files with Baseband; general usage
-is covered in the :ref:`Getting Started <getting_started>` section.  The
-examples below use the sample file ``baseband/data/sample.dada``, and the
-the `astropy.units` and `baseband.dada` modules::
+is covered in the :ref:`Getting Started <getting_started>` section. For
+situations in which one is unsure of a file's format, Baseband features the
+general `baseband.open` and `baseband.file_info` functions, which are also
+discussed in :ref:`Getting Started <getting_started>`.  The examples below use
+the sample file ``baseband/data/sample.dada``, and the the `astropy.units` and
+`baseband.dada` modules::
 
     >>> from baseband import dada
     >>> import astropy.units as u
     >>> from baseband.data import SAMPLE_DADA
 
-Single files can be opened with `~baseband.dada.open` in binary mode. 
-DADA files typically consist of just a single header and payload, and can be
+Single files can be opened with `~baseband.dada.open` in binary mode. DADA
+files typically consist of just a single header and payload, and can be
 read into a single `~baseband.dada.DADAFrame`.
 
 ::

--- a/docs/gsb/index.rst
+++ b/docs/gsb/index.rst
@@ -72,8 +72,14 @@ Usage Notes
 ===========
 
 This section covers reading and writing GSB files with Baseband; general usage
-is covered in the :ref:`Getting Started <getting_started>` section. The
-examples below use the sample files in the ``baseband/data/gsb/`` directory,
+is covered in the :ref:`Getting Started <getting_started>` section.  While
+Baseband features the general `baseband.open` and `baseband.file_info`
+functions, these cannot read GSB binary files without the accompanying
+timestamp file (at which point it is obvious the files are GSB).
+`baseband.file_info`, however, can be used on the timestamp file to determine
+if it is in rawdump or phased format.
+
+The examples below use the samplefiles in the ``baseband/data/gsb/`` directory,
 and the `numpy`, `astropy.units` and `baseband.gsb` modules::
 
     >>> import numpy as np

--- a/docs/mark4/index.rst
+++ b/docs/mark4/index.rst
@@ -53,9 +53,11 @@ Usage
 
 This section covers reading and writing Mark 4 files with Baseband; general
 usage can be found under the :ref:`Getting Started <getting_started>` section.
-The examples below use the small sample file ``baseband/data/sample.m4``, and
-the `numpy`, `astropy.units`, `astropy.time.Time`, and `baseband.mark4`
-modules::
+For situations in which one is unsure of a file's format, Baseband features the
+general `baseband.open` and `baseband.file_info` functions, which are also
+discussed in :ref:`Getting Started <getting_started>`.  The examples below use
+the small sample file ``baseband/data/sample.m4``, and the `numpy`,
+`astropy.units`, `astropy.time.Time`, and `baseband.mark4` modules::
 
     >>> import numpy as np
     >>> import astropy.units as u

--- a/docs/mark5b/index.rst
+++ b/docs/mark5b/index.rst
@@ -41,9 +41,11 @@ Usage
 
 This section covers reading and writing Mark 5B files with Baseband; general
 usage can be found under the :ref:`Getting Started <getting_started>` section.
-The examples below use the small sample file ``baseband/data/sample.m5b``, and
-the `numpy`, `astropy.units`, `astropy.time.Time`, and `baseband.mark5b`
-modules::
+For situations in which one is unsure of a file's format, Baseband features the
+general `baseband.open` and `baseband.file_info` functions, which are also
+discussed in :ref:`Getting Started <getting_started>`.  The examples below use
+the small sample file ``baseband/data/sample.m5b``, and the `numpy`,
+`astropy.units`, `astropy.time.Time`, and `baseband.mark5b` modules::
 
     >>> import numpy as np
     >>> import astropy.units as u

--- a/docs/tutorials/getting_started.rst
+++ b/docs/tutorials/getting_started.rst
@@ -6,9 +6,9 @@
 Getting Started
 ***************
 
-For some file formats, one can simply import baseband and use `baseband.open` to
-access the file.  This gives one a filehandle from which one can read decoded
-samples::
+For most file formats, one can simply import baseband and use `baseband.open`
+to access the file.  This gives one a filehandle from which one can read
+decoded samples::
 
     >>> import baseband
     >>> from baseband.data import SAMPLE_DADA

--- a/docs/vdif/index.rst
+++ b/docs/vdif/index.rst
@@ -43,8 +43,11 @@ Usage Notes
 
 This section covers reading and writing VDIF files with Baseband; general
 usage can be found under the :ref:`Getting Started <getting_started>` section.
-The examples below use the small sample file ``baseband/data/sample.vdif``, and
-the `numpy`, `astropy.units`, and `baseband.vdif` modules::
+For situations in which one is unsure of a file's format, Baseband features the
+general `baseband.open` and `baseband.file_info` functions, which are also
+discussed in :ref:`Getting Started <getting_started>`.  The examples below use
+the small sample file ``baseband/data/sample.vdif``, and the `numpy`,
+`astropy.units`, and `baseband.vdif` modules::
 
     >>> import numpy as np
     >>> from baseband import vdif


### PR DESCRIPTION
Make mention of generic opener in format docs.  Clarify Mark 5B automatic sample rate docstring to mention using two consecutive frames.

Addresses #213 and #221.