### PR TITLE
Initialize DADA and GUPPI header start times using either offset or start time

### DIFF
--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -403,7 +403,7 @@ samples_per_frame : int,
 sample_rate : `~astropy.units.Quantity`
     Number of complete samples per second, i.e. the rate at which each
     channel of each polarization is sampled.
-offset : `~astropy.units.Quantity`, optional
+offset : `~astropy.units.Quantity` or `~astropy.time.TimeDelta`, optional
     Time offset from the start of the whole observation (default: 0).
 npol : int, optional
     Number of polarizations (default: 1).

--- a/baseband/dada/header.py
+++ b/baseband/dada/header.py
@@ -411,15 +411,19 @@ class DADAHeader(OrderedDict):
     def time(self, time):
         """Set header time.
 
-        Note that this sets the start time of the header, assuming the offset
-        is already set correctly.
+        If ``start_time`` is not already set, this sets it using the time and
+        ``offset``.  Otherwise, this sets ``offset`` using the time and
+        ``start_time``.
 
         Parameters
         ----------
         time : `~astropy.time.Time`
             Time for the first sample associated with this header.
         """
-        self.start_time = time - self.offset
+        if 'MJD_START' not in self.keys():
+            self.start_time = time - self.offset
+        else:
+            self.offset = time - self.start_time
 
     def _ipython_key_completions_(self):
         # Enables tab-completion of header keys in IPython.

--- a/baseband/dada/tests/test_dada.py
+++ b/baseband/dada/tests/test_dada.py
@@ -82,10 +82,10 @@ class TestDADA(object):
         header3.frame_nbytes = 9096
         assert header3.payload_nbytes == 5000
         # Try initialising with properties instead of keywords.
-        # Here, we first just try the start time.
+        # Here, we first just try the start time and offset.
         header4 = dada.DADAHeader.fromvalues(
             start_time=header.start_time,
-            offset=header.time-header.start_time,
+            offset=header.time - header.start_time,
             bps=header.bps, complex_data=header.complex_data,
             sample_rate=header.sample_rate, sideband=header.sideband,
             samples_per_frame=header.samples_per_frame,
@@ -96,9 +96,9 @@ class TestDADA(object):
             pic_version=header['PIC_VERSION'])
         assert header4 == header
         assert header4.mutable is True
-        # And now try both start time and time of observation.
+        # And now try the time and offset.
         header5 = dada.DADAHeader.fromvalues(
-            offset=header.offset, time=header.time,
+            offset=header.time - header.start_time, time=header.time,
             bps=header.bps, complex_data=header.complex_data,
             sample_rate=header.sample_rate, sideband=header.sideband,
             samples_per_frame=header.samples_per_frame,
@@ -107,28 +107,40 @@ class TestDADA(object):
             telescope=header['TELESCOPE'], instrument=header['INSTRUMENT'],
             receiver=header['RECEIVER'], freq=header['FREQ'],
             pic_version=header['PIC_VERSION'])
+        # Finally try the time and start time.
         assert header5 == header
-        # Check repr can be used to instantiate header
-        header6 = eval('dada.' + repr(header))
+        header6 = dada.DADAHeader.fromvalues(
+            time=header.time, start_time=header.start_time,
+            bps=header.bps, complex_data=header.complex_data,
+            sample_rate=header.sample_rate, sideband=header.sideband,
+            samples_per_frame=header.samples_per_frame,
+            sample_shape=header.sample_shape,
+            source=header['SOURCE'], ra=header['RA'], dec=header['DEC'],
+            telescope=header['TELESCOPE'], instrument=header['INSTRUMENT'],
+            receiver=header['RECEIVER'], freq=header['FREQ'],
+            pic_version=header['PIC_VERSION'])
         assert header6 == header
-        # repr includes the comments
-        assert header6.comments == header.comments
-        # Therefore repr should be identical too.
-        assert repr(header6) == repr(header)
-        # Check instantiation via tuple
-        header7 = dada.DADAHeader(((key, (header[key], header.comments[key]))
-                                   for key in header))
+        # Check repr can be used to instantiate header
+        header7 = eval('dada.' + repr(header))
         assert header7 == header
+        # repr includes the comments
         assert header7.comments == header.comments
-        # Check copying
-        header8 = header.copy()
+        # Therefore repr should be identical too.
+        assert repr(header7) == repr(header)
+        # Check instantiation via tuple
+        header8 = dada.DADAHeader(((key, (header[key], header.comments[key]))
+                                   for key in header))
         assert header8 == header
-        assert header8.mutable is True
         assert header8.comments == header.comments
-        header9 = copy.copy(header8)
+        # Check copying
+        header9 = header.copy()
         assert header9 == header
         assert header9.mutable is True
         assert header9.comments == header.comments
+        header10 = copy.copy(header9)
+        assert header10 == header
+        assert header10.mutable is True
+        assert header10.comments == header.comments
 
     def test_payload(self, tmpdir):
         payload = self.payload

--- a/baseband/guppi/base.py
+++ b/baseband/guppi/base.py
@@ -285,7 +285,7 @@ samples_per_frame : int
     ``payload_nbytes``.
 payload_nbytes : int
     Number of bytes per payload.  Can alternatively give ``samples_per_frame``.
-offset : `~astropy.units.Quantity`, optional
+offset : `~astropy.units.Quantity` or `~astropy.time.TimeDelta`, optional
     Time offset from the start of the whole observation (default: 0).
 npol : int, optional
     Number of polarizations (default: 1).

--- a/baseband/guppi/header.py
+++ b/baseband/guppi/header.py
@@ -336,7 +336,7 @@ class GUPPIHeader(fits.Header):
 
     @offset.setter
     def offset(self, offset):
-        self['PKTIDX'] = int(round((offset.to_value(u.s) / self['TBIN'] /
+        self['PKTIDX'] = int(round((offset.to(u.s).value / self['TBIN'] /
                                     self['PKTSIZE']) *
                                    ((self._bpcs + 7) // 8)))
 
@@ -363,15 +363,19 @@ class GUPPIHeader(fits.Header):
     def time(self, time):
         """Set header time.
 
-        Note that this sets the start time of the header, assuming the offset
-        is already set correctly.
+        If ``start_time`` is not already set, this sets it using the time and
+        ``offset``.  Otherwise, this sets ``offset`` using the time and
+        ``start_time``.
 
         Parameters
         ----------
         time : `~astropy.time.Time`
             Time for the first sample associated with this header.
         """
-        self.start_time = time - self.offset
+        if 'STT_IMJD' not in self.keys():
+            self.start_time = time - self.offset
+        else:
+            self.offset = time - self.start_time
 
     def _ipython_key_completions_(self):
         # Enables tab-completion of header keys in IPython.

--- a/baseband/guppi/tests/test_guppi.py
+++ b/baseband/guppi/tests/test_guppi.py
@@ -128,6 +128,34 @@ class TestGUPPI(object):
         assert header8 == header
         assert header8.mutable is True
 
+        # Check that we can set the offset by either passing the offset or the
+        # start time.
+        offset = 9.472 * u.s
+        header9 = guppi.GUPPIHeader.fromvalues(
+            time=header.start_time + offset, offset=offset,
+            sample_rate=header.sample_rate,
+            samples_per_frame=header.samples_per_frame,
+            overlap=header.overlap, sample_shape=header.sample_shape,
+            sideband=header.sideband, bps=header.bps,
+            pktsize=header['PKTSIZE'], obsfreq=header['OBSFREQ'],
+            src_name=header['SRC_NAME'], observer=header['OBSERVER'],
+            telescop=header['TELESCOP'], ra_str=header['RA_STR'],
+            dec_str=header['DEC_STR'])
+        header10 = guppi.GUPPIHeader.fromvalues(
+            start_time=header.start_time, time=header.start_time + offset,
+            sample_rate=header.sample_rate,
+            samples_per_frame=header.samples_per_frame,
+            overlap=header.overlap, sample_shape=header.sample_shape,
+            sideband=header.sideband, bps=header.bps,
+            pktsize=header['PKTSIZE'], obsfreq=header['OBSFREQ'],
+            src_name=header['SRC_NAME'], observer=header['OBSERVER'],
+            telescop=header['TELESCOP'], ra_str=header['RA_STR'],
+            dec_str=header['DEC_STR'])
+        assert np.abs(header9.offset - offset) < 1 * u.ns
+        assert np.abs(header9.start_time - header.start_time) < 1 * u.ns
+        assert np.abs(header10.offset - offset) < 1 * u.ns
+        assert np.abs(header10.start_time - header.start_time) < 1 * u.ns
+
     def test_payload(self, tmpdir):
         payload = self.payload
         assert payload.nbytes == 16384


### PR DESCRIPTION
Allows setting of DADA and GUPPI header time and start time in their respective `fromvalues` methods by either passing `time` and `offset` or `time` and `start_time`.  (Once initialized, setting a mutable header's `time` will change its offset.)

Addresses #224.