### PR TITLE
Fixed rounding error when encoding 4-bit data using encode_4bit_base.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Bug Fixes
 - Ensure ``gsb`` times can be decoded with astropy-dev (which is to become
   astropy 3.1). [#249]
 
+- Fixed rounding error when encoding 4-bit data using
+  `baseband.vlbi_base.encoding.encode_4bit_base`. [#250]
+
 1.1 (2018-06-06)
 ================
 

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -280,10 +280,13 @@ class TestVDIF(object):
         assert np.allclose(payload2.data, acmplx)
         header = vdif.VDIFHeader.fromvalues(edv=0, complex_data=False, bps=8,
                                             payload_nbytes=payload1.nbytes)
-        assert np.all(vdif.VDIFPayload.fromdata(areal, header) == payload1)
+        assert vdif.VDIFPayload.fromdata(areal, header) == payload1
+        # Also check that a circular decode-encode is self-consistent.
+        assert vdif.VDIFPayload.fromdata(payload1.data, header) == payload1
         header['complex_data'] = True
-        assert np.all(vdif.VDIFPayload.fromdata(acmplx, header) == payload2)
-        # Also check for bps=4
+        assert vdif.VDIFPayload.fromdata(acmplx, header) == payload2
+        assert vdif.VDIFPayload.fromdata(payload2.data, header) == payload2
+        # Also check for bps=4.
         decode = (aint[:, np.newaxis] >> np.array([0, 4])) & 0xf
         areal = ((decode - 8.) / 2.95).reshape(-1, 1)
         acmplx = areal[::2] + 1j * areal[1::2]
@@ -294,8 +297,10 @@ class TestVDIF(object):
         header = vdif.VDIFHeader.fromvalues(edv=0, complex_data=False, bps=4,
                                             payload_nbytes=payload3.nbytes)
         assert vdif.VDIFPayload.fromdata(areal, header) == payload3
+        assert vdif.VDIFPayload.fromdata(payload3.data, header) == payload3
         header['complex_data'] = True
         assert vdif.VDIFPayload.fromdata(acmplx, header) == payload4
+        assert vdif.VDIFPayload.fromdata(payload4.data, header) == payload4
 
     def test_payload(self, tmpdir):
         with open(SAMPLE_FILE, 'rb') as fh:

--- a/baseband/vlbi_base/encoding.py
+++ b/baseband/vlbi_base/encoding.py
@@ -54,7 +54,7 @@ decoder_levels = {
     1: np.array([-1.0, 1.0], dtype=np.float32),
     2: np.array([-OPTIMAL_2BIT_HIGH, -1.0, 1.0, OPTIMAL_2BIT_HIGH],
                 dtype=np.float32),
-    4: (np.arange(16, dtype=np.float32) - 8.)/FOUR_BIT_1_SIGMA}
+    4: (np.arange(16, dtype=np.float32) - 8.) / FOUR_BIT_1_SIGMA}
 """Levels for data encoded with different numbers of bits.."""
 
 two_bit_2_sigma = 2 * TWO_BIT_1_SIGMA
@@ -95,8 +95,8 @@ def encode_4bit_base(values):
     This returns an unsigned integer array containing encoded sample
     values that range from 0 to 15.  Floating point sample values are
     converted to unsigned int by first scaling them by
-    ``FOUR_BIT_1_SIGMA = 2.95``, then adding 8.  Some sample output
-    levels are:
+    ``FOUR_BIT_1_SIGMA = 2.95``, then adding 8.5 (the 0.5 to ensure proper
+    rounding when typecasting to uint8). Some sample output levels are:
 
       ========================= ======
       Input range               Output
@@ -111,7 +111,7 @@ def encode_4bit_base(values):
     """
     # Optimized for speed by doing calculations in-place.
     values = values * FOUR_BIT_1_SIGMA
-    values += 8.
+    values += 8.5
     return np.clip(values, 0., 15., out=values).astype(np.uint8)
 
 


### PR DESCRIPTION
Discovered when assisting Rebecca with writing her ARO files.

A short test to show there's a problem in current master:

```
from baseband import vdif
import numpy as np
 
words = np.array([50462976,  117835012,  185207048,  252579084], dtype=np.uint32)
payload = vdif.payload.VDIFPayload(words, nchan=1, bps=4, complex_data=True)
assert np.all(payload.fromdata(payload.data, bps=4, edv=0).data ==
              payload.data)
```

In the PR, this is now checked in `test_vdif.py` by checking that re-encoding decoded data is self-consistent.