### PR TITLE
WIP: Sequentialfile for all

### DIFF
--- a/baseband/core.py
+++ b/baseband/core.py
@@ -47,7 +47,12 @@ def file_info(name, format=FILE_FORMATS, **kwargs):
       - ``inconsistent_kwargs``: not needed to open the file, and inconsistent.
       - ``irrelevant_kwargs``: provide information irrelevant for opening.
     """
-    if isinstance(format, tuple):
+
+    # Handle lists and tuples of files, which may be passed from open.
+    if isinstance(name, (tuple, list)):
+        return file_info(name[0], format, **kwargs)
+    # If we're looking at one file but multiple formats, cycle through formats.
+    elif isinstance(format, tuple):
         for format_ in format:
             info = file_info(name, format_, **kwargs)
             if info:

--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -1,7 +1,6 @@
 # Licensed under the GPLv3 - see LICENSE
 from __future__ import division, unicode_literals, print_function
 import io
-import os
 import re
 
 import numpy as np
@@ -23,8 +22,8 @@ __all__ = ['DADAFileNameSequencer', 'DADAFileReader', 'DADAFileWriter',
            'DADAStreamBase', 'DADAStreamReader', 'DADAStreamWriter', 'open']
 
 
-class DADAFileNameSequencer:
-    """List-like generator of filenames using a template.
+class DADAFileNameSequencer(sf.FileNameSequencer):
+    """List-like generator of DADA filenames using a template.
 
     The template is formatted, filling in any items in curly brackets with
     values from the header, as well as possibly a file number equal to the
@@ -39,7 +38,8 @@ class DADAFileNameSequencer:
     Parameters
     ----------
     template : str
-        Template to format to get specific filenames.
+        Template to format to get specific filenames.  Curly bracket item
+        keywords are not case-sensitive.
     header : dict-like
         Structure holding key'd values that are used to fill in the format.
         Keys must be in all caps (eg. ``DATE``), as with DADA header keys.
@@ -48,9 +48,6 @@ class DADAFileNameSequencer:
     --------
 
     >>> from baseband import dada
-    >>> dfs = dada.base.DADAFileNameSequencer('a{file_nr:03d}.dada', {})
-    >>> dfs[10]
-    'a010.dada'
     >>> dfs = dada.base.DADAFileNameSequencer(
     ...     '{date}_{file_nr:03d}.dada', {'DATE': "2018-01-01"})
     >>> dfs[10]
@@ -59,7 +56,7 @@ class DADAFileNameSequencer:
     >>> with open(SAMPLE_DADA, 'rb') as fh:
     ...     header = dada.DADAHeader.fromfile(fh)
     >>> template = '{utc_start}.{obs_offset:016d}.000000.dada'
-    >>> dfs = DADAFileNameSequencer(template, header)
+    >>> dfs = dada.base.DADAFileNameSequencer(template, header)
     >>> dfs[0]
     '2013-07-02-01:37:40.0000006400000000.000000.dada'
     >>> dfs[1]
@@ -85,24 +82,14 @@ class DADAFileNameSequencer:
             self._obs_offset0 = self.items['OBS_OFFSET']
             self._file_size = header['FILE_SIZE']
 
-    def __getitem__(self, frame_nr):
-        if frame_nr < 0:
-            frame_nr += len(self)
-            if frame_nr < 0:
-                raise IndexError('frame number out of range.')
-
-        self.items['FRAME_NR'] = self.items['FILE_NR'] = frame_nr
+    def _process_items(self, file_nr):
+        super(DADAFileNameSequencer, self)._process_items(file_nr)
+        # Pop file_nr, as we need to capitalize it.
+        file_nr = self.items.pop('file_nr')
+        self.items['FRAME_NR'] = self.items['FILE_NR'] = file_nr
         if self._has_obs_offset:
             self.items['OBS_OFFSET'] = (self._obs_offset0 +
-                                        frame_nr * self._file_size)
-        return self.template.format(**self.items)
-
-    def __len__(self):
-        frame_nr = 0
-        while os.path.isfile(self[frame_nr]):
-            frame_nr += 1
-
-        return frame_nr
+                                        file_nr * self._file_size)
 
 
 class DADAFileReader(VLBIFileReaderBase):

--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -80,7 +80,7 @@ class DADAFileNameSequencer(sf.FileNameSequencer):
         self._has_obs_offset = 'OBS_OFFSET' in self.items
         if self._has_obs_offset:
             self._obs_offset0 = self.items['OBS_OFFSET']
-            self._file_size = header['FILE_SIZE']
+            self._payload_size = header['FILE_SIZE']
 
     def _process_items(self, file_nr):
         super(DADAFileNameSequencer, self)._process_items(file_nr)
@@ -89,7 +89,18 @@ class DADAFileNameSequencer(sf.FileNameSequencer):
         self.items['FRAME_NR'] = self.items['FILE_NR'] = file_nr
         if self._has_obs_offset:
             self.items['OBS_OFFSET'] = (self._obs_offset0 +
-                                        file_nr * self._file_size)
+                                        file_nr * self._payload_size)
+
+    @classmethod
+    def template_first_file(cls, name, **kwargs):
+        """Returns the first file of a template based on its keys.
+
+        Used by openers to access first header within a file sequence.
+        """
+        kwargs = {key.upper(): value for key, value in kwargs.items()}
+        for key in ('FILE_NR', 'FRAME_NR', 'OBS_OFFSET', 'FILE_SIZE'):
+            kwargs.setdefault(key, 0)
+        return cls(name, kwargs)[kwargs['FRAME_NR']]
 
 
 class DADAFileReader(VLBIFileReaderBase):
@@ -337,12 +348,40 @@ class DADAStreamWriter(DADAStreamBase, VLBIStreamWriterBase):
     raw : filehandle
         For writing the header and raw data to storage.
     header0 : :class:`~baseband.dada.DADAHeader`
-        Header for the first frame, holding time information, etc.
+        Header for the first frame, holding time information, etc.  Can instead
+        give keyword arguments to construct a header (see ``**kwargs``).
     squeeze : bool, optional
         If `True` (default), `write` accepts squeezed arrays as input,
         and adds any dimensions of length unity.
+    **kwargs
+        If no header is given, an attempt is made to construct one from these.
+        For a standard header, this would include the following.
+
+    --- Header keywords : (see :meth:`~baseband.dada.DADAHeader.fromvalues`)
+
+    time : `~astropy.time.Time`
+        Start time of the file.
+    samples_per_frame : int,
+        Number of complete samples per frame.
+    sample_rate : `~astropy.units.Quantity`
+        Number of complete samples per second, i.e. the rate at which each
+        channel of each polarization is sampled.
+    offset : `~astropy.units.Quantity` or `~astropy.time.TimeDelta`, optional
+        Time offset from the start of the whole observation (default: 0).
+    npol : int, optional
+        Number of polarizations (default: 1).
+    nchan : int, optional
+        Number of channels (default: 1).
+    complex_data : bool, optional
+        Whether data are complex (default: `False`).
+    bps : int, optional
+        Bits per elementary sample, i.e. per real or imaginary component for
+        complex data (default: 8).
     """
-    def __init__(self, fh_raw, header0, squeeze=True):
+
+    def __init__(self, fh_raw, header0=None, squeeze=True, **kwargs):
+        if header0 is None:
+            header0 = DADAHeader.fromvalues(**kwargs)
         assert header0.get('OBS_OVERLAP', 0) == 0
         fh_raw = DADAFileWriter(fh_raw)
         super(DADAStreamWriter, self).__init__(fh_raw, header0,
@@ -364,7 +403,9 @@ class DADAStreamWriter(DADAStreamBase, VLBIStreamWriterBase):
         del frame
 
 
-opener = make_opener('DADA', globals(), doc="""
+open = make_opener('DADA', globals(), DADAFileNameSequencer,
+                   ('squeeze', 'subset', 'verify'), ('squeeze',),
+                   default_frames_per_file=1, doc="""
 --- For reading a stream : (see :class:`~baseband.dada.base.DADAStreamReader`)
 
 squeeze : bool, optional
@@ -387,28 +428,8 @@ squeeze : bool, optional
     any dimensions of length unity.
 **kwargs
     If the header is not given, an attempt will be made to construct one
-    with any further keyword arguments.
-
---- Header keywords : (see :meth:`~baseband.dada.DADAHeader.fromvalues`)
-
-time : `~astropy.time.Time`
-    Start time of the file.
-samples_per_frame : int,
-    Number of complete samples per frame.
-sample_rate : `~astropy.units.Quantity`
-    Number of complete samples per second, i.e. the rate at which each
-    channel of each polarization is sampled.
-offset : `~astropy.units.Quantity` or `~astropy.time.TimeDelta`, optional
-    Time offset from the start of the whole observation (default: 0).
-npol : int, optional
-    Number of polarizations (default: 1).
-nchan : int, optional
-    Number of channels (default: 1).
-complex_data : bool, optional
-    Whether data are complex (default: `False`).
-bps : int, optional
-    Bits per elementary sample, i.e. per real or imaginary component for
-    complex data (default: 8).
+    with any further keyword arguments.  See
+    :class:`~baseband.dada.base.DADAStreamWriter`.
 
 Returns
 -------
@@ -417,71 +438,12 @@ Filehandle
     :class:`~baseband.dada.base.DADAFileWriter` (binary), or
     :class:`~baseband.dada.base.DADAStreamReader` or
     :class:`~baseband.dada.base.DADAStreamWriter` (stream).
-""")
 
-
-# Need to wrap the opener to be able to deal with file lists or templates.
-# TODO: move this up to the opener??
-def open(name, mode='rs', **kwargs):
-    header0 = kwargs.get('header0', None)
-    squeeze = kwargs.pop('squeeze', None)
-    # If sequentialfile object, check that it's opened properly.
-    if isinstance(name, sf.SequentialFileBase):
-        assert (('r' in mode and name.mode == 'rb') or
-                ('w' in mode and name.mode == 'w+b')), (
-                    "open only accepts sequential files opened in 'rb' mode "
-                    "for reading or 'w+b' mode for writing.")
-    is_template = isinstance(name, six.string_types) and ('{' in name and
-                                                          '}' in name)
-    is_sequence = isinstance(name, (tuple, list))
-
-    if 'b' not in mode:
-        if header0 is None:
-            if 'w' in mode:
-                # For writing a header is required.
-                header0 = DADAHeader.fromvalues(**kwargs)
-                kwargs = {}
-
-            elif is_template and ('OBS_OFFSET' in name or
-                                  'obs_offset' in name):
-                # For reading try reading header from first file if needed.
-                # We make a temporary file sequencer for this, as the real one
-                # will need the header file size.
-                kwargs = {key.upper(): value for key, value in kwargs.items()}
-                for key in ('FILE_NR', 'FRAME_NR', 'OBS_OFFSET', 'FILE_SIZE'):
-                    kwargs.setdefault(key, 0)
-                first_file = (DADAFileNameSequencer(name, kwargs)
-                              [kwargs['FRAME_NR']])
-                with io.open(first_file, 'rb') as fh:
-                    header0 = DADAHeader.fromfile(fh)
-                kwargs = {}
-            else:
-                header0 = {}
-
-        if is_template:
-            name = DADAFileNameSequencer(name, header0)
-
-        if is_template or is_sequence:
-            if 'r' in mode:
-                name = sf.open(name, 'rb')
-            else:
-                name = sf.open(name, 'w+b', file_size=header0.frame_nbytes)
-
-        if header0 and 'w' in mode:
-            kwargs['header0'] = header0
-
-    if squeeze is not None:
-        kwargs['squeeze'] = squeeze
-
-    return opener(name, mode, **kwargs)
-
-
-open.__doc__ = opener.__doc__ + """\n
 Notes
 -----
-For streams, one can also pass in a list of files, or a template string that
-can be formatted using 'frame_nr', 'obs_offset', and other header keywords
-(by `~baseband.dada.base.DADAFileNameSequencer`).
+For streams, one can pass a template string formatted using header
+keywords.  In particular, 'obs_offset' and 'frame_nr' are
+appropriately incremented by `~baseband.dada.base.DADAFileNameSequencer`.
 
 For writing, one can mimic what is done at quite a few telescopes by using
 the template '{utc_start}_{obs_offset:016d}.000000.dada'.
@@ -497,4 +459,4 @@ keyword arguments with values appropriate for the first file.
 One may also pass in a `~baseband.helpers.sequentialfile` object
 (opened in 'rb' mode for reading or 'w+b' for writing), though for typical use
 cases it is practically identical to passing in a list or template.
-"""
+""")

--- a/baseband/guppi/base.py
+++ b/baseband/guppi/base.py
@@ -74,6 +74,16 @@ class GUPPIFileNameSequencer(sf.FileNameSequencer):
         # Pop file_nr, as we need to capitalize it.
         self.items['FILE_NR'] = self.items.pop('file_nr')
 
+    @classmethod
+    def template_first_file(cls, name, **kwargs):
+        """Returns the first file of a template based on its keys.
+
+        Used by openers to access first header within a file sequence.
+        """
+        kwargs = {key.upper(): value for key, value in kwargs.items()}
+        kwargs.setdefault('FILE_NR', 0)
+        return cls(name, kwargs)[kwargs['FILE_NR']]
+
 
 class GUPPIFileReader(VLBIFileReaderBase):
     """Simple reader for GUPPI files.
@@ -282,12 +292,42 @@ class GUPPIStreamWriter(GUPPIStreamBase, VLBIStreamWriterBase):
     raw : filehandle
         For writing the header and raw data to storage.
     header0 : :class:`~baseband.guppi.GUPPIHeader`
-        Header for the first frame, holding time information, etc.
+        Header for the first frame, holding time information, etc.  Can instead
+        give keyword arguments to construct a header (see ``**kwargs``).
     squeeze : bool, optional
         If `True` (default), `write` accepts squeezed arrays as input,
         and adds any dimensions of length unity.
+    **kwargs
+        If no header is given, an attempt is made to construct one from these.
+        For a standard header, this would include the following.
+
+    --- Header keywords : (see :meth:`~baseband.guppi.GUPPIHeader.fromvalues`)
+
+    time : `~astropy.time.Time`
+        Start time of the file.  Must have an integer number of seconds.
+    sample_rate : `~astropy.units.Quantity`
+        Number of complete samples per second, i.e. the rate at which each
+        channel of each polarization is sampled.
+    samples_per_frame : int
+        Number of complete samples per frame.  Can alternatively give
+        ``payload_nbytes``.
+    payload_nbytes : int
+        Number of bytes per payload.  Can alternatively give ``samples_per_frame``.
+    offset : `~astropy.units.Quantity` or `~astropy.time.TimeDelta`, optional
+        Time offset from the start of the whole observation (default: 0).
+    npol : int, optional
+        Number of polarizations (default: 1).
+    nchan : int, optional
+        Number of channels (default: 1).  For GUPPI, complex data is only allowed
+        when nchan > 1.
+    bps : int, optional
+        Bits per elementary sample, i.e. per real or imaginary component for
+        complex data (default: 8).
     """
-    def __init__(self, fh_raw, header0, squeeze=True):
+
+    def __init__(self, fh_raw, header0=None, squeeze=True, **kwargs):
+        if header0 is None:
+            header0 = GUPPIHeader.fromvalues(**kwargs)
         assert header0.get('OVERLAP', 0) == 0, ("overlap must be 0 when "
                                                 "writing GUPPI files.")
         fh_raw = GUPPIFileWriter(fh_raw)
@@ -310,7 +350,9 @@ class GUPPIStreamWriter(GUPPIStreamBase, VLBIStreamWriterBase):
         del frame
 
 
-opener = make_opener('GUPPI', globals(), doc="""
+open = make_opener('GUPPI', globals(), GUPPIFileNameSequencer,
+                   ('squeeze', 'subset', 'verify'), ('squeeze',),
+                   default_frames_per_file=128, doc="""
 --- For reading a stream : (see `~baseband.guppi.base.GUPPIStreamReader`)
 
 squeeze : bool, optional
@@ -336,30 +378,8 @@ frames_per_file : int, optional
     within each file.  Default: 128.
 **kwargs
     If the header is not given, an attempt will be made to construct one
-    with any further keyword arguments.
-
---- Header keywords : (see :meth:`~baseband.guppi.GUPPIHeader.fromvalues`)
-
-time : `~astropy.time.Time`
-    Start time of the file.  Must have an integer number of seconds.
-sample_rate : `~astropy.units.Quantity`
-    Number of complete samples per second, i.e. the rate at which each
-    channel of each polarization is sampled.
-samples_per_frame : int
-    Number of complete samples per frame.  Can alternatively give
-    ``payload_nbytes``.
-payload_nbytes : int
-    Number of bytes per payload.  Can alternatively give ``samples_per_frame``.
-offset : `~astropy.units.Quantity` or `~astropy.time.TimeDelta`, optional
-    Time offset from the start of the whole observation (default: 0).
-npol : int, optional
-    Number of polarizations (default: 1).
-nchan : int, optional
-    Number of channels (default: 1).  For GUPPI, complex data is only allowed
-    when nchan > 1.
-bps : int, optional
-    Bits per elementary sample, i.e. per real or imaginary component for
-    complex data (default: 8).
+    with any further keyword arguments.  See
+    :class:`~baseband.guppi.base.GUPPIStreamWriter`.
 
 Returns
 -------
@@ -368,52 +388,10 @@ Filehandle
     :class:`~baseband.guppi.base.GUPPIFileWriter` (binary), or
     :class:`~baseband.guppi.base.GUPPIStreamReader` or
     :class:`~baseband.guppi.base.GUPPIStreamWriter` (stream).
-""")
 
-
-# Need to wrap the opener to be able to deal with file lists or templates.
-# TODO: move this up to the opener??
-def open(name, mode='rs', **kwargs):
-    frames_per_file = kwargs.pop('frames_per_file', 128)
-    header0 = kwargs.get('header0', None)
-    squeeze = kwargs.pop('squeeze', None)
-    # If sequentialfile object, check that it's opened properly.
-    if isinstance(name, sf.SequentialFileBase):
-        assert (('r' in mode and name.mode == 'rb') or
-                ('w' in mode and name.mode == 'w+b')), (
-                    "open only accepts sequential files opened in 'rb' mode "
-                    "for reading or 'w+b' mode for writing.")
-    is_sequence = isinstance(name, (tuple, list))
-
-    if 'b' not in mode:
-        if header0 is None:
-            if 'w' in mode:
-                # For writing a header is required.
-                header0 = GUPPIHeader.fromvalues(**kwargs)
-                kwargs = {}
-            else:
-                header0 = {}
-
-        if is_sequence:
-            if 'r' in mode:
-                name = sf.open(name, 'rb')
-            else:
-                name = sf.open(name, 'w+b', file_size=(
-                    frames_per_file * header0.frame_nbytes))
-
-        if header0 and 'w' in mode:
-            kwargs['header0'] = header0
-
-    if squeeze is not None:
-        kwargs['squeeze'] = squeeze
-
-    return opener(name, mode, **kwargs)
-
-
-open.__doc__ = opener.__doc__ + """\n
 Notes
 -----
 For streams, one can also pass in a list of files, or equivalently a
 `~baseband.helpers.sequentialfile` object (opened in 'rb' mode for reading or
 'w+b' for writing).
-"""
+""")

--- a/baseband/guppi/base.py
+++ b/baseband/guppi/base.py
@@ -1,6 +1,7 @@
 # Licensed under the GPLv3 - see LICENSE
 from __future__ import division, unicode_literals, print_function
 
+import re
 import astropy.units as u
 from astropy.utils import lazyproperty
 
@@ -13,8 +14,65 @@ from .payload import GUPPIPayload
 from .frame import GUPPIFrame
 
 
-__all__ = ['GUPPIFileReader', 'GUPPIFileWriter', 'GUPPIStreamBase',
-           'GUPPIStreamReader', 'GUPPIStreamWriter', 'open']
+__all__ = ['GUPPIFileNameSequencer', 'GUPPIFileReader', 'GUPPIFileWriter',
+           'GUPPIStreamBase', 'GUPPIStreamReader', 'GUPPIStreamWriter', 'open']
+
+
+class GUPPIFileNameSequencer(sf.FileNameSequencer):
+    """List-like generator of GUPPI filenames using a template.
+
+    The template is formatted, filling in any items in curly brackets with
+    values from the header, as well as possibly a file number equal to the
+    indexing value, indicated with '{file_nr}'.
+
+    The length of the instance will be the number of files that exist that
+    match the template for increasing values of the file number.
+
+    Parameters
+    ----------
+    template : str
+        Template to format to get specific filenames.  Curly bracket item
+        keywords are not case-sensitive.
+    header : dict-like
+        Structure holding key'd values that are used to fill in the format.
+        Keys must be in all caps (eg. ``DATE``), as with GUPPI header keys.
+
+    Examples
+    --------
+
+    >>> from baseband import guppi
+    >>> gfs = guppi.base.GUPPIFileNameSequencer(
+    ...     '{date}_{file_nr:03d}.raw', {'DATE': "2018-01-01"})
+    >>> gfs[10]
+    '2018-01-01_010.raw'
+    >>> from baseband.data import SAMPLE_PUPPI
+    >>> with open(SAMPLE_PUPPI, 'rb') as fh:
+    ...     header = guppi.GUPPIHeader.fromfile(fh)
+    >>> template = 'puppi_{stt_imjd}_{src_name}_{scannum}.{file_nr:04d}.raw'
+    >>> gfs = guppi.base.GUPPIFileNameSequencer(template, header)
+    >>> gfs[0]
+    'puppi_58132_J1810+1744_2176.0000.raw'
+    >>> gfs[10]
+    'puppi_58132_J1810+1744_2176.0010.raw'
+    """
+    def __init__(self, template, header):
+        # convert template names to upper case, since header keywords are
+        # upper case as well.
+        self.items = {}
+
+        def check_and_convert(x):
+            string = x.group().upper()
+            key = string[1:-1]
+            if key != 'FILE_NR':
+                self.items[key] = header[key]
+            return string
+
+        self.template = re.sub(r'{\w+[}:]', check_and_convert, template)
+
+    def _process_items(self, file_nr):
+        super(GUPPIFileNameSequencer, self)._process_items(file_nr)
+        # Pop file_nr, as we need to capitalize it.
+        self.items['FILE_NR'] = self.items.pop('file_nr')
 
 
 class GUPPIFileReader(VLBIFileReaderBase):

--- a/baseband/guppi/tests/test_guppi.py
+++ b/baseband/guppi/tests/test_guppi.py
@@ -9,6 +9,7 @@ import astropy.units as u
 from astropy.tests.helper import catch_warnings
 from ... import guppi
 from ...helpers import sequentialfile as sf
+from ..base import GUPPIFileNameSequencer
 from ...data import SAMPLE_PUPPI as SAMPLE_FILE
 
 
@@ -584,3 +585,17 @@ class TestGUPPI(object):
             fn.seek(1231)
             new_data = fn.read(47)
             assert np.all(new_data == data[1231:1231 + 47])
+
+
+class TestGUPPIFileNameSequencer(object):
+    def setup(self):
+        with open(SAMPLE_FILE, 'rb') as fh:
+            self.header = guppi.GUPPIHeader.fromfile(fh)
+
+    def test_header_extraction(self):
+        # Follow Nikhil's J1810 Arecibo observation file naming scheme:
+        # puppi_58132_J1810+1744_2176.0000.raw, etc.
+        template = 'puppi_{stt_imjd}_{src_name}_{scannum}.{file_nr:04d}.raw'
+        fns = GUPPIFileNameSequencer(template, self.header)
+        assert fns[0] == 'puppi_58132_J1810+1744_2176.0000.raw'
+        assert fns[29] == 'puppi_58132_J1810+1744_2176.0029.raw'

--- a/baseband/guppi/tests/test_guppi.py
+++ b/baseband/guppi/tests/test_guppi.py
@@ -544,6 +544,19 @@ class TestGUPPI(object):
             data3 = fr.read()
         assert np.all(data3 == data)
 
+        # Test writing and reading based on a pattern.
+        template = str(tmpdir.join('guppi_{file_nr:01d}.raw'))
+        with guppi.open(template, 'ws', header0=self.header_w,
+                        file_size=(2 * self.header_w.frame_nbytes)) as fw:
+            fw.write(data)
+
+        with guppi.open(template, 'rs') as fn:
+            assert len(fn.fh_raw.files) == 2
+            assert fn.fh_raw.files[-1] == str(tmpdir.join('guppi_1.raw'))
+            data4 = fn.read()
+        assert np.all(data4 == data)
+
+
     def test_partial_last_frame(self, tmpdir):
         """Test reading a file with an incomplete last frame."""
         # Read in sample file as a byte stream.

--- a/baseband/helpers/sequentialfile.py
+++ b/baseband/helpers/sequentialfile.py
@@ -90,6 +90,15 @@ class FileNameSequencer(object):
 
         return file_nr
 
+    @classmethod
+    def template_first_file(cls, name, **kwargs):
+        """Returns the first file of a template based on its keys.
+
+        Used by openers to access first header within a file sequence.
+        """
+        kwargs.setdefault('file_nr', 0)
+        return cls(name, kwargs)[kwargs['file_nr']]
+
 
 class SequentialFileBase(object):
     """Deal with several files as if they were one contiguous one.

--- a/baseband/helpers/sequentialfile.py
+++ b/baseband/helpers/sequentialfile.py
@@ -3,12 +3,92 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import io
+import os
+import re
 import itertools
 from bisect import bisect
 import numpy as np
 from astropy.utils import lazyproperty
 
-__all__ = ['SequentialFileReader', 'SequentialFileWriter', 'open']
+__all__ = ['FileNameSequencer', 'SequentialFileReader', 'SequentialFileWriter',
+           'open']
+
+
+class FileNameSequencer(object):
+    """List-like generator of filenames using a template.
+
+    The template is formatted, filling in any items in curly brackets with
+    values from the header.  It is additionally possible to insert a file
+    number equal to the indexing value, indicated with '{file_nr}', and the
+    header time in ISO 8601 format, excluding fractions of a second, indicated
+    with '{header_time}'.
+
+    The length of the instance will be the number of files that exist
+    that match the template for increasing values of the file number.
+
+    Parameters
+    ----------
+    template : str
+        Template to format to get specific filenames.  Curly bracket item
+        keywords are case-sensitive (eg. '{FRAME_NR}' or '{Frame_NR}' will not
+        use ``header['frame_nr']``.
+    header : dict-like
+        Structure holding key'd values that are used to fill in the format.
+
+    Examples
+    --------
+
+    >>> from baseband import vdif
+    >>> from baseband.helpers import sequentialfile as sf
+    >>> vfs = sf.FileNameSequencer('a{file_nr:03d}.vdif', {})
+    >>> vfs[10]
+    'a010.vdif'
+    >>> vfs = sf.FileNameSequencer(
+    ...     'obs{YEAR}_{file_nr:03d}.vdif', {'YEAR': "2018"})
+    >>> vfs[10]
+    'obs2018_010.vdif'
+    >>> from baseband.data import SAMPLE_VDIF
+    >>> with vdif.open(SAMPLE_VDIF, 'rb') as fh:
+    ...     header = vdif.VDIFHeader.fromfile(fh)
+    >>> template = 'obs.edv{edv:d}.{header_time}.{file_nr:05d}.vdif'
+    >>> vfs = sf.FileNameSequencer(template, header)
+    >>> vfs[10]
+    'obs.edv3.2014-06-16T05:56:07.00010.vdif'
+    """
+    def __init__(self, template, header):
+        # convert template names to upper case, since header keywords are
+        # upper case as well.
+        self.items = {}
+
+        def check_and_convert(x):
+            string = x.group()
+            key = string[1:-1]
+            if key == 'header_time':
+                self.items[key] = header.time.isot.split(".")[0]
+            elif key != 'file_nr':
+                self.items[key] = header[key]
+            return string
+
+        self.template = re.sub(r'{\w+[}:]', check_and_convert, template)
+
+    def _process_items(self, file_nr):
+        if file_nr < 0:
+            file_nr += len(self)
+            if file_nr < 0:
+                raise IndexError('file number out of range.')
+
+        self.items['file_nr'] = file_nr
+
+    def __getitem__(self, file_nr):
+        self._process_items(file_nr)
+        return self.template.format(**self.items)
+
+    def __len__(self):
+        file_nr = 0
+        while os.path.isfile(self[file_nr]):
+            file_nr += 1
+
+        return file_nr
 
 
 class SequentialFileBase(object):

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -8,6 +8,7 @@ import astropy.units as u
 from ..vlbi_base.base import (make_opener, VLBIFileBase, VLBIFileReaderBase,
                               VLBIStreamBase, VLBIStreamReaderBase,
                               VLBIStreamWriterBase)
+from ..helpers import sequentialfile as sf
 from .header import Mark4Header
 from .payload import Mark4Payload
 from .frame import Mark4Frame
@@ -468,7 +469,12 @@ class Mark4StreamWriter(Mark4StreamBase, VLBIStreamWriterBase):
         return Mark4Frame(header, self._payload)
 
 
-open = make_opener('Mark4', globals(), doc="""
+# 2**14 is totally arbitrary.
+open = make_opener('Mark4', globals(), sf.FileNameSequencer,
+                   ('sample_rate', 'ntrack', 'decade', 'ref_time',
+                    'squeeze', 'subset', 'fill_value', 'verify'),
+                   ('sample_rate', 'squeeze'),
+                   default_frames_per_file=2**14, doc="""
 --- For reading a stream : (see `~baseband.mark4.base.Mark4StreamReader`)
 
 sample_rate : `~astropy.units.Quantity`, optional

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -8,6 +8,7 @@ from astropy.utils import lazyproperty
 from ..vlbi_base.base import (VLBIFileBase, VLBIFileReaderBase, VLBIStreamBase,
                               VLBIStreamReaderBase, VLBIStreamWriterBase,
                               make_opener)
+from ..helpers import sequentialfile as sf
 from .header import Mark5BHeader
 from .payload import Mark5BPayload
 from .frame import Mark5BFrame
@@ -393,8 +394,12 @@ class Mark5BStreamWriter(Mark5BStreamBase, VLBIStreamWriterBase):
         # Reuse payload.
         return Mark5BFrame(header, self._payload, valid=True)
 
-
-open = make_opener('Mark5B', globals(), doc="""
+# 2**14 is totally arbitrary.
+open = make_opener('Mark5B', globals(), sf.FileNameSequencer,
+                   ('sample_rate', 'kday', 'ref_time', 'nchan',
+                    'bps', 'squeeze', 'subset', 'fill_value', 'verify'),
+                   ('sample_rate', 'nchan', 'bps', 'squeeze'),
+                   default_frames_per_file=2**14, doc="""
 --- For reading a stream : (see `~baseband.mark5b.base.Mark5BStreamReader`)
 
 sample_rate : `~astropy.units.Quantity`, optional

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -682,6 +682,37 @@ class TestMark5B(object):
             assert abs(fh.start_time - test_time) < 1.*u.ns
             assert fh.header0['frame_nr'] == 198
 
+    def test_sequentialfile(self, tmpdir):
+        """Tests writing and reading of sequential files.
+
+        These tests focus on reading and writing with lists.
+        """
+
+        # Use sample file as basis of a file sequence.
+        with mark5b.open(SAMPLE_FILE, 'rs', sample_rate=32*u.MHz,
+                         kday=56000, nchan=8, bps=2) as fh:
+            header = fh.header0.copy()
+            data = fh.read()
+            dtime = fh.stop_time - fh.start_time
+        data = np.r_[data, data, data, data, data]
+
+        # Create a file sequence using template.
+        files = [str(tmpdir.join('f.{0:03d}.m5b'.format(x))) for x in range(5)]
+        with mark5b.open(files, 'ws', file_size=4 * header.frame_nbytes,
+                         sample_rate=32*u.MHz, nchan=8, kday=56000,
+                         **header) as fw:
+            fw.write(data)
+
+        # Open files, checking that we can pass a subset.
+        with mark5b.open(files, 'rs', sample_rate=32*u.MHz, nchan=8,
+                         kday=56000, subset=slice(1, 5)) as fn:
+            assert len(fn.fh_raw.files) == 5
+            assert fn.fh_raw.files[-1] == str(tmpdir.join('f.004.m5b'))
+            assert fn.header0.time == header.time
+            assert fn.stop_time - fn.start_time - 5 * dtime < 1 * u.ns
+            assert np.all(data[:, 1:5] == fn.read())
+
+
     # Test that writing an incomplete stream is possible, and that frame set is
     # appropriately marked as invalid.
     @pytest.mark.parametrize('fill_value', (0., -999.))

--- a/baseband/tests/test_sequential_baseband.py
+++ b/baseband/tests/test_sequential_baseband.py
@@ -23,7 +23,7 @@ def test_sequentialfile_vdif_stream(tmpdir):
         edv=0, time=Time('2010-01-01'), nchan=2, bps=2,
         complex_data=False, frame_nr=0, thread_id=0, samples_per_frame=16,
         station='me')
-    with sequentialfile.open(vdif_sequencer, 'wb',
+    with sequentialfile.open(vdif_sequencer, 'w+b',
                              file_size=4*header.frame_nbytes) as sfh, \
             vdif.open(sfh, 'ws', header0=header, nthread=2,
                       sample_rate=256*u.Hz) as fw:

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -9,6 +9,7 @@ import astropy.units as u
 from ..vlbi_base.base import (make_opener, VLBIFileBase, VLBIFileReaderBase,
                               VLBIStreamBase, VLBIStreamReaderBase,
                               VLBIStreamWriterBase)
+from ..helpers import sequentialfile as sf
 from .header import VDIFHeader
 from .frame import VDIFFrame, VDIFFrameSet
 from .file_info import VDIFFileReaderInfo
@@ -570,7 +571,11 @@ class VDIFStreamWriter(VDIFStreamBase, VLBIStreamWriterBase):
         return self._frameset
 
 
-open = make_opener('VDIF', globals(), doc="""
+# 1024 is the maximum number of threads in a VDIF frameset.
+open = make_opener('VDIF', globals(), sf.FileNameSequencer,
+                   ('sample_rate', 'squeeze', 'subset', 'fill_value',
+                    'verify'), ('sample_rate', 'nthread', 'squeeze'),
+                   default_frames_per_file=1024, doc="""
 --- For reading a stream : (see :class:`~baseband.vdif.base.VDIFStreamReader`)
 
 sample_rate : `~astropy.units.Quantity`, optional

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -983,6 +983,39 @@ class TestVDIF(object):
             vdif.open(tmp_file, 's')
 
 
+def test_sequentialfile(tmpdir):
+    """Tests writing and reading of sequential files.
+
+    These tests focus on reading and writing with templates.
+    """
+
+    # Use sample file as basis of a file sequence.
+    with vdif.open(SAMPLE_FILE, 'rs') as fh:
+        header = fh.header0.copy()
+        data = fh.read()
+        dtime = fh.stop_time - fh.start_time
+    data = np.r_[data, data, data]
+
+    # Create a file sequence using template.
+    template = str(tmpdir.join('f.{file_nr:03d}.vdif'))
+    with vdif.open(template, 'ws', frames_per_file=2 * 8, nthread=8,
+                   **header) as fw:
+        fw.write(data)
+
+    # Read in file-sequence and check data consistency.
+    with vdif.open(template, 'rs') as fn:
+        assert len(fn.fh_raw.files) == 3
+        assert fn.fh_raw.files[-1] == str(tmpdir.join('f.002.vdif'))
+        assert fn.header0.time == header.time
+        assert fn.stop_time - fn.start_time - 3 * dtime < 1 * u.ns
+        assert np.all(data == fn.read())
+
+    # Read in one file and check if everything makes sense.
+    with vdif.open(str(tmpdir.join('f.002.vdif')), 'rs') as fn:
+        assert fn.header0.time - header.time - 2. * dtime < 1 * u.ns
+        assert np.all(data[80000:] == fn.read())
+
+
 def test_vlbi_vdif():
     """Tests SAMPLE_VLBI, which is SAMPLE_VDIF with uncorrected timestamps."""
     with vdif.open(SAMPLE_VLBI, 'rs') as fh, \

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -643,7 +643,7 @@ class VLBIStreamWriterBase(VLBIStreamBase):
         return super(VLBIStreamWriterBase, self).close()
 
 
-default_open_doc_head = """Open baseband file for reading or writing.
+default_open_doc = """Open {baseband} file for reading or writing.
 
 Opened as a binary file, one gets a wrapped filehandle that adds
 methods to read/write a frame.  Opened as a stream, the handle is
@@ -653,26 +653,9 @@ as if it were a stream of samples.
 Parameters
 ----------
 name : str or filehandle
-    File name or handle.
-mode : {'rb', 'wb', 'rs', or 'ws'}, optional
-    Whether to open for reading or writing, and as a regular binary
-    file or as a stream. Default: 'rs', for reading a stream.
-**kwargs
-    Additional arguments when opening the file as a stream.
-"""
-
-default_open_doc_tail = """Open baseband file for reading or writing.
-
-Opened as a binary file, one gets a wrapped filehandle that adds
-methods to read/write a frame.  Opened as a stream, the handle is
-wrapped further, with methods such as reading and writing to the file
-as if it were a stream of samples.
-
-Parameters
-----------
-name : str or filehandle
-    File name or handle.
-mode : {'rb', 'wb', 'rs', or 'ws'}, optional
+    File name or handle.  The handle can be a `~baseband.helpers.sequentialfile`
+    object, a list or tuple of files, or a template string (see Notes).
+mode : {{'rb', 'wb', 'rs', or 'ws'}}, optional
     Whether to open for reading or writing, and as a regular binary
     file or as a stream. Default: 'rs', for reading a stream.
 **kwargs
@@ -680,8 +663,8 @@ mode : {'rb', 'wb', 'rs', or 'ws'}, optional
 """
 
 
-def make_opener(fmt, reader_classes, seqfile_class, filesize_func=None,
-                doc='', append_doc=True):
+def make_opener(fmt, reader_classes, seqfile_class, reader_args, writer_args,
+                default_frames_per_file=1, doc='', append_doc=True):
     """Create a baseband file opener.
 
     Parameters
@@ -704,9 +687,6 @@ def make_opener(fmt, reader_classes, seqfile_class, filesize_func=None,
                                        'StreamReader', 'StreamWriter')}
 
     def open(name, mode='rs', **kwargs):
-        # 
-        header0 = kwargs.get('header0', None)
-        squeeze = kwargs.pop('squeeze', None)
         # If sequentialfile object, check that it's opened properly.
         if isinstance(name, sf.SequentialFileBase):
             assert (('r' in mode and name.mode == 'rb') or
@@ -717,51 +697,75 @@ def make_opener(fmt, reader_classes, seqfile_class, filesize_func=None,
                                                               '}' in name)
         is_sequence = isinstance(name, (tuple, list))
 
-        if 'b' not in mode:
+        # Check if user passed header0.
+        header0 = kwargs.get('header0', None)
+
+        if is_template or is_sequence:
             if header0 is None:
                 if 'w' in mode:
                     # For writing a header is required.
-                    header0 = reader_classes[cls_type].fromvalues(**kwargs)
-                    kwargs = {}
+                    # TODO: This is pretty ugly, but popping keys from kwargs
+                    # before the dict into fromvalues fails to pass
+                    # sample_rate to the header (since all other VDIF EDVs
+                    # must pass sample_rate directly to the stream writer.
+                    # Since VDIFStreamWriter's sample rate checking in
+                    # __init__ is already super-ugly, maybe add a
+                    # self-consistency check there so we can pop kwargs here?
+                    with warnings.catch_warnings():
+                        warnings.simplefilter("ignore")
+                        header0 = reader_classes['Header'].fromvalues(**kwargs)
+                    passed_kwargs = {key: kwargs[key] for key in kwargs.keys()
+                                     if key in (
+                        writer_args + ('file_size', 'frames_per_file'))}
+                    passed_kwargs['header0'] = header0
 
-                elif is_template and ('OBS_OFFSET' in name or
-                                      'obs_offset' in name):
+                    # Store keys to pass to stream writer (user shouldn't be
+                    # passing anything to binary classes anyway!)
+                    kwargs = passed_kwargs
+
+                elif is_template:
                     # For reading try reading header from first file if needed.
-                    # We make a temporary file sequencer for this, as the real one
-                    # will need the header file size.
-                    kwargs = {key.upper(): value for key, value in kwargs.items()}
-                    for key in ('FILE_NR', 'FRAME_NR', 'OBS_OFFSET', 'FILE_SIZE'):
-                        kwargs.setdefault(key, 0)
-                    first_file = (DADAFileNameSequencer(name, kwargs)
-                                  [kwargs['FRAME_NR']])
+                    # We make a temporary file sequencer for this, as the real
+                    # one may need the header file size to iterate properly.
+                    first_file = seqfile_class.template_first_file(name,
+                                                                   **kwargs)
                     with io.open(first_file, 'rb') as fh:
-                        header0 = DADAHeader.fromfile(fh)
-                    kwargs = {}
+                        header0 = reader_classes['Header'].fromfile(fh)
+
+                    passed_kwargs = {key: kwargs[key] for key in kwargs.keys()
+                                     if key in reader_args}
+
+                    # Store keys to pass to stream writer (user shouldn't be
+                    # passing anything to binary classes anyway!)
+                    kwargs = passed_kwargs
+
                 else:
                     header0 = {}
 
             if is_template:
-                name = DADAFileNameSequencer(name, header0)
+                name = seqfile_class(name, header0)
 
-            if is_template or is_sequence:
-                if 'r' in mode:
-                    name = sf.open(name, 'rb')
-                else:
-                    name = sf.open(name, 'w+b', file_size=header0.frame_nbytes)
+            # Open a sequentialfile object.
+            if 'r' in mode:
+                name = sf.open(name, 'rb')
+            else:
+                # This also removes these keys from kwargs before passing it
+                # to stream readers/writers.
+                file_size = kwargs.pop('file_size', None)
+                frames_per_file = kwargs.pop('frames_per_file',
+                                             default_frames_per_file)
+                if file_size is None:
+                    file_size = frames_per_file * header0.frame_nbytes
+                name = sf.open(name, 'w+b', file_size=file_size)
 
-            if header0 and 'w' in mode:
-                kwargs['header0'] = header0
-
-        if squeeze is not None:
-            kwargs['squeeze'] = squeeze
-
-
-
+        # Select FileReader/Writer for binary, StreamReader/Writer for stream.
         if 'b' in mode:
             cls_type = 'File'
         else:
             cls_type = 'Stream'
 
+        # Select reading or writing.  Check if ``name`` is a filehandle, and
+        # open it if not.
         if 'w' in mode:
             cls_type += 'Writer'
             got_fh = hasattr(name, 'write')
@@ -776,6 +780,8 @@ def make_opener(fmt, reader_classes, seqfile_class, filesize_func=None,
             raise ValueError("only support opening {0} file for reading "
                              "or writing (mode='r' or 'w')."
                              .format(fmt))
+        # Try wrapping ``name`` with file or stream reader (``name`` is a
+        # binary filehandle at this point).
         try:
             return reader_classes[cls_type](name, **kwargs)
         except Exception as exc:
@@ -786,7 +792,8 @@ def make_opener(fmt, reader_classes, seqfile_class, filesize_func=None,
                     pass
             raise exc
 
-    open.__doc__ = (default_open_doc.replace('baseband', fmt) + doc
+    # Load custom documentation for format.
+    open.__doc__ = (default_open_doc.format(baseband=fmt) + doc
                     if append_doc else doc)
     # This ensures the function becomes visible to sphinx.
     if module:

--- a/docs/helpers/index.rst
+++ b/docs/helpers/index.rst
@@ -40,7 +40,7 @@ We now open a sequential file object for writing::
     >>> from baseband.helpers import sequentialfile as sf
     >>> filenames = ["seqvdif_{0}".format(i) for i in range(2)]
     >>> file_size = fh.fh_raw.seek(0, 2) // 2
-    >>> fwr = sf.open(filenames, mode='wb', file_size=file_size)
+    >>> fwr = sf.open(filenames, mode='w+b', file_size=file_size)
 
 The first argument passed to |open| must be a **time-ordered sequence** of
 filenames in a list, tuple, or other subscriptable object that returns


### PR DESCRIPTION
Proposed design of a revised file factory for `open` that also incorporates listlike and sequential file object reading.  Not sure if I really like the design.  In particular:

- `make_opener` is now sufficiently complex that perhaps we should turn it into a class whose `__call__` method functions like `open` does now.  Having to manually pass in typical file sizes or which kwargs are stream keywords rather than header0 ones feels clunky.
- Regardless of what `make_opener` becomes, it appears we still have to manually distinguish which keyword arguments do what within the opener (passed as an argument, listed in a class definition, etc.), which itsel feels clunky.
- The `if is_template or is_sequence` block could probably be cleaned up, though it's currently late so I'll save it to tomorrow.
- Alternatively, everything gets a lot simpler if we extend support for `sequentialfile` objects, lists and tuples to VLBI formats, but restrict processing templates to DADA and GUPPI.  We can keep the new `FileNameSequencer` in `helpers`, but only have those two formats use it.

Also haven't updated any of the docstrings to reflect new functionality.  Documentation on sequential file reading should also be partly pushed to Getting Started, since it's now more straightforward.  There should also be a check that passing a list of files to `baseband.open` now works as well (`file_info` acts on a single file, but once the format is known the entire list can be passed to the format open).