### PR TITLE
Allow user to choose whether stream readers verify frames.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ New Features
   will check whether the file is of that format, and then load it using the
   corresponding module. [#198]
 
+- Allow users to pass a ``verify`` keyword to file openers reading streams. 
+  [#233]
+
 - Added support for the GUPPI format. [#212]
 
 - Enabled `baseband.dada.open` to read streams where the last frame has an

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -114,7 +114,7 @@ class VLBIStreamBase(object):
 
     def __init__(self, fh_raw, header0, sample_rate, samples_per_frame,
                  unsliced_shape, bps, complex_data, squeeze, subset=(),
-                 fill_value=0.):
+                 fill_value=0., verify=True):
         self.fh_raw = fh_raw
         self._header0 = header0
         self._bps = bps
@@ -137,6 +137,8 @@ class VLBIStreamBase(object):
         self._subset = subset
         self._sample_shape = self._get_sample_shape()
         self._frame_index = None
+
+        self.verify = verify
 
     @property
     def squeeze(self):
@@ -242,6 +244,15 @@ class VLBIStreamBase(object):
             raise
         self._sample_rate = sample_rate
 
+    @property
+    def verify(self):
+        """Whether to do consistency checks on frames being read."""
+        return self._verify
+
+    @verify.setter
+    def verify(self, verify):
+        self._verify = bool(verify)
+
     def tell(self, unit=None):
         """Current offset in the file.
 
@@ -298,7 +309,7 @@ class VLBIStreamReaderBase(VLBIStreamBase):
 
     def __init__(self, fh_raw, header0, sample_rate, samples_per_frame,
                  unsliced_shape, bps, complex_data, squeeze, subset,
-                 fill_value):
+                 fill_value, verify):
 
         if sample_rate is None:
             try:
@@ -315,7 +326,7 @@ class VLBIStreamReaderBase(VLBIStreamBase):
 
         super(VLBIStreamReaderBase, self).__init__(
             fh_raw, header0, sample_rate, samples_per_frame, unsliced_shape,
-            bps, complex_data, squeeze, subset, fill_value)
+            bps, complex_data, squeeze, subset, fill_value, verify)
 
     info = VLBIStreamReaderInfo()
 
@@ -550,14 +561,14 @@ class VLBIStreamWriterBase(VLBIStreamBase):
 
     def __init__(self, fh_raw, header0, sample_rate, samples_per_frame,
                  unsliced_shape, bps, complex_data, squeeze, subset,
-                 fill_value):
+                 fill_value, verify):
 
         if sample_rate is None:
             raise ValueError("must pass in an explicit `sample_rate`.")
 
         super(VLBIStreamWriterBase, self).__init__(
             fh_raw, header0, sample_rate, samples_per_frame, unsliced_shape,
-            bps, complex_data, squeeze, subset, fill_value)
+            bps, complex_data, squeeze, subset, fill_value, verify)
 
     def _unsqueeze(self, data):
         new_shape = list(data.shape)

--- a/baseband/vlbi_base/tests/test_vlbi_base.py
+++ b/baseband/vlbi_base/tests/test_vlbi_base.py
@@ -444,7 +444,8 @@ class TestSqueezeAndSubset(object):
     def setup(self):
         self.other_args = dict(fh_raw=None, header0=None, bps=1,
                                complex_data=False, samples_per_frame=1000,
-                               sample_rate=10000*u.Hz, fill_value=0.)
+                               sample_rate=10000*u.Hz, fill_value=0.,
+                               verify=True)
         self.sample_shape_maker = namedtuple('SampleShape',
                                              'n0, n1, n2, n3, n4')
         self.unsliced_shape = (1, 21, 33, 1, 2)


### PR DESCRIPTION
Adds `verify` as a property of stream classes, and allow the user to set its value during stream reader initialization.  The user can change the reader's behaviour by altering `verify` (without re-opening the file).  `verify` is ignored by stream writers (though the user can technically still set it).

Timing tests show a 20% speed improvement when sequentially decoding VDIF data (subject to the number of threads), but closer to a 5% improvement for sequentially decoding Mark 4 data.

If approved I'll write a note in the changelog.  I'd also be grateful for suggestions on where to note this in the docs (if at all).

Addresses #133.