### PR TITLE
Speed up verify

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,11 @@ Other Changes and Additions
 - The `baseband.data` module with sample data files now has an explicit entry
   in the documentation. [#198]
 
+- Increased speed of VLBI stream reading by changing the way header sync
+  patterns are stored, and removing redundant verification steps.  VDIF
+  sequential decode is now 5 - 10% faster (depending on the number of
+  threads). [#241]
+
 1.0.1 (2018-06-04)
 ==================
 

--- a/baseband/mark4/header.py
+++ b/baseband/mark4/header.py
@@ -139,6 +139,7 @@ class Mark4TrackHeader(VLBIHeaderBase):
          ('bcd_second', (4, 24, 8)),
          ('bcd_fraction', (4, 12, 12)),
          ('crc', (4, 0, 12))))
+    _sync_pattern = _header_parser.defaults['sync_pattern']
 
     _properties = ('decade', 'track_id', 'fraction', 'time')
     """Properties accessible/usable in initialisation."""
@@ -160,8 +161,7 @@ class Mark4TrackHeader(VLBIHeaderBase):
     def verify(self):
         """Verify header integrity."""
         assert len(self.words) == 5
-        assert np.all(self['sync_pattern'] ==
-                      self._header_parser.defaults['sync_pattern'])
+        assert np.all(self['sync_pattern'] == self._sync_pattern)
         assert np.all((self['bcd_fraction'] & 0xf) % 5 != 4)
         if self.decade is not None:
             assert (1950 < self.decade < 3000)

--- a/baseband/mark5b/header.py
+++ b/baseband/mark5b/header.py
@@ -69,6 +69,7 @@ class Mark5BHeader(VLBIHeaderBase):
          ('bcd_seconds', (2, 0, 20)),
          ('bcd_fraction', (3, 16, 16)),
          ('crc', (3, 0, 16))))
+    _sync_pattern = _header_parser.defaults['sync_pattern']
 
     _struct = four_word_struct
 
@@ -91,8 +92,7 @@ class Mark5BHeader(VLBIHeaderBase):
     def verify(self):
         """Verify header integrity."""
         assert len(self.words) == 4
-        assert (self['sync_pattern'] ==
-                self._header_parser.defaults['sync_pattern'])
+        assert self['sync_pattern'] == self._sync_pattern
         assert self.kday is None or (33000 < self.kday < 400000)
         if self.kday is not None:
             assert self.kday % 1000 == 0, "kday must be thousands of MJD."

--- a/baseband/vdif/frame.py
+++ b/baseband/vdif/frame.py
@@ -119,7 +119,9 @@ class VDIFFrame(VLBIFrameBase):
         """
         header = cls._header_class.fromfile(fh, edv, verify)
         payload = cls._payload_class.fromfile(fh, header=header)
-        return cls(header, payload, verify=verify)
+        # Since header was (optionally) verified, and payload was initialized
+        # using header, frame verification is unnecessary.
+        return cls(header, payload, verify=False)
 
     @classmethod
     def fromdata(cls, data, header=None, verify=True, **kwargs):

--- a/docs/tutorials/new_edv.rst
+++ b/docs/tutorials/new_edv.rst
@@ -90,7 +90,7 @@ inheritance diagram.  To support a new EDV, we create a new subclass to
 
     >>> class VDIFHeader4(vdif.header.VDIFHeader):
     ...     _edv = 4
-    ...     
+    ...
     ...     _header_parser = vlbi.header.HeaderParser(
     ...         (('invalid_data', (0, 31, 1, False)),
     ...          ('legacy_mode', (0, 30, 1, False)),


### PR DESCRIPTION
Moved header sync patterns to private variables to speed up `verify`.  For VDIF, doing

```
header['sync_pattern'] == header._header_parser.defaults['sync_pattern']
```

takes 2.73 µs, while doing

```
header['sync_pattern'] == header._header_parser.defaults['sync_pattern'
```

takes 556 ns.  For Mark 4 the effect of using `np.all(header['sync_pattern'] == header._sync_pattern)` is less significant - 11 µs instead of 14.4 µs using `np.all(header['sync_pattern'] == header._header_parser.defaults['sync_pattern'])`.

Also removed frame verification when using `VDIFFrame.fromfile`, reducing 14.1 µs per frame read in.  About half of this (6.93 µs) is just used to check that the payload sample shape is the same as the header sample shape, so if we really wanted to we could just eliminate that instead of removing all verification.

Using the PR code to sequentially decode 2 billion complete samples (~500 MB) from an 8-thread VDIF file, we shave ~5 s / min (~8%) when compared to current master.

Addresses some of the comments in #133.