### PR TITLE
Abstract FileNameSequencer

### DIFF
--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -33,7 +33,8 @@ class DADAFileNameSequencer(sf.FileNameSequencer):
     size in bytes.
 
     The length of the instance will be the number of files that exist that
-    match the template for increasing values of the file number.
+    match the template for increasing values of the file number (when writing,
+    it is the number of files that have so far been generated).
 
     Parameters
     ----------
@@ -65,8 +66,6 @@ class DADAFileNameSequencer(sf.FileNameSequencer):
     '2013-07-02-01:37:40.0000006400640000.000000.dada'
     """
     def __init__(self, template, header):
-        # convert template names to upper case, since header keywords are
-        # upper case as well.
         self.items = {}
 
         def check_and_convert(x):
@@ -76,6 +75,8 @@ class DADAFileNameSequencer(sf.FileNameSequencer):
                 self.items[key] = header[key]
             return string
 
+        # This converts template names to upper case, since header keywords are
+        # all upper case.
         self.template = re.sub(r'{\w+[}:]', check_and_convert, template)
         self._has_obs_offset = 'OBS_OFFSET' in self.items
         if self._has_obs_offset:

--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -1,7 +1,6 @@
 # Licensed under the GPLv3 - see LICENSE
 from __future__ import division, unicode_literals, print_function
 import io
-import os
 import re
 
 import numpy as np
@@ -23,8 +22,8 @@ __all__ = ['DADAFileNameSequencer', 'DADAFileReader', 'DADAFileWriter',
            'DADAStreamBase', 'DADAStreamReader', 'DADAStreamWriter', 'open']
 
 
-class DADAFileNameSequencer:
-    """List-like generator of filenames using a template.
+class DADAFileNameSequencer(sf.FileNameSequencer):
+    """List-like generator of DADA filenames using a template.
 
     The template is formatted, filling in any items in curly brackets with
     values from the header, as well as possibly a file number equal to the
@@ -39,7 +38,8 @@ class DADAFileNameSequencer:
     Parameters
     ----------
     template : str
-        Template to format to get specific filenames.
+        Template to format to get specific filenames.  Curly bracket item
+        keywords are not case-sensitive.
     header : dict-like
         Structure holding key'd values that are used to fill in the format.
         Keys must be in all caps (eg. ``DATE``), as with DADA header keys.
@@ -48,9 +48,6 @@ class DADAFileNameSequencer:
     --------
 
     >>> from baseband import dada
-    >>> dfs = dada.base.DADAFileNameSequencer('a{file_nr:03d}.dada', {})
-    >>> dfs[10]
-    'a010.dada'
     >>> dfs = dada.base.DADAFileNameSequencer(
     ...     '{date}_{file_nr:03d}.dada', {'DATE': "2018-01-01"})
     >>> dfs[10]
@@ -59,7 +56,7 @@ class DADAFileNameSequencer:
     >>> with open(SAMPLE_DADA, 'rb') as fh:
     ...     header = dada.DADAHeader.fromfile(fh)
     >>> template = '{utc_start}.{obs_offset:016d}.000000.dada'
-    >>> dfs = DADAFileNameSequencer(template, header)
+    >>> dfs = dada.base.DADAFileNameSequencer(template, header)
     >>> dfs[0]
     '2013-07-02-01:37:40.0000006400000000.000000.dada'
     >>> dfs[1]
@@ -85,24 +82,14 @@ class DADAFileNameSequencer:
             self._obs_offset0 = self.items['OBS_OFFSET']
             self._file_size = header['FILE_SIZE']
 
-    def __getitem__(self, frame_nr):
-        if frame_nr < 0:
-            frame_nr += len(self)
-            if frame_nr < 0:
-                raise IndexError('frame number out of range.')
-
-        self.items['FRAME_NR'] = self.items['FILE_NR'] = frame_nr
+    def _process_items(self, file_nr):
+        super(DADAFileNameSequencer, self)._process_items(file_nr)
+        # Pop file_nr, as we need to capitalize it.
+        file_nr = self.items.pop('file_nr')
+        self.items['FRAME_NR'] = self.items['FILE_NR'] = file_nr
         if self._has_obs_offset:
             self.items['OBS_OFFSET'] = (self._obs_offset0 +
-                                        frame_nr * self._file_size)
-        return self.template.format(**self.items)
-
-    def __len__(self):
-        frame_nr = 0
-        while os.path.isfile(self[frame_nr]):
-            frame_nr += 1
-
-        return frame_nr
+                                        file_nr * self._file_size)
 
 
 class DADAFileReader(VLBIFileReaderBase):

--- a/baseband/dada/tests/test_dada.py
+++ b/baseband/dada/tests/test_dada.py
@@ -676,8 +676,8 @@ class TestDADAFileNameSequencer(object):
             self.header = dada.DADAHeader.fromfile(fh)
 
     def test_offset_enumeration(self):
-        fns = DADAFileNameSequencer('{obs_offset:06d}.x', {'OBS_OFFSET': 10,
-                                                           'FILE_SIZE': 20})
+        fns = DADAFileNameSequencer(
+            '{obs_offset:06d}.x', {'OBS_OFFSET': 10, 'FILE_SIZE': 20})
         assert fns[0] == '000010.x'
         assert fns[9] == '000190.x'
 

--- a/baseband/guppi/base.py
+++ b/baseband/guppi/base.py
@@ -26,7 +26,8 @@ class GUPPIFileNameSequencer(sf.FileNameSequencer):
     indexing value, indicated with '{file_nr}'.
 
     The length of the instance will be the number of files that exist that
-    match the template for increasing values of the file number.
+    match the template for increasing values of the file number (when writing,
+    it is the number of files that have so far been generated).
 
     Parameters
     ----------
@@ -56,8 +57,6 @@ class GUPPIFileNameSequencer(sf.FileNameSequencer):
     'puppi_58132_J1810+1744_2176.0010.raw'
     """
     def __init__(self, template, header):
-        # convert template names to upper case, since header keywords are
-        # upper case as well.
         self.items = {}
 
         def check_and_convert(x):
@@ -67,6 +66,8 @@ class GUPPIFileNameSequencer(sf.FileNameSequencer):
                 self.items[key] = header[key]
             return string
 
+        # This converts template names to upper case, since header keywords are
+        # all upper case.
         self.template = re.sub(r'{\w+[}:]', check_and_convert, template)
 
     def _process_items(self, file_nr):

--- a/baseband/guppi/base.py
+++ b/baseband/guppi/base.py
@@ -1,6 +1,7 @@
 # Licensed under the GPLv3 - see LICENSE
 from __future__ import division, unicode_literals, print_function
 
+import re
 import astropy.units as u
 from astropy.utils import lazyproperty
 
@@ -13,8 +14,65 @@ from .payload import GUPPIPayload
 from .frame import GUPPIFrame
 
 
-__all__ = ['GUPPIFileReader', 'GUPPIFileWriter', 'GUPPIStreamBase',
-           'GUPPIStreamReader', 'GUPPIStreamWriter', 'open']
+__all__ = ['GUPPIFileNameSequencer', 'GUPPIFileReader', 'GUPPIFileWriter',
+           'GUPPIStreamBase', 'GUPPIStreamReader', 'GUPPIStreamWriter', 'open']
+
+
+class GUPPIFileNameSequencer(sf.FileNameSequencer):
+    """List-like generator of GUPPI filenames using a template.
+
+    The template is formatted, filling in any items in curly brackets with
+    values from the header, as well as possibly a file number equal to the
+    indexing value, indicated with '{file_nr}'.
+
+    The length of the instance will be the number of files that exist that
+    match the template for increasing values of the file number.
+
+    Parameters
+    ----------
+    template : str
+        Template to format to get specific filenames.  Curly bracket item
+        keywords are not case-sensitive.
+    header : dict-like
+        Structure holding key'd values that are used to fill in the format.
+        Keys must be in all caps (eg. ``DATE``), as with GUPPI header keys.
+
+    Examples
+    --------
+
+    >>> from baseband import guppi
+    >>> gfs = guppi.base.GUPPIFileNameSequencer(
+    ...     '{date}_{file_nr:03d}.raw', {'DATE': "2018-01-01"})
+    >>> gfs[10]
+    '2018-01-01_010.raw'
+    >>> from baseband.data import SAMPLE_PUPPI
+    >>> with open(SAMPLE_PUPPI, 'rb') as fh:
+    ...     header = guppi.GUPPIHeader.fromfile(fh)
+    >>> template = 'puppi_{stt_imjd}_{src_name}_{scannum}.{file_nr:04d}.raw'
+    >>> gfs = guppi.base.GUPPIFileNameSequencer(template, header)
+    >>> gfs[0]
+    'puppi_58132_J1810+1744_2176.0000.raw'
+    >>> gfs[10]
+    'puppi_58132_J1810+1744_2176.0010.raw'
+    """
+    def __init__(self, template, header):
+        # convert template names to upper case, since header keywords are
+        # upper case as well.
+        self.items = {}
+
+        def check_and_convert(x):
+            string = x.group().upper()
+            key = string[1:-1]
+            if key != 'FILE_NR':
+                self.items[key] = header[key]
+            return string
+
+        self.template = re.sub(r'{\w+[}:]', check_and_convert, template)
+
+    def _process_items(self, file_nr):
+        super(GUPPIFileNameSequencer, self)._process_items(file_nr)
+        # Pop file_nr, as we need to capitalize it.
+        self.items['FILE_NR'] = self.items.pop('file_nr')
 
 
 class GUPPIFileReader(VLBIFileReaderBase):

--- a/baseband/guppi/tests/test_guppi.py
+++ b/baseband/guppi/tests/test_guppi.py
@@ -9,6 +9,7 @@ import astropy.units as u
 from astropy.tests.helper import catch_warnings
 from ... import guppi
 from ...helpers import sequentialfile as sf
+from ..base import GUPPIFileNameSequencer
 from ...data import SAMPLE_PUPPI as SAMPLE_FILE
 
 
@@ -584,3 +585,17 @@ class TestGUPPI(object):
             fn.seek(1231)
             new_data = fn.read(47)
             assert np.all(new_data == data[1231:1231 + 47])
+
+
+class TestGUPPIFileNameSequencer(object):
+    def setup(self):
+        with open(SAMPLE_FILE, 'rb') as fh:
+            self.header = guppi.GUPPIHeader.fromfile(fh)
+
+    def test_header_extraction(self):
+        # Follow Nikhil's J1810 Arecibo observation file naming scheme:
+        # puppi_58132_J1810+1744_2176.0000.raw, etc.
+        template = 'puppi_{stt_imjd}_{src_name}_{scannum}.{file_nr:04d}.raw'
+        fns = GUPPIFileNameSequencer(template, self.header)
+        assert fns[0] == 'puppi_58132_J1810+1744_2176.0000.raw'
+        assert fns[29] == 'puppi_58132_J1810+1744_2176.0029.raw'

--- a/baseband/helpers/sequentialfile.py
+++ b/baseband/helpers/sequentialfile.py
@@ -3,12 +3,92 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import io
+import os
+import re
 import itertools
 from bisect import bisect
 import numpy as np
 from astropy.utils import lazyproperty
 
-__all__ = ['SequentialFileReader', 'SequentialFileWriter', 'open']
+__all__ = ['FileNameSequencer', 'SequentialFileReader', 'SequentialFileWriter',
+           'open']
+
+
+class FileNameSequencer(object):
+    """List-like generator of filenames using a template.
+
+    The template is formatted, filling in any items in curly brackets with
+    values from the header.  It is additionally possible to insert a file
+    number equal to the indexing value, indicated with '{file_nr}', and the
+    header time in ISO 8601 format, excluding fractions of a second, indicated
+    with '{header_time}'.
+
+    The length of the instance will be the number of files that exist
+    that match the template for increasing values of the file number.
+
+    Parameters
+    ----------
+    template : str
+        Template to format to get specific filenames.  Curly bracket item
+        keywords are case-sensitive (eg. '{FRAME_NR}' or '{Frame_NR}' will not
+        use ``header['frame_nr']``.
+    header : dict-like
+        Structure holding key'd values that are used to fill in the format.
+
+    Examples
+    --------
+
+    >>> from baseband import vdif
+    >>> from baseband.helpers import sequentialfile as sf
+    >>> vfs = sf.FileNameSequencer('a{file_nr:03d}.vdif', {})
+    >>> vfs[10]
+    'a010.vdif'
+    >>> vfs = sf.FileNameSequencer(
+    ...     'obs{YEAR}_{file_nr:03d}.vdif', {'YEAR': "2018"})
+    >>> vfs[10]
+    'obs2018_010.vdif'
+    >>> from baseband.data import SAMPLE_VDIF
+    >>> with vdif.open(SAMPLE_VDIF, 'rb') as fh:
+    ...     header = vdif.VDIFHeader.fromfile(fh)
+    >>> template = 'obs.edv{edv:d}.{header_time}.{file_nr:05d}.vdif'
+    >>> vfs = sf.FileNameSequencer(template, header)
+    >>> vfs[10]
+    'obs.edv3.2014-06-16T05:56:07.00010.vdif'
+    """
+    def __init__(self, template, header):
+        # convert template names to upper case, since header keywords are
+        # upper case as well.
+        self.items = {}
+
+        def check_and_convert(x):
+            string = x.group()
+            key = string[1:-1]
+            if key == 'header_time':
+                self.items[key] = header.time.isot.split(".")[0]
+            elif key != 'file_nr':
+                self.items[key] = header[key]
+            return string
+
+        self.template = re.sub(r'{\w+[}:]', check_and_convert, template)
+
+    def _process_items(self, file_nr):
+        if file_nr < 0:
+            file_nr += len(self)
+            if file_nr < 0:
+                raise IndexError('file number out of range.')
+
+        self.items['file_nr'] = file_nr
+
+    def __getitem__(self, file_nr):
+        self._process_items(file_nr)
+        return self.template.format(**self.items)
+
+    def __len__(self):
+        file_nr = 0
+        while os.path.isfile(self[file_nr]):
+            file_nr += 1
+
+        return file_nr
 
 
 class SequentialFileBase(object):

--- a/baseband/helpers/tests/test_sequentialfile.py
+++ b/baseband/helpers/tests/test_sequentialfile.py
@@ -306,15 +306,13 @@ class TestFileNameSequencer(object):
         assert fns2[13] == 'python_13'
 
         with pytest.raises(KeyError):
-            sf.FileNameSequencer('{SNAKE:06d}.x', {'PYTHON': 10})
+            sf.FileNameSequencer('{snake:06d}.x', {'SNAKE': 10})
 
     def test_header_extraction(self):
-        # Follow the typical naming scheme:
-        # 2016-04-23-07:29:30_0000000000000000.000000.dada
-        template = 'x.v{vdif_version}.{header_time}.{file_nr:05d}.vdif'
+        template = 'x.edv{edv}.stn_{station_id}.{file_nr:05d}.vdif'
         fns = sf.FileNameSequencer(template, self.header)
-        assert fns[0] == 'x.v1.2014-06-16T05:56:07.00000.vdif'
-        assert fns[133] == 'x.v1.2014-06-16T05:56:07.00133.vdif'
+        assert fns[0] == 'x.edv3.stn_65532.00000.vdif'
+        assert fns[133] == 'x.edv3.stn_65532.00133.vdif'
 
     def test_len(self, tmpdir):
         template = str(tmpdir.join('a{file_nr}.bin'))


### PR DESCRIPTION
Create a base `helpers.sequentialfile.FileNameSequencer` for all formats, with `DADAFileNameSequencer` and `GUPPIFileNameSequencer` as subclasses.

This is the first step of several to add list and sequentialfile object support for VLBI formats, and further generalize `open`.

Partly addresses #231.