### PR TITLE
Ensure no warnings appear when doing fh.info() or bcd encoding/decoding

### DIFF
--- a/baseband/core.py
+++ b/baseband/core.py
@@ -64,7 +64,9 @@ def file_info(name, format=FILE_FORMATS, **kwargs):
 
     module = importlib.import_module('.' + format, package='baseband')
     # Opening as a binary file (text for GSB) should always work, and allows
-    # us to determine whether the file is of the correct format.
+    # us to determine whether the file is of the correct format.  Here, getting
+    # info should never fail or even emit warnings (i.e., if tests start to
+    # give warnings, info should be fixed, not a filter done here).
     mode = 'rb' if format != 'gsb' else 'rt'
     with module.open(name, mode=mode) as fh:
         info = fh.info

--- a/baseband/vlbi_base/file_info.py
+++ b/baseband/vlbi_base/file_info.py
@@ -5,6 +5,8 @@ Loosely based on `~astropy.utils.data_info.DataInfo`.
 """
 from __future__ import division, unicode_literals, print_function
 
+import warnings
+
 import astropy.units as u
 from astropy.extern import six
 
@@ -189,13 +191,17 @@ class VLBIFileReaderInfo(VLBIInfoBase):
     def _get_header0(self):
         fh = self._parent
         old_offset = fh.tell()
-        try:
-            fh.seek(0)
-            return fh.read_header()
-        except Exception:
-            return None
-        finally:
-            fh.seek(old_offset)
+        # Here, we do not even know whether we have the right format. We thus
+        # use a try/except and filter out all warnings.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            try:
+                fh.seek(0)
+                return fh.read_header()
+            except Exception:
+                return None
+            finally:
+                fh.seek(old_offset)
 
     def _get_format(self):
         return self._parent.__class__.__name__.split('File')[0].lower()

--- a/baseband/vlbi_base/tests/test_vlbi_base.py
+++ b/baseband/vlbi_base/tests/test_vlbi_base.py
@@ -57,7 +57,7 @@ class TestBCD(object):
     def test_bcd_encode(self):
         assert bcd_encode(1) == 0x1
         assert bcd_encode(9123) == 0x9123
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             bcd_encode('bla')
 
     def test_roundtrip(self):

--- a/baseband/vlbi_base/utils.py
+++ b/baseband/vlbi_base/utils.py
@@ -1,6 +1,8 @@
 # Licensed under the GPLv3 - see LICENSE
 from __future__ import division, unicode_literals, print_function
 
+from operator import index
+
 import numpy as np
 import six
 
@@ -10,14 +12,12 @@ __all__ = ['bcd_decode', 'bcd_encode', 'CRC']
 def bcd_decode(value):
     try:
         # Far faster than my routine for scalars
-        return int('{:x}'.format(value))
-    except ValueError:  # Might be an array (older python versions)
-        if not isinstance(value, np.ndarray):
-            raise ValueError("invalid BCD encoded value {0}={1}."
-                             .format(value, hex(value)))
-    except TypeError:  # Might still be an array (newer python versions)
-        if not isinstance(value, np.ndarray):
-            raise
+        return int('{:x}'.format(index(value)))
+    except TypeError as exc:  # Might still be an array
+        try:
+            assert issubclass(value.dtype.type, np.integer)
+        except Exception:
+            raise exc
 
     bcd = value
     factor = 1
@@ -38,10 +38,12 @@ def bcd_decode(value):
 def bcd_encode(value):
     try:
         # Far faster than my routine for scalars
-        return int('{:d}'.format(value), base=16)
-    except Exception:  # Maybe an array?
-        if not isinstance(value, np.ndarray):
-            raise
+        return int('{:d}'.format(index(value)), base=16)
+    except TypeError as exc:  # Might still be an array
+        try:
+            assert issubclass(value.dtype.type, np.integer)
+        except Exception:
+            raise exc
 
     result = np.zeros_like(value)
     result = 0


### PR DESCRIPTION
Especially if the file is not of the right type.

Found this while trying the tests on python 3.7 (which slightly changed behaviour, though I now see it is not python 3.7 specific)