### PR TITLE
Sequential file support openers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,16 @@
+1.2 (unreleased)
+================
+
+New Features
+------------
+
+- Expanded support for acccessing sequences of files to VLBI format
+  openers and `baseband.open`.  Enabled `baseband.guppi.open` to open file
+  sequences using string templates like with `baseband.dada.open`. [#254]
+
+- Created `baseband.helpers.FileNameSequencer`, a general-purpose
+  filename sequencer that can be passed to any format opener. [#253]
+
 1.1.1 (unreleased)
 ==================
 

--- a/baseband/core.py
+++ b/baseband/core.py
@@ -48,10 +48,6 @@ def file_info(name, format=FILE_FORMATS, **kwargs):
       - ``consistent_kwargs``: not needed to open the file, but consistent.
       - ``inconsistent_kwargs``: not needed to open the file, and inconsistent.
       - ``irrelevant_kwargs``: provide information irrelevant for opening.
-
-    Instead of a file handle or name, one may pass in a
-    `~baseband.helpers.sequentialfile` object (opened in 'rb' mode for reading
-    or 'w+b' for writing) containing filenames.  For writing, .
     """
 
     # Handle lists and tuples of files, which may be passed from open.
@@ -166,7 +162,9 @@ def open(name, mode='rs', format=FILE_FORMATS, **kwargs):
     Parameters
     ----------
     name : str or filehandle, or sequence of str
-        File name, filehandle, or sequence of file names.
+        File name, filehandle, or sequence of file names.  A sequence may be a
+        list or str of ordered filenames, or an instance of
+        `~baseband.helpers.sequentialfile.FileNameSequencer`.
     mode : {'rb', 'wb', 'rs', or 'ws'}, optional
         Whether to open for reading or writing, and as a regular binary
         file or as a stream. Default: 'rs', for reading a stream.

--- a/baseband/core.py
+++ b/baseband/core.py
@@ -1,8 +1,9 @@
 # Licensed under the GPLv3 - see LICENSE
 """Routines to obtain information on baseband files."""
 import importlib
-
 import numpy as np
+
+from .helpers import sequentialfile as sf
 
 __all__ = ['file_info', 'open']
 
@@ -20,8 +21,9 @@ def file_info(name, format=FILE_FORMATS, **kwargs):
 
     Parameters
     ----------
-    name : str or filehandle
-        Raw file for which to obtain information.
+    name : str or filehandle, or sequence of str
+        Raw file for which to obtain information.  If a sequence of files is
+        passed, returns information from the first file (see Notes).
     format : str, tuple of str, optional
         Formats to try.  If not given, try all standard formats.
     **kwargs
@@ -46,8 +48,17 @@ def file_info(name, format=FILE_FORMATS, **kwargs):
       - ``consistent_kwargs``: not needed to open the file, but consistent.
       - ``inconsistent_kwargs``: not needed to open the file, and inconsistent.
       - ``irrelevant_kwargs``: provide information irrelevant for opening.
+
+    Instead of a file handle or name, one may pass in a
+    `~baseband.helpers.sequentialfile` object (opened in 'rb' mode for reading
+    or 'w+b' for writing) containing filenames.  For writing, .
     """
-    if isinstance(format, tuple):
+
+    # Handle lists and tuples of files, which may be passed from open.
+    if isinstance(name, (tuple, list, sf.FileNameSequencer)):
+        return file_info(name[0], format, **kwargs)
+    # If we're looking at one file but multiple formats, cycle through formats.
+    elif isinstance(format, tuple):
         for format_ in format:
             info = file_info(name, format_, **kwargs)
             if info:
@@ -145,7 +156,7 @@ def file_info(name, format=FILE_FORMATS, **kwargs):
 
 
 def open(name, mode='rs', format=FILE_FORMATS, **kwargs):
-    """Open a baseband file for reading or writing.
+    """Open a baseband file (or sequence of files) for reading or writing.
 
     Opened as a binary file, one gets a wrapped filehandle that adds
     methods to read/write a frame.  Opened as a stream, the handle is
@@ -154,8 +165,8 @@ def open(name, mode='rs', format=FILE_FORMATS, **kwargs):
 
     Parameters
     ----------
-    name : str or filehandle
-        File name or handle.
+    name : str or filehandle, or sequence of str
+        File name, filehandle, or sequence of file names.
     mode : {'rb', 'wb', 'rs', or 'ws'}, optional
         Whether to open for reading or writing, and as a regular binary
         file or as a stream. Default: 'rs', for reading a stream.

--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -469,8 +469,9 @@ def open(name, mode='rs', **kwargs):
 
             elif is_template:
                 # Store parameters to pass.
-                passed_kwargs = {key: kwargs[key] for key in kwargs.keys()
-                                 if key in ('squeeze', 'subset', 'verify')}
+                passed_kwargs = {key: kwargs.pop(key) for key in
+                                 ('squeeze', 'subset', 'verify')
+                                 if key in kwargs}
                 kwargs = {key.upper(): value for key, value in kwargs.items()}
 
                 # If obs_offset is needed, make a temporary file sequence to

--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -421,12 +421,13 @@ Filehandle
 
 Notes
 -----
-For streams, one can also pass in a list of files, or a template string that
-can be formatted using 'frame_nr', 'obs_offset', and other header keywords
-(by `~baseband.dada.base.DADAFileNameSequencer`).
+For streams, one can also pass to ``name`` a list of files, or a template
+string that can be formatted using 'frame_nr', 'obs_offset', and other header
+keywords (by `~baseband.dada.base.DADAFileNameSequencer`).
 
 For writing, one can mimic what is done at quite a few telescopes by using
-the template '{utc_start}_{obs_offset:016d}.000000.dada'.
+the template '{utc_start}_{obs_offset:016d}.000000.dada'.  Unlike for the VLBI
+openers, ``file_size`` is set to the size of one frame as given by the header.
 
 For reading, to read series such as the above, use something like
 '2013-07-02-01:37:40_{obs_offset:016d}.000000.dada'.  Note that here we

--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -65,7 +65,7 @@ class DADAFileNameSequencer(sf.FileNameSequencer):
     >>> dfs[10]
     '2013-07-02-01:37:40.0000006400640000.000000.dada'
     """
-    def __init__(self, template, header):
+    def __init__(self, template, header={}):
         self.items = {}
 
         def check_and_convert(x):

--- a/baseband/dada/tests/test_dada.py
+++ b/baseband/dada/tests/test_dada.py
@@ -471,7 +471,7 @@ class TestDADA(object):
         header.payload_nbytes = self.header.payload_nbytes // 2
         filenames = (str(tmpdir.join('a.dada')),
                      str(tmpdir.join('b.dada')))
-        with dada.open(filenames, 'ws', header0=header) as fw:
+        with dada.open(filenames, 'ws', **header) as fw:
             start_time = fw.start_time
             fw.write(data[:1000])
             time1000 = fw.time
@@ -502,10 +502,18 @@ class TestDADA(object):
                 dada.open(fraw, 'ws', header0=header) as fw:
             fw.write(data)
 
-        with sf.open(filenames, 'rb') as fraw, \
-                dada.open(fraw, 'rs') as fr:
+        with dada.open(filenames, 'rs') as fr:
             data3 = fr.read()
         assert np.all(data3 == data)
+
+        # Test subsetting.
+        with dada.open(filenames, 'rs', subset=1) as fr:
+            data4 = fr.read()
+        assert np.all(data4 == data[:, 1])
+
+        # Check that we can't pass a filename sequence in 'wb' mode.
+        with pytest.raises(ValueError):
+            dada.open(filenames, 'wb')
 
     def test_partial_last_frame(self, tmpdir):
         """Test reading an incomplete frame from one or a sequence of files."""

--- a/baseband/dada/tests/test_dada.py
+++ b/baseband/dada/tests/test_dada.py
@@ -506,10 +506,10 @@ class TestDADA(object):
             data3 = fr.read()
         assert np.all(data3 == data)
 
-        # Test subsetting.
-        with dada.open(filenames, 'rs', subset=1) as fr:
+        # Test passing stream reader kwargs.
+        with dada.open(filenames, 'rs', subset=1, squeeze=False) as fr:
             data4 = fr.read()
-        assert np.all(data4 == data[:, 1])
+        assert np.all(data4.squeeze() == data[:, 1])
 
         # Check that we can't pass a filename sequence in 'wb' mode.
         with pytest.raises(ValueError):

--- a/baseband/guppi/base.py
+++ b/baseband/guppi/base.py
@@ -1,7 +1,9 @@
 # Licensed under the GPLv3 - see LICENSE
 from __future__ import division, unicode_literals, print_function
-
+import io
 import re
+
+from astropy.extern import six
 import astropy.units as u
 from astropy.utils import lazyproperty
 
@@ -369,52 +371,77 @@ Filehandle
     :class:`~baseband.guppi.base.GUPPIFileWriter` (binary), or
     :class:`~baseband.guppi.base.GUPPIStreamReader` or
     :class:`~baseband.guppi.base.GUPPIStreamWriter` (stream).
+
+Notes
+-----
+For streams, one can also pass in a list of files, or a template string that
+can be formatted using 'stt_imjd', 'src_name', and other header keywords
+(by `~baseband.dada.base.GUPPIFileNameSequencer`).
+
+For writing, one can mimic, for example, what is done at Arecibo by using
+the template 'puppi_{stt_imjd}_{src_name}_{scannum}.{file_nr:04d}.raw'.  GUPPI
+typically has 128 frames per file; to change this, use the ``frames_per_file``
+keyword.
+
+For reading, to read series such as the above, you will need to use something
+like 'puppi_58132_J1810+1744_2176.{file_nr:04d}.raw'.  Here we have to pass in
+the MJD, source name and scan number explicitly, since the template is used to
+get the first file name, before any header is read, and therefore the only
+keyword available is file_nr', which is assumed to be zero for the first file.
+To avoid this restriction, pass in keyword arguments with values appropriate
+for the first file.
+
+One may also pass in a `~baseband.helpers.sequentialfile` object
+(opened in 'rb' mode for reading or 'w+b' for writing), though for typical use
+cases it is practically identical to passing in a list or template.
 """)
 
 
 # Need to wrap the opener to be able to deal with file lists or templates.
-# TODO: move this up to the opener??
 def open(name, mode='rs', **kwargs):
-    frames_per_file = kwargs.pop('frames_per_file', 128)
+    # Extract needed kwargs (and keep some from being passed to opener).
     header0 = kwargs.get('header0', None)
-    squeeze = kwargs.pop('squeeze', None)
-    # If sequentialfile object, check that it's opened properly.
-    if isinstance(name, sf.SequentialFileBase):
-        assert (('r' in mode and name.mode == 'rb') or
-                ('w' in mode and name.mode == 'w+b')), (
-                    "open only accepts sequential files opened in 'rb' mode "
-                    "for reading or 'w+b' mode for writing.")
-    is_sequence = isinstance(name, (tuple, list))
+    frames_per_file = kwargs.pop('frames_per_file', 128)
 
+    # Check if ``name`` is a template or sequence.
+    is_template = isinstance(name, six.string_types) and ('{' in name and
+                                                          '}' in name)
+    is_sequence = isinstance(name, (tuple, list, sf.FileNameSequencer))
+
+    # For stream writing, header0 is needed; for reading, it is needed for
+    # initializing a template only.
     if 'b' not in mode:
+        # Initialize header0 if it doesn't yet exist.
         if header0 is None:
             if 'w' in mode:
-                # For writing a header is required.
+                # Store squeeze.
+                passed_kwargs = ({'squeeze': kwargs.pop('squeeze')}
+                                 if 'squeeze' in kwargs.keys() else {})
+                # Make header0.
                 header0 = GUPPIHeader.fromvalues(**kwargs)
-                kwargs = {}
-            else:
-                header0 = {}
+                # Pass squeeze and header0 on to stream writer.
+                kwargs = passed_kwargs
+                kwargs['header0'] = header0
 
-        if is_sequence:
-            if 'r' in mode:
-                name = sf.open(name, 'rb')
-            else:
-                name = sf.open(name, 'w+b', file_size=(
-                    frames_per_file * header0.frame_nbytes))
+            elif is_template:
+                # Store parameters to pass.
+                passed_kwargs = {key: kwargs[key] for key in kwargs.keys()
+                                 if key in ('squeeze', 'subset', 'verify')}
+                header0 = {key.upper(): value for key, value in kwargs.items()}
+                kwargs = passed_kwargs
 
-        if header0 and 'w' in mode:
-            kwargs['header0'] = header0
+        if is_template:
+            name = GUPPIFileNameSequencer(name, header0)
 
-    if squeeze is not None:
-        kwargs['squeeze'] = squeeze
+    # If writing with a template or sequence, pass ``file_size``.
+    if 'w' in mode and (is_template or is_sequence):
+        if 'b' in mode:
+            raise ValueError("does not support opening a file sequence in "
+                             "'wb' mode.  Try passing in a SequentialFile "
+                             "object instead.")
+        kwargs['file_size'] = frames_per_file * header0.frame_nbytes
 
     return opener(name, mode, **kwargs)
 
 
-open.__doc__ = opener.__doc__ + """\n
-Notes
------
-For streams, one can also pass in a list of files, or equivalently a
-`~baseband.helpers.sequentialfile` object (opened in 'rb' mode for reading or
-'w+b' for writing).
-"""
+open.__doc__ = opener.__doc__

--- a/baseband/guppi/base.py
+++ b/baseband/guppi/base.py
@@ -58,7 +58,7 @@ class GUPPIFileNameSequencer(sf.FileNameSequencer):
     >>> gfs[10]
     'puppi_58132_J1810+1744_2176.0010.raw'
     """
-    def __init__(self, template, header):
+    def __init__(self, template, header={}):
         self.items = {}
 
         def check_and_convert(x):

--- a/baseband/guppi/base.py
+++ b/baseband/guppi/base.py
@@ -425,8 +425,9 @@ def open(name, mode='rs', **kwargs):
 
             elif is_template:
                 # Store parameters to pass.
-                passed_kwargs = {key: kwargs[key] for key in kwargs.keys()
-                                 if key in ('squeeze', 'subset', 'verify')}
+                passed_kwargs = {key: kwargs.pop(key) for key in
+                                 ('squeeze', 'subset', 'verify')
+                                 if key in kwargs}
                 header0 = {key.upper(): value for key, value in kwargs.items()}
                 kwargs = passed_kwargs
 

--- a/baseband/guppi/base.py
+++ b/baseband/guppi/base.py
@@ -1,6 +1,5 @@
 # Licensed under the GPLv3 - see LICENSE
 from __future__ import division, unicode_literals, print_function
-import io
 import re
 
 from astropy.extern import six
@@ -374,20 +373,20 @@ Filehandle
 
 Notes
 -----
-For streams, one can also pass in a list of files, or a template string that
-can be formatted using 'stt_imjd', 'src_name', and other header keywords
-(by `~baseband.dada.base.GUPPIFileNameSequencer`).
+For streams, one can also pass to ``name`` a list of files, or a template
+string that can be formatted using 'stt_imjd', 'src_name', and other header
+keywords (by `~baseband.dada.base.GUPPIFileNameSequencer`).
 
 For writing, one can mimic, for example, what is done at Arecibo by using
 the template 'puppi_{stt_imjd}_{src_name}_{scannum}.{file_nr:04d}.raw'.  GUPPI
 typically has 128 frames per file; to change this, use the ``frames_per_file``
-keyword.
+keyword.  ``file_size`` is set by ``frames_per_file`` and cannot be passed.
 
 For reading, to read series such as the above, you will need to use something
 like 'puppi_58132_J1810+1744_2176.{file_nr:04d}.raw'.  Here we have to pass in
 the MJD, source name and scan number explicitly, since the template is used to
 get the first file name, before any header is read, and therefore the only
-keyword available is file_nr', which is assumed to be zero for the first file.
+keyword available is 'file_nr', which is assumed to be zero for the first file.
 To avoid this restriction, pass in keyword arguments with values appropriate
 for the first file.
 

--- a/baseband/guppi/tests/test_guppi.py
+++ b/baseband/guppi/tests/test_guppi.py
@@ -610,7 +610,7 @@ class TestGUPPI(object):
         assert np.all(data2 == data)
 
         # More complex template that requires keywords.
-        template = 'puppi_{stt_imjd}.{file_nr:04d}.raw'
+        template = str(tmpdir.join('puppi_{stt_imjd}.{file_nr:04d}.raw'))
         with guppi.open(template, 'ws', frames_per_file=1,
                         header0=self.header_w) as fw:
             fw.write(data[:1920])

--- a/baseband/guppi/tests/test_guppi.py
+++ b/baseband/guppi/tests/test_guppi.py
@@ -533,6 +533,17 @@ class TestGUPPI(object):
             assert np.abs(fr.time - fr.stop_time) < 1. * u.ns
         assert np.all(data2 == data)
 
+        # Pass sequentialfile objects to reader.
+        with sf.open(filenames, 'w+b',
+                     file_size=2*self.header_w.frame_nbytes) as fraw, \
+                guppi.open(fraw, 'ws', header0=self.header_w) as fw:
+            fw.write(data)
+
+        with sf.open(filenames, 'rb') as fraw, \
+                guppi.open(fraw, 'rs') as fr:
+            data3 = fr.read()
+        assert np.all(data3 == data)
+
         # Check that we can't pass a filename sequence in 'wb' mode.
         with pytest.raises(ValueError):
             guppi.open(filenames, 'wb')
@@ -620,11 +631,11 @@ class TestGUPPI(object):
             data3 = fr.read()
         assert np.all(data3 == data)
 
-        # Try subsetting.
-        with guppi.open(template, 'rs', subset=(0, [2, 3]),
+        # Try passing stream reader kwargs.
+        with guppi.open(template, 'rs', subset=(0, [2, 3]), squeeze=False,
                         **kwargs) as fr:
             data4 = fr.read()
-        assert np.all(data4 == data[:, 0, 2:])
+        assert np.all(data4.squeeze() == data[:, 0, 2:])
 
         # Just to check internal checks are OK.
         filename = template.format(stt_imjd=self.header_w['STT_IMJD'],

--- a/baseband/guppi/tests/test_guppi.py
+++ b/baseband/guppi/tests/test_guppi.py
@@ -503,8 +503,8 @@ class TestGUPPI(object):
         start_time = self.header_w.time
         with guppi.open(SAMPLE_FILE, 'rs') as fh:
             data = fh.read()
-        filenames = (str(tmpdir.join('guppi_a.raw')),
-                     str(tmpdir.join('guppi_b.raw')))
+        filenames = (str(tmpdir.join('guppi_1.raw')),
+                     str(tmpdir.join('guppi_2.raw')))
         with guppi.open(filenames, 'ws', header0=self.header_w,
                         frames_per_file=2) as fw:
             start_time = fw.start_time
@@ -533,16 +533,9 @@ class TestGUPPI(object):
             assert np.abs(fr.time - fr.stop_time) < 1. * u.ns
         assert np.all(data2 == data)
 
-        # Pass sequentialfile objects to reader.
-        with sf.open(filenames, 'w+b',
-                     file_size=(2 * self.header_w.frame_nbytes)) as fraw, \
-                guppi.open(fraw, 'ws', header0=self.header_w) as fw:
-            fw.write(data)
-
-        with sf.open(filenames, 'rb') as fraw, \
-                guppi.open(fraw, 'rs') as fr:
-            data3 = fr.read()
-        assert np.all(data3 == data)
+        # Check that we can't pass a filename sequence in 'wb' mode.
+        with pytest.raises(ValueError):
+            guppi.open(filenames, 'wb')
 
     def test_partial_last_frame(self, tmpdir):
         """Test reading a file with an incomplete last frame."""
@@ -585,6 +578,62 @@ class TestGUPPI(object):
             fn.seek(1231)
             new_data = fn.read(47)
             assert np.all(new_data == data[1231:1231 + 47])
+
+    def test_template_stream(self, tmpdir):
+        start_time = self.header_w.time
+        with guppi.open(SAMPLE_FILE, 'rs') as fh:
+            data = fh.read()
+
+        # Simple template with file number counter.
+        template = str(tmpdir.join('guppi_{file_nr:02d}.raw'))
+        with guppi.open(template, 'ws', frames_per_file=1,
+                        **self.header_w) as fw:
+            fw.write(data)
+
+        with guppi.open(template, 'rs') as fr:
+            assert len(fr.fh_raw.files) == 4
+            assert fr.fh_raw.files[-1] == str(tmpdir.join('guppi_03.raw'))
+            assert np.abs(fr.stop_time -
+                          (start_time + 3840 / (250 * u.Hz))) < 1.*u.ns
+            data2 = fr.read()
+        assert np.all(data2 == data)
+
+        # More complex template that requires keywords.
+        template = 'puppi_{stt_imjd}.{file_nr:04d}.raw'
+        with guppi.open(template, 'ws', frames_per_file=1,
+                        header0=self.header_w) as fw:
+            fw.write(data[:1920])
+            assert fw.start_time == start_time
+            assert (np.abs(fw.time - (start_time + 1920 / (250 * u.Hz))) <
+                    1. * u.ns)
+            fw.write(data[1920:])
+            assert (np.abs(fw.time - (start_time + 3840 / (250 * u.Hz))) <
+                    1. * u.ns)
+
+        # We cannot just open using the same template, since STT_IMJD is
+        # not available.
+        with pytest.raises(KeyError):
+            guppi.open(template, 'rs')
+
+        kwargs = dict(STT_IMJD=self.header_w['STT_IMJD'])
+        with guppi.open(template, 'rs', **kwargs) as fr:
+            data3 = fr.read()
+        assert np.all(data3 == data)
+
+        # Try subsetting.
+        with guppi.open(template, 'rs', subset=(0, [2, 3]),
+                        **kwargs) as fr:
+            data4 = fr.read()
+        assert np.all(data4 == data[:, 0, 2:])
+
+        # Just to check internal checks are OK.
+        filename = template.format(stt_imjd=self.header_w['STT_IMJD'],
+                                   file_nr=0)
+        with pytest.raises(ValueError):
+            guppi.open(filename, 's')
+        with pytest.raises(TypeError):
+            # Extraneous argument.
+            guppi.open(filename, 'rs', files=(filename,))
 
 
 class TestGUPPIFileNameSequencer(object):

--- a/baseband/helpers/sequentialfile.py
+++ b/baseband/helpers/sequentialfile.py
@@ -39,7 +39,7 @@ class FileNameSequencer(object):
 
     >>> from baseband import vdif
     >>> from baseband.helpers import sequentialfile as sf
-    >>> vfs = sf.FileNameSequencer('a{file_nr:03d}.vdif', {})
+    >>> vfs = sf.FileNameSequencer('a{file_nr:03d}.vdif')
     >>> vfs[10]
     'a010.vdif'
     >>> from baseband.data import SAMPLE_VDIF
@@ -49,7 +49,7 @@ class FileNameSequencer(object):
     >>> vfs[10]
     'obs.edv3.00010.vdif'
     """
-    def __init__(self, template, header):
+    def __init__(self, template, header={}):
         self.items = {}
 
         def check_and_convert(x):

--- a/baseband/helpers/tests/test_sequentialfile.py
+++ b/baseband/helpers/tests/test_sequentialfile.py
@@ -299,7 +299,7 @@ class TestFileNameSequencer(object):
             self.header = vdif.VDIFHeader.fromfile(fh)
 
     def test_enumeration(self):
-        fns1 = sf.FileNameSequencer('x{file_nr:03d}.vdif', {})
+        fns1 = sf.FileNameSequencer('x{file_nr:03d}.vdif')
         assert fns1[0] == 'x000.vdif'
         assert fns1[107] == 'x107.vdif'
         fns2 = sf.FileNameSequencer('{SNAKE}_{file_nr}', {'SNAKE': 'python'})
@@ -316,7 +316,7 @@ class TestFileNameSequencer(object):
 
     def test_len(self, tmpdir):
         template = str(tmpdir.join('a{file_nr}.bin'))
-        fns = sf.FileNameSequencer(template, {})
+        fns = sf.FileNameSequencer(template)
         for i in range(5):
             assert len(fns) == i
             filename = fns[i]

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -509,7 +509,7 @@ squeeze : bool, optional
     If `True` (default), writer accepts squeezed arrays as input, and adds
     any dimensions of length unity.
 file_size : int or None, optional
-    When writing to a sequence of files, the size of one file in bytes.
+    When writing to a sequence of files, the maximum size of one file in bytes.
     If `None` (default), the file size is unlimited, and only the first
     file will be written to.
 **kwargs
@@ -528,7 +528,7 @@ Filehandle
 Notes
 -----
 Although it is not generally expected to be useful for Mark 4, like for
-other formats one can also pass in a list, tuple, or subclass of
+other formats one can also pass to ``name`` a list, tuple, or subclass of
 `~baseband.helpers.sequentialfile.FileNameSequencer`.  For writing to multiple
 files, the ``file_size`` keyword must be passed or only the first file will be
 written to.  One may also pass in a `~baseband.helpers.sequentialfile` object

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -508,6 +508,10 @@ sample_rate : `~astropy.units.Quantity`
 squeeze : bool, optional
     If `True` (default), writer accepts squeezed arrays as input, and adds
     any dimensions of length unity.
+file_size : int or None, optional
+    When writing to a sequence of files, the size of one file in bytes.
+    If `None` (default), the file size is unlimited, and only the first
+    file will be written to.
 **kwargs
     If the header is not given, an attempt will be made to construct one
     with any further keyword arguments.  See
@@ -520,4 +524,13 @@ Filehandle
     :class:`~baseband.mark4.base.Mark4FileWriter` (binary), or
     :class:`~baseband.mark4.base.Mark4StreamReader` or
     :class:`~baseband.mark4.base.Mark4StreamWriter` (stream)
+
+Notes
+-----
+One can also pass in a list, tuple, or subclass of
+`~baseband.helpers.sequentialfile.FileNameSequencer`.  For writing to multiple
+files, the ``file_size`` keyword must be passed or only the first file will be
+written to.  One may also pass in a `~baseband.helpers.sequentialfile` object
+(opened in 'rb' mode for reading or 'w+b' for writing), though for typical use
+cases it is practically identical to passing in a list or template.
 """)

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -527,7 +527,8 @@ Filehandle
 
 Notes
 -----
-One can also pass in a list, tuple, or subclass of
+Although it is not generally expected to be useful for Mark 4, like for
+other formats one can also pass in a list, tuple, or subclass of
 `~baseband.helpers.sequentialfile.FileNameSequencer`.  For writing to multiple
 files, the ``file_size`` keyword must be passed or only the first file will be
 written to.  One may also pass in a `~baseband.helpers.sequentialfile` object

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -440,6 +440,10 @@ bps : int, optional
 squeeze : bool, optional
     If `True` (default), writer accepts squeezed arrays as input,
     and adds channel and thread dimensions if they have length unity.
+file_size : int or None, optional
+    When writing to a sequence of files, the size of one file in bytes.
+    If `None` (default), the file size is unlimited, and only the first
+    file will be written to.
 **kwargs
     If no header is given, an attempt is made to construct one with any further
     keyword arguments.  See :class:`~baseband.mark5b.base.Mark5BStreamWriter`.
@@ -451,4 +455,13 @@ Filehandle
     :class:`~baseband.mark5b.base.Mark5BFileWriter` (binary), or
     :class:`~baseband.mark5b.base.Mark5BStreamReader` or
     :class:`~baseband.mark5b.base.Mark5BStreamWriter` (stream).
+
+Notes
+-----
+One can also pass in a list, tuple, or subclass of
+`~baseband.helpers.sequentialfile.FileNameSequencer`.  For writing to multiple
+files, the ``file_size`` keyword must be passed or only the first file will be
+written to.  One may also pass in a `~baseband.helpers.sequentialfile` object
+(opened in 'rb' mode for reading or 'w+b' for writing), though for typical use
+cases it is practically identical to passing in a list or template.
 """)

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -441,7 +441,7 @@ squeeze : bool, optional
     If `True` (default), writer accepts squeezed arrays as input,
     and adds channel and thread dimensions if they have length unity.
 file_size : int or None, optional
-    When writing to a sequence of files, the size of one file in bytes.
+    When writing to a sequence of files, the maximum size of one file in bytes.
     If `None` (default), the file size is unlimited, and only the first
     file will be written to.
 **kwargs
@@ -458,7 +458,7 @@ Filehandle
 
 Notes
 -----
-One can also pass in a list, tuple, or subclass of
+One can also pass to ``name`` a list, tuple, or subclass of
 `~baseband.helpers.sequentialfile.FileNameSequencer`.  For writing to multiple
 files, the ``file_size`` keyword must be passed or only the first file will be
 written to.  One may also pass in a `~baseband.helpers.sequentialfile` object

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -694,11 +694,11 @@ class TestMark5B(object):
             header = fh.header0.copy()
             data = fh.read()
             dtime = fh.stop_time - fh.start_time
-        data = np.r_[data, data, data, data, data]
+        data = np.concatenate((data, data, data, data, data))
 
         # Create a file sequence using template.
         files = [str(tmpdir.join('f.{0:03d}.m5b'.format(x))) for x in range(5)]
-        with mark5b.open(files, 'ws', file_size=(4 * header.frame_nbytes),
+        with mark5b.open(files, 'ws', file_size=4*header.frame_nbytes,
                          sample_rate=32*u.MHz, nchan=8, kday=56000,
                          **header) as fw:
             fw.write(data)

--- a/baseband/tests/test_core.py
+++ b/baseband/tests/test_core.py
@@ -84,13 +84,14 @@ def test_open_sequence(tmpdir):
         assert np.all(fn.read() == data1)
 
     # Open VDIF file sequence by passing a FileNameSequencer.
-    files = sf.FileNameSequencer('f{file_nr:03d}.vdif', {})
+    files = sf.FileNameSequencer('f{file_nr:03d}.vdif')
     with baseband_open(SAMPLE_VDIF) as fh:
         data2 = fh.read()
         header2 = fh.header0.copy()
 
+    # Sample file has 2 framesets of 8 frames each.
     with baseband_open(files, 'ws', format='vdif', nthread=8,
-                       file_size=(8 * header2.frame_nbytes), **header2) as fw:
+                       file_size=8*header2.frame_nbytes, **header2) as fw:
         fw.write(data2)
 
     # Can't check header0 because frameset might be out of order.

--- a/baseband/tests/test_core.py
+++ b/baseband/tests/test_core.py
@@ -3,10 +3,12 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import pytest
+import numpy as np
 from astropy.time import Time
 import astropy.units as u
 
 from .. import open as baseband_open, file_info
+from ..helpers import sequentialfile as sf
 from ..data import (SAMPLE_MARK4 as SAMPLE_M4, SAMPLE_MARK5B as SAMPLE_M5B,
                     SAMPLE_VDIF, SAMPLE_MWA_VDIF as SAMPLE_MWA, SAMPLE_DADA)
 
@@ -61,6 +63,41 @@ def test_open_wrong_args():
     with pytest.raises(ValueError) as exc:  # inconsistent nchan.
         baseband_open(SAMPLE_DADA, 'rs', nchan=8)
     assert "inconsistent" in str(exc.value)
+
+
+def test_open_sequence(tmpdir):
+    """Test opening file sequences with `baseband.open`."""
+    # Open DADA file sequence by passing a list.
+    with baseband_open(SAMPLE_DADA) as fh:
+        data1 = fh.read()
+        header1 = fh.header0.copy()
+    header1.payload_nbytes = header1.payload_nbytes // 2
+
+    files = [str(tmpdir.join('f.{0:d}.dada'.format(x))) for x in range(2)]
+    with baseband_open(files, 'ws', format='dada', header0=header1) as fw:
+        fw.write(data1)
+
+    with baseband_open(files) as fn:
+        assert fn.info.format == 'dada'
+        assert len(fn.fh_raw.files) == 2
+        assert fn.header0 == header1
+        assert np.all(fn.read() == data1)
+
+    # Open VDIF file sequence by passing a FileNameSequencer.
+    files = sf.FileNameSequencer('f{file_nr:03d}.vdif', {})
+    with baseband_open(SAMPLE_VDIF) as fh:
+        data2 = fh.read()
+        header2 = fh.header0.copy()
+
+    with baseband_open(files, 'ws', format='vdif', nthread=8,
+                       file_size=(8 * header2.frame_nbytes), **header2) as fw:
+        fw.write(data2)
+
+    # Can't check header0 because frameset might be out of order.
+    with baseband_open(files) as fn:
+        assert fn.info.format == 'vdif'
+        assert len(fn.fh_raw.files) == 2
+        assert np.all(data2 == fn.read())
 
 
 def test_open_write_checks():

--- a/baseband/tests/test_core.py
+++ b/baseband/tests/test_core.py
@@ -84,7 +84,7 @@ def test_open_sequence(tmpdir):
         assert np.all(fn.read() == data1)
 
     # Open VDIF file sequence by passing a FileNameSequencer.
-    files = sf.FileNameSequencer('f{file_nr:03d}.vdif')
+    files = sf.FileNameSequencer(str(tmpdir.join('f{file_nr:03d}.vdif')))
     with baseband_open(SAMPLE_VDIF) as fh:
         data2 = fh.read()
         header2 = fh.header0.copy()

--- a/baseband/tests/test_sequential_baseband.py
+++ b/baseband/tests/test_sequential_baseband.py
@@ -23,7 +23,7 @@ def test_sequentialfile_vdif_stream(tmpdir):
         edv=0, time=Time('2010-01-01'), nchan=2, bps=2,
         complex_data=False, frame_nr=0, thread_id=0, samples_per_frame=16,
         station='me')
-    with sequentialfile.open(vdif_sequencer, 'wb',
+    with sequentialfile.open(vdif_sequencer, 'w+b',
                              file_size=4*header.frame_nbytes) as sfh, \
             vdif.open(sfh, 'ws', header0=header, nthread=2,
                       sample_rate=256*u.Hz) as fw:

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -606,7 +606,7 @@ squeeze : bool, optional
     If `True` (default), writer accepts squeezed arrays as input, and adds any
     dimensions of length unity.
 file_size : int or None, optional
-    When writing to a sequence of files, the size of one file in bytes.
+    When writing to a sequence of files, the maximum size of one file in bytes.
     If `None` (default), the file size is unlimited, and only the first
     file will be written to.
 **kwargs
@@ -616,7 +616,7 @@ file_size : int or None, optional
 
 Notes
 -----
-One can also pass in a list, tuple, or subclass of
+One can also pass to ``name`` a list, tuple, or subclass of
 `~baseband.helpers.sequentialfile.FileNameSequencer`.  For writing to multiple
 files, the ``file_size`` keyword must be passed or only the first file will be
 written to.  One may also pass in a `~baseband.helpers.sequentialfile` object

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -605,16 +605,21 @@ nthread : int, optional
 squeeze : bool, optional
     If `True` (default), writer accepts squeezed arrays as input, and adds any
     dimensions of length unity.
+file_size : int or None, optional
+    When writing to a sequence of files, the size of one file in bytes.
+    If `None` (default), the file size is unlimited, and only the first
+    file will be written to.
 **kwargs
     If the header is not given, an attempt will be made to construct one
     with any further keyword arguments.  See
     :class:`~baseband.vdif.base.VDIFStreamWriter`.
 
-Returns
--------
-Filehandle
-    :class:`~baseband.vdif.base.VDIFFileReader` or
-    :class:`~baseband.vdif.base.VDIFFileWriter` (binary), or
-    :class:`~baseband.vdif.base.VDIFStreamReader` or
-    :class:`~baseband.vdif.base.VDIFStreamWriter` (stream).
+Notes
+-----
+One can also pass in a list, tuple, or subclass of
+`~baseband.helpers.sequentialfile.FileNameSequencer`.  For writing to multiple
+files, the ``file_size`` keyword must be passed or only the first file will be
+written to.  One may also pass in a `~baseband.helpers.sequentialfile` object
+(opened in 'rb' mode for reading or 'w+b' for writing), though for typical use
+cases it is practically identical to passing in a list or template.
 """)

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -9,6 +9,7 @@ import astropy.units as u
 from astropy.tests.helper import catch_warnings
 
 from ... import vdif, vlbi_base
+from ...helpers import sequentialfile as sf
 from ...data import (SAMPLE_VDIF as SAMPLE_FILE, SAMPLE_VLBI_VDIF as
                      SAMPLE_VLBI, SAMPLE_MWA_VDIF as SAMPLE_MWA,
                      SAMPLE_AROCHIME_VDIF as SAMPLE_AROCHIME)
@@ -981,6 +982,40 @@ class TestVDIF(object):
         with pytest.raises(ValueError):
             # Missing w or r.
             vdif.open(tmp_file, 's')
+
+
+def test_sequentialfile(tmpdir):
+    """Tests writing and reading of sequential files.
+
+    These tests focus on reading and writing with templates.
+    """
+
+    # Use sample file as basis of a file sequence.
+    with vdif.open(SAMPLE_FILE, 'rs') as fh:
+        header = fh.header0.copy()
+        data = fh.read()
+        dtime = fh.stop_time - fh.start_time
+    data = np.r_[data, data, data]
+
+    # Create a file sequence using template.
+    template = str(tmpdir.join('f.{file_nr:03d}.vdif'))
+    files = sf.FileNameSequencer(template, {})
+    with vdif.open(files, 'ws', file_size=(16 * header.frame_nbytes),
+                   nthread=8, **header) as fw:
+        fw.write(data)
+
+    # Read in file-sequence and check data consistency.
+    with vdif.open(files, 'rs') as fn:
+        assert len(fn.fh_raw.files) == 3
+        assert fn.fh_raw.files[-1] == str(tmpdir.join('f.002.vdif'))
+        assert fn.header0.time == header.time
+        assert fn.stop_time - fn.start_time - 3 * dtime < 1 * u.ns
+        assert np.all(data == fn.read())
+
+    # Read in one file and check if everything makes sense.
+    with vdif.open(template.format(file_nr=2), 'rs') as fn:
+        assert fn.header0.time - header.time - 2. * dtime < 1 * u.ns
+        assert np.all(data[80000:] == fn.read())
 
 
 def test_vlbi_vdif():

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -995,12 +995,12 @@ def test_sequentialfile(tmpdir):
         header = fh.header0.copy()
         data = fh.read()
         dtime = fh.stop_time - fh.start_time
-    data = np.r_[data, data, data]
+    data = np.concatenate((data, data, data))
 
     # Create a file sequence using template.
     template = str(tmpdir.join('f.{file_nr:03d}.vdif'))
-    files = sf.FileNameSequencer(template, {})
-    with vdif.open(files, 'ws', file_size=(16 * header.frame_nbytes),
+    files = sf.FileNameSequencer(template)
+    with vdif.open(files, 'ws', file_size=16*header.frame_nbytes,
                    nthread=8, **header) as fw:
         fw.write(data)
 

--- a/docs/dada/index.rst
+++ b/docs/dada/index.rst
@@ -86,12 +86,11 @@ To set up a file for writing as a stream is possible as well::
 
 Here, we have used an even smaller size of the payload, to show how one can
 define multiple files.  DADA data are typically stored in sequences of files. 
-If, in place of a single filename, one passes a time-ordered list or tuple of
-filenames to `~baseband.dada.open`, it uses |sequentialfile.open| to read or
-write to them as a single contiguous file.  If, as above, one passes a template
-string, `~baseband.dada.open` uses `~baseband.dada.base.DADAFileNameSequencer`
-to create a subscriptable filename generator, which is then passed to
-|sequentialfile.open|.  (See API links for further details.)
+If one passes a time-ordered list or tuple of filenames to
+`~baseband.dada.open`, it uses |sequentialfile.open| to access the sequence.
+If, as above, one passes a template string, `~baseband.dada.open` uses
+`~baseband.dada.base.DADAFileNameSequencer` to create and use a filename
+sequencer.  (See API links for further details.)
 
 .. |sequentialfile.open| replace:: `sequentialfile.open <baseband.helpers.sequentialfile.open>`
 

--- a/docs/guppi/index.rst
+++ b/docs/guppi/index.rst
@@ -102,31 +102,32 @@ zero when writing (so we set ``samples_per_frame`` to its stream reader value
 from above)::
 
     >>> from astropy.time import Time
-    >>> files = ['puppi_test.000{i}.raw'.format(i=i) for i in range(2)]
-    >>> fw = guppi.open(files, 'ws', frames_per_file=2, sample_rate=250*u.Hz,
+    >>> fw = guppi.open('puppi_test.{file_nr:04d}.raw', 'ws',
+    ...                 frames_per_file=2, sample_rate=250*u.Hz,
     ...                 samples_per_frame=960, pktsize=1024,
     ...                 time=Time(58132.59135416667, format='mjd'),
     ...                 npol=2, nchan=4)
     >>> fw.write(d)
     >>> fw.close()
-    >>> fr = guppi.open(files, 'rs')
+    >>> fr = guppi.open('puppi_test.{file_nr:04d}.raw', 'rs')
     >>> d2 = fr.read()
     >>> (d == d2).all()
     True
     >>> fr.close()
 
-Here we show how we can write to a sequence of files.  One may pass a
-time-ordered list or tuple of filenames to `~baseband.guppi.open`, which then
-uses |sequentialfile.open| to read or write to them as a single contiguous
-file.  Unlike when writing DADA files, which have one frame per file, we must
-specify the number of frames in one file.  Note that typically one does not
-have to pass ``PKTSIZE``, the UDP data packet size (set by the observing mode),
-but the sample file has small enough frames that the default of 8192 bytes is
-too large.  Baseband only uses ``PKTSIZE`` to double-check the sample offset of
-the frame, so ``PKTSIZE`` must be set to a value such each payload, excluding
-overlap samples, contains an integer number of packets.
-
-.. |sequentialfile.open| replace:: `sequentialfile.open <baseband.helpers.sequentialfile.open>`
+Here we show how to write a sequence of files by passing a string template
+to `~baseband.guppi.open`, which prompts it to create and use a filename
+sequencer generated with `~baseband.guppi.base.GUPPIFileNameSequencer`.  One
+may also pass a time-ordered list or tuple of filenames to
+`~baseband.guppi.open`.  Unlike when writing DADA files, which have one frame
+per file, we specify the number of frames in one file using``frames_per_file``.
+Note that typically one does not have to pass ``PKTSIZE``, the UDP data packet
+size (set by the observing mode), but the sample file has small enough frames
+that the default of 8192 bytes is too large.  Baseband only uses ``PKTSIZE`` to
+double-check the sample offset of the frame, so ``PKTSIZE`` must be set to a
+value such that each payload, excluding overlap samples, contains an integer
+number of packets.  (See API links for further details on how to read and
+write file sequences.)
 
 .. _guppi_api:
 

--- a/docs/helpers/index.rst
+++ b/docs/helpers/index.rst
@@ -40,7 +40,7 @@ We now open a sequential file object for writing::
     >>> from baseband.helpers import sequentialfile as sf
     >>> filenames = ["seqvdif_{0}".format(i) for i in range(2)]
     >>> file_size = fh.fh_raw.seek(0, 2) // 2
-    >>> fwr = sf.open(filenames, mode='wb', file_size=file_size)
+    >>> fwr = sf.open(filenames, mode='w+b', file_size=file_size)
 
 The first argument passed to |open| must be a **time-ordered sequence** of
 filenames in a list, tuple, or other subscriptable object that returns


### PR DESCRIPTION
Reworked `vlbi_base.base.make_opener` to accept lists, tuples and `FileNameSequencer` objects for opening, adding native file sequence support for VLBI formats. Modified and expanded the wrappers for DADA and GUPPI so that both format openers can handle template strings. Made a small modification to `baseband.file_info` so that `baseband.open` can read the same file sequence formats.

A few minor features and bugfixes:
- It is now possible to pass all stream reader and writer kwargs to the DADA opener; before, 'subset' and 'verify' could not be passed with a template string.
- It is now possible to pass a template string to the DADA opener in 'rs' mode that uses header properties (like 'utc_time'), but not 'obs_offset'.
- For VLBI formats, it is possible to open an iterable of filenames in 'wb' mode. So as not to overcomplicate the header setting process, it's now explicitly disallowed for DADA and GUPPI.
- All opener sections have notes about opening file sequences. Moved the notes for DADA and GUPPI to when making `opener` rather than defining `open`.  This is not entirely appropriate, but now that `make_opener` adds sequential file functionality the distinction between `opener` and `open` can't be cleanly separated in the docstring.

I still need to revise the documentation and add a note in the changelog, and will do those once the code design has been accepted.

We should also decide if this becomes (part of) a 1.2 release.

At least partly addresses #231.