### PR TITLE
Ensure TimeGSB works with latest astropy.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+1.1.1 (unreleased)
+==================
+
+Bug Fixes
+---------
+
+- Ensure ``gsb`` times can be decoded with astropy-dev (which is to become
+  astropy 3.1). [#249]
+
 1.1 (2018-06-06)
 ================
 
@@ -11,7 +20,7 @@ New Features
   will check whether the file is of that format, and then load it using the
   corresponding module. [#198]
 
-- Allow users to pass a ``verify`` keyword to file openers reading streams. 
+- Allow users to pass a ``verify`` keyword to file openers reading streams.
   [#233]
 
 - Added support for the GUPPI format. [#212]
@@ -25,7 +34,7 @@ API Changes
 - In analogy with Mark 5B, VDIF header time getting and setting now requires
   a frame rate rather than a sample rate. [#217, #218]
 
-- DADA and GUPPI now support passing either a ``start_time`` or ``offset`` 
+- DADA and GUPPI now support passing either a ``start_time`` or ``offset``
   (in addition to ``time``) to set the start time in the header. [#240]
 
 Bug Fixes

--- a/baseband/gsb/header.py
+++ b/baseband/gsb/header.py
@@ -51,14 +51,22 @@ class TimeGSB(TimeString):
         self.jd1, self.jd2 = erfa.dtf2d(
             self.scale.upper().encode('utf8'), *iterator.operands[1:])
 
+    # This can be removed once we only support astropy >=3.1.
+    # The str(c) is necessary for python2/numpy -> no unicode literals...
+    _new_ihmsfs_dtype = np.dtype([(str(c), np.intc) for c in 'hmsf'])
+
     def to_value(self, parent=None):
         scale = self.scale.upper().encode('ascii'),
         iys, ims, ids, ihmsfs = erfa.d2dtf(scale, self.precision,
                                            self.jd1, self.jd2)
-        ihrs = ihmsfs[..., 0]
-        imins = ihmsfs[..., 1]
-        isecs = ihmsfs[..., 2]
-        ifracs = ihmsfs[..., 3]
+        # For ASTROPY_LT_3_1, convert to the new structured array dtype that is
+        # returned by the new erfa gufuncs.
+        if not ihmsfs.dtype.names:
+            ihmsfs = ihmsfs.view(self._new_ihmsfs_dtype)
+        ihrs = ihmsfs['h']
+        imins = ihmsfs['m']
+        isecs = ihmsfs['s']
+        ifracs = ihmsfs['f']
 
         fmt = ('{0:04d} {1:02d} {2:02d} {3:02d} {4:02d} {5:02d} 0.{6:0' +
                str(self.precision) + 'd}')


### PR DESCRIPTION
The change of erfa routines to gufuncs meant that the output
of d2dtf now consists of a structured array.

Found from automatic testing.