### PR TITLE
Context Manager

### DIFF
--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -251,10 +251,10 @@ class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase):
                                                squeeze=squeeze, subset=subset,
                                                verify=verify)
         # Store number of frames, for finding last header.
-        with self.fh_raw.temporary_offset():
-            self.fh_raw.seek(0, 2)
+        with self.fh_raw.temporary_offset() as fh_raw:
+            fh_raw.seek(0, 2)
             self._nframes, self._partial_frame_nbytes = divmod(
-                self.fh_raw.tell(), self.header0.frame_nbytes)
+                fh_raw.tell(), self.header0.frame_nbytes)
             # If there is a partial last frame.
             if self._partial_frame_nbytes > 0:
                 # If partial last frame contains payload bytes.
@@ -280,9 +280,9 @@ class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase):
         """
         # Seek forward rather than backward, as last frame often has missing
         # bytes.
-        with self.fh_raw.temporary_offset():
-            self.fh_raw.seek((self._nframes - 1) * self.header0.frame_nbytes)
-            header = self.fh_raw.read_header()
+        with self.fh_raw.temporary_offset() as fh_raw:
+            fh_raw.seek((self._nframes - 1) * self.header0.frame_nbytes)
+            header = fh_raw.read_header()
             if self._partial_frame_nbytes > self.header0.nbytes:
                 header.mutable = True
                 # Payload should have integer number of both words and complete

--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -147,7 +147,8 @@ class DADAFileReader(VLBIFileReaderBase):
         frame_rate : `~astropy.units.Quantity`
             Frames per second.
         """
-        with self.seek_temporary(0):
+        with self.temporary_offset():
+            self.seek(0)
             header = self.read_header()
             return (header.sample_rate / header.samples_per_frame).to(u.Hz)
 
@@ -250,7 +251,8 @@ class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase):
                                                squeeze=squeeze, subset=subset,
                                                verify=verify)
         # Store number of frames, for finding last header.
-        with self.fh_raw.seek_temporary(0, 2):
+        with self.fh_raw.temporary_offset():
+            self.fh_raw.seek(0, 2)
             self._nframes, self._partial_frame_nbytes = divmod(
                 self.fh_raw.tell(), self.header0.frame_nbytes)
             # If there is a partial last frame.
@@ -278,8 +280,8 @@ class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase):
         """
         # Seek forward rather than backward, as last frame often has missing
         # bytes.
-        with self.fh_raw.seek_temporary((self._nframes - 1) *
-                                        self.header0.frame_nbytes):
+        with self.fh_raw.temporary_offset():
+            self.fh_raw.seek((self._nframes - 1) * self.header0.frame_nbytes)
             header = self.fh_raw.read_header()
             if self._partial_frame_nbytes > self.header0.nbytes:
                 header.mutable = True

--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -147,13 +147,9 @@ class DADAFileReader(VLBIFileReaderBase):
         frame_rate : `~astropy.units.Quantity`
             Frames per second.
         """
-        oldpos = self.tell()
-        self.seek(0)
-        try:
+        with self.seek_temporary(0):
             header = self.read_header()
             return (header.sample_rate / header.samples_per_frame).to(u.Hz)
-        finally:
-            self.seek(oldpos)
 
 
 class DADAFileWriter(VLBIFileBase):
@@ -254,25 +250,24 @@ class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase):
                                                squeeze=squeeze, subset=subset,
                                                verify=verify)
         # Store number of frames, for finding last header.
-        raw_offset = self.fh_raw.tell()
-        self._nframes, self._partial_frame_nbytes = divmod(
-            self.fh_raw.seek(0, 2), self.header0.frame_nbytes)
-        # If there is a partial last frame.
-        if self._partial_frame_nbytes > 0:
-            # If partial last frame contains payload bytes.
-            if self._partial_frame_nbytes > self.header0.nbytes:
-                self._nframes += 1
-                # If there's only one frame and it's incomplete.
-                if self._nframes == 1:
-                    self._header0 = self._last_header
-                    self.samples_per_frame = self.header0.samples_per_frame
-            # Otherwise, ignore the partial frame unless it's the only frame,
-            # in which case raise an EOFError.
-            elif self._nframes == 0:
-                raise EOFError('file (of {0} bytes) appears to end without'
-                               'any payload.'.format(
-                                   self._partial_frame_nbytes))
-        self.fh_raw.seek(raw_offset)
+        with self.fh_raw.seek_temporary(0, 2):
+            self._nframes, self._partial_frame_nbytes = divmod(
+                self.fh_raw.tell(), self.header0.frame_nbytes)
+            # If there is a partial last frame.
+            if self._partial_frame_nbytes > 0:
+                # If partial last frame contains payload bytes.
+                if self._partial_frame_nbytes > self.header0.nbytes:
+                    self._nframes += 1
+                    # If there's only one frame and it's incomplete.
+                    if self._nframes == 1:
+                        self._header0 = self._last_header
+                        self.samples_per_frame = self.header0.samples_per_frame
+                # Otherwise, ignore the partial frame unless it's the only
+                # frame, in which case raise an EOFError.
+                elif self._nframes == 0:
+                    raise EOFError('file (of {0} bytes) appears to end without'
+                                   'any payload.'.format(
+                                       self._partial_frame_nbytes))
 
     @lazyproperty
     def _last_header(self):
@@ -283,21 +278,23 @@ class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase):
         """
         # Seek forward rather than backward, as last frame often has missing
         # bytes.
-        raw_offset = self.fh_raw.tell()
-        self.fh_raw.seek((self._nframes - 1) * self.header0.frame_nbytes)
-        header = self.fh_raw.read_header()
-        if self._partial_frame_nbytes > self.header0.nbytes:
-            header.mutable = True
-            # Payload should have integer number of both words and complete
-            # samples.
-            payload_block = lcm(
-                DADAPayload._dtype_word.itemsize,
-                self.header0.bps * (2 if self.header0.complex_data else 1) *
-                np.prod(self.sample_shape) // 8)
-            header.payload_nbytes = payload_block * (
-                (self._partial_frame_nbytes - header.nbytes) // payload_block)
-            header.mutable = False
-        self.fh_raw.seek(raw_offset)
+        with self.fh_raw.seek_temporary((self._nframes - 1) *
+                                        self.header0.frame_nbytes):
+            header = self.fh_raw.read_header()
+            if self._partial_frame_nbytes > self.header0.nbytes:
+                header.mutable = True
+                # Payload should have integer number of both words and complete
+                # samples.
+                payload_block = lcm(
+                    DADAPayload._dtype_word.itemsize,
+                    self.header0.bps * (
+                        2 if self.header0.complex_data else 1) *
+                    np.prod(self.sample_shape) // 8)
+                header.payload_nbytes = payload_block * (
+                    (self._partial_frame_nbytes - header.nbytes) //
+                    payload_block)
+                header.mutable = False
+
         return header
 
     @lazyproperty

--- a/baseband/gsb/base.py
+++ b/baseband/gsb/base.py
@@ -71,7 +71,8 @@ class GSBTimeStampIO(VLBIFileBase):
         frame_rate : `~astropy.units.Quantity`
             Frames per second.
         """
-        with self.seek_temporary(0):
+        with self.temporary_offset():
+            self.seek(0)
             timestamp0 = self.read_timestamp()
             timestamp1 = self.read_timestamp()
             return (1. / (timestamp1.time - timestamp0.time)).to(u.Hz)
@@ -286,7 +287,8 @@ class GSBStreamReader(GSBStreamBase, VLBIStreamReaderBase):
     @lazyproperty
     def _last_header(self):
         """Last header of the timestamp file."""
-        with self.fh_ts.seek_temporary(0, 2):
+        with self.fh_ts.temporary_offset():
+            self.fh_ts.seek(0, 2)
             fh_ts_len = self.fh_ts.tell()
             if fh_ts_len == self.header0.nbytes:
                 # Only one line in file

--- a/baseband/gsb/base.py
+++ b/baseband/gsb/base.py
@@ -287,9 +287,9 @@ class GSBStreamReader(GSBStreamBase, VLBIStreamReaderBase):
     @lazyproperty
     def _last_header(self):
         """Last header of the timestamp file."""
-        with self.fh_ts.temporary_offset():
-            self.fh_ts.seek(0, 2)
-            fh_ts_len = self.fh_ts.tell()
+        with self.fh_ts.temporary_offset() as fh_ts:
+            fh_ts.seek(0, 2)
+            fh_ts_len = fh_ts.tell()
             if fh_ts_len == self.header0.nbytes:
                 # Only one line in file
                 return self.header0
@@ -297,8 +297,8 @@ class GSBStreamReader(GSBStreamBase, VLBIStreamReaderBase):
             # Read last bytes in binary, since cannot seek back from end in
             # text files.
             from_end = min(5 * self.header0.nbytes // 2, fh_ts_len)
-            self.fh_ts.buffer.seek(-from_end, 2)
-            last_lines = self.fh_ts.buffer.read(from_end).strip().split(b'\n')
+            fh_ts.buffer.seek(-from_end, 2)
+            last_lines = fh_ts.buffer.read(from_end).strip().split(b'\n')
 
         last_line = last_lines[-1].decode('ascii')
         last_line_tuple = tuple(last_line.split())

--- a/baseband/gsb/file_info.py
+++ b/baseband/gsb/file_info.py
@@ -10,9 +10,9 @@ class GSBTimeStampInfo(VLBIFileReaderInfo):
     _header0_attrs = ('mode',)
 
     def _get_header0(self):
-        fh = self._parent
-        with fh.seek_temporary(0):
+        with self._parent.temporary_offset() as fh:
             try:
+                fh.seek(0)
                 return fh.read_timestamp()
             except Exception:
                 return None

--- a/baseband/gsb/file_info.py
+++ b/baseband/gsb/file_info.py
@@ -11,14 +11,11 @@ class GSBTimeStampInfo(VLBIFileReaderInfo):
 
     def _get_header0(self):
         fh = self._parent
-        old_offset = fh.tell()
-        try:
-            fh.seek(0)
-            return fh.read_timestamp()
-        except Exception:
-            return None
-        finally:
-            fh.seek(old_offset)
+        with fh.seek_temporary(0):
+            try:
+                return fh.read_timestamp()
+            except Exception:
+                return None
 
     def _get_format(self):
         return 'gsb'

--- a/baseband/guppi/base.py
+++ b/baseband/guppi/base.py
@@ -131,7 +131,8 @@ class GUPPIFileReader(VLBIFileReaderBase):
         frame_rate : `~astropy.units.Quantity`
             Frames per second.
         """
-        with self.seek_temporary(0):
+        with self.temporary_offset():
+            self.seek(0)
             header = self.read_header()
             return (header.sample_rate /
                     (header.samples_per_frame - header.overlap)).to(u.Hz)

--- a/baseband/guppi/base.py
+++ b/baseband/guppi/base.py
@@ -131,14 +131,10 @@ class GUPPIFileReader(VLBIFileReaderBase):
         frame_rate : `~astropy.units.Quantity`
             Frames per second.
         """
-        oldpos = self.tell()
-        self.seek(0)
-        try:
+        with self.seek_temporary(0):
             header = self.read_header()
             return (header.sample_rate /
                     (header.samples_per_frame - header.overlap)).to(u.Hz)
-        finally:
-            self.seek(oldpos)
 
 
 class GUPPIFileWriter(VLBIFileBase):

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -92,7 +92,8 @@ class Mark4FileReader(VLBIFileReaderBase):
         frame_rate : `~astropy.units.Quantity`
             Frames per second.
         """
-        with self.seek_temporary(0):
+        with self.temporary_offset():
+            self.seek(0)
             self.locate_frame()
             header0 = self.read_header()
             self.seek(header0.payload_nbytes, 1)

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -92,15 +92,11 @@ class Mark4FileReader(VLBIFileReaderBase):
         frame_rate : `~astropy.units.Quantity`
             Frames per second.
         """
-        oldpos = self.tell()
-        self.seek(0)
-        try:
+        with self.seek_temporary(0):
             self.locate_frame()
             header0 = self.read_header()
             self.seek(header0.payload_nbytes, 1)
             header1 = self.read_header()
-        finally:
-            self.seek(oldpos)
 
         # Mark 4 specification states frames-lengths range from 1.25 ms
         # to 160 ms.

--- a/baseband/mark4/file_info.py
+++ b/baseband/mark4/file_info.py
@@ -84,9 +84,9 @@ class Mark4FileReaderInfo(VLBIFileReaderInfo):
     _parent_attrs = ('ntrack', 'decade', 'ref_time')
 
     def _get_header0(self):
-        fh = self._parent
-        with fh.seek_temporary(0):
+        with self._parent.temporary_offset() as fh:
             try:
+                fh.seek(0)
                 offset0 = fh.locate_frame()
                 if offset0 is None:
                     return None

--- a/baseband/mark4/file_info.py
+++ b/baseband/mark4/file_info.py
@@ -85,19 +85,16 @@ class Mark4FileReaderInfo(VLBIFileReaderInfo):
 
     def _get_header0(self):
         fh = self._parent
-        old_offset = fh.tell()
-        try:
-            fh.seek(0)
-            offset0 = fh.locate_frame()
-            if offset0 is None:
-                return None
+        with fh.seek_temporary(0):
+            try:
+                offset0 = fh.locate_frame()
+                if offset0 is None:
+                    return None
 
-            self.offset0 = offset0
-            return fh.read_header()
-        except Exception:
-            return None
-        finally:
-            fh.seek(old_offset)
+                self.offset0 = offset0
+                return fh.read_header()
+            except Exception:
+                return None
 
     def _collect_info(self):
         super(Mark4FileReaderInfo, self)._collect_info()

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -99,8 +99,9 @@ class Mark5BFileReader(VLBIFileReaderBase):
         try:
             return super(Mark5BFileReader, self).get_frame_rate()
         except Exception as exc:
-            with self.seek_temporary(0):
+            with self.temporary_offset():
                 try:
+                    self.seek(0)
                     header0 = self.read_header()
                     self.seek(header0.payload_nbytes, 1)
                     header1 = self.read_header()

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -139,8 +139,9 @@ class VDIFFileReader(VLBIFileReaderBase):
         try:
             return super(VDIFFileReader, self).get_frame_rate()
         except Exception as exc:
-            with self.seek_temporary(0):
+            with self.temporary_offset():
                 try:
+                    self.seek(0)
                     header = self.read_header()
                     return np.round((header.sample_rate /
                                      header.samples_per_frame).to(u.Hz))
@@ -428,7 +429,8 @@ class VDIFStreamReader(VDIFStreamBase, VLBIStreamReaderBase):
     def _last_header(self):
         """Last header of the file."""
         # Go to end of file.
-        with self.fh_raw.seek_temporary(0, 2):
+        with self.fh_raw.temporary_offset():
+            self.fh_raw.seek(0, 2)
             raw_size = self.fh_raw.tell()
             # Find first header with same thread_id going backward.
             found = False

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -429,20 +429,19 @@ class VDIFStreamReader(VDIFStreamBase, VLBIStreamReaderBase):
     def _last_header(self):
         """Last header of the file."""
         # Go to end of file.
-        with self.fh_raw.temporary_offset():
-            self.fh_raw.seek(0, 2)
-            raw_size = self.fh_raw.tell()
+        with self.fh_raw.temporary_offset() as fh_raw:
+            fh_raw.seek(0, 2)
+            raw_size = fh_raw.tell()
             # Find first header with same thread_id going backward.
             found = False
             # Set maximum as twice number of frames in frameset.
             maximum = 2 * self._frameset_nbytes
             while not found:
-                self.fh_raw.seek(-self.header0.frame_nbytes, 1)
-                last_header = self.fh_raw.find_header(
+                fh_raw.seek(-self.header0.frame_nbytes, 1)
+                last_header = fh_raw.find_header(
                     template_header=self.header0,
                     maximum=maximum, forward=False)
-                if last_header is None or (raw_size - self.fh_raw.tell() >
-                                           maximum):
+                if last_header is None or (raw_size - fh_raw.tell() > maximum):
                     raise ValueError("corrupt VDIF? No thread_id={0} frame "
                                      "in last {1} bytes."
                                      .format(self.header0['thread_id'],

--- a/baseband/vdif/file_info.py
+++ b/baseband/vdif/file_info.py
@@ -11,20 +11,17 @@ class VDIFFileReaderInfo(VLBIFileReaderInfo):
 
     def _get_header0(self):
         fh = self._parent
-        old_offset = fh.tell()
-        try:
-            fh.seek(0)
-            header0 = fh.read_header()
-            # Almost all bytes are interpretable as headers,
-            # so we need a basic sanity check.
-            fh.seek(header0.frame_nbytes)
-            header1 = fh.read_header()
-            if header1.same_stream(header0):
-                return header0
-        except Exception:
-            pass
-        finally:
-            fh.seek(old_offset)
+        with fh.seek_temporary(0):
+            try:
+                header0 = fh.read_header()
+                # Almost all bytes are interpretable as headers,
+                # so we need a basic sanity check.
+                fh.seek(header0.frame_nbytes)
+                header1 = fh.read_header()
+                if header1.same_stream(header0):
+                    return header0
+            except Exception:
+                pass
 
     def _get_start_time(self):
         try:
@@ -35,14 +32,11 @@ class VDIFFileReaderInfo(VLBIFileReaderInfo):
     def _get_sample_shape(self):
         # To get the sample shape, need to read a while frameset.
         fh = self._parent
-        old_offset = fh.tell()
-        try:
-            fh.seek(0)
-            return fh.read_frameset().sample_shape
-        except Exception:
-            return None
-        finally:
-            fh.seek(old_offset)
+        with fh.seek_temporary(0):
+            try:
+                return fh.read_frameset().sample_shape
+            except Exception:
+                return None
 
     def _collect_info(self):
         super(VDIFFileReaderInfo, self)._collect_info()

--- a/baseband/vdif/file_info.py
+++ b/baseband/vdif/file_info.py
@@ -10,9 +10,9 @@ class VDIFFileReaderInfo(VLBIFileReaderInfo):
     _header0_attrs = ('edv', 'bps', 'samples_per_frame')
 
     def _get_header0(self):
-        fh = self._parent
-        with fh.seek_temporary(0):
+        with self._parent.temporary_offset() as fh:
             try:
+                fh.seek(0)
                 header0 = fh.read_header()
                 # Almost all bytes are interpretable as headers,
                 # so we need a basic sanity check.
@@ -31,9 +31,9 @@ class VDIFFileReaderInfo(VLBIFileReaderInfo):
 
     def _get_sample_shape(self):
         # To get the sample shape, need to read a while frameset.
-        fh = self._parent
-        with fh.seek_temporary(0):
+        with self._parent.temporary_offset() as fh:
             try:
+                fh.seek(0)
                 return fh.read_frameset().sample_shape
             except Exception:
                 return None

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -422,9 +422,9 @@ class VLBIStreamReaderBase(VLBIStreamBase):
     @lazyproperty
     def _last_header(self):
         """Last header of the file."""
-        with self.fh_raw.temporary_offset():
-            self.fh_raw.seek(-self.header0.frame_nbytes, 2)
-            last_header = self.fh_raw.find_header(forward=False)
+        with self.fh_raw.temporary_offset() as fh_raw:
+            fh_raw.seek(-self.header0.frame_nbytes, 2)
+            last_header = fh_raw.find_header(forward=False)
         if last_header is None:
             raise ValueError("corrupt VLBI frame? No frame in last {0} bytes."
                              .format(10 * self.header0.frame_nbytes))
@@ -512,24 +512,6 @@ class VLBIStreamReaderBase(VLBIStreamBase):
                              "'current', or 2 or 'end'.")
 
         return self.offset
-
-    @contextmanager
-    def temporary_offset(self):
-        """Context manager for temporarily seeking to another stream position.
-
-        To be used as part of a ``with`` statement::
-
-            with fh.temporary_offset() [as fh]:
-                with-block
-
-        On exiting the ``with-block``, the sample pointer is moved back to its
-        original position.
-        """
-        oldpos = self.tell()
-        try:
-            yield self
-        finally:
-            self.seek(oldpos)
 
     @property
     def dtype(self):

--- a/baseband/vlbi_base/file_info.py
+++ b/baseband/vlbi_base/file_info.py
@@ -190,18 +190,15 @@ class VLBIFileReaderInfo(VLBIInfoBase):
 
     def _get_header0(self):
         fh = self._parent
-        old_offset = fh.tell()
-        # Here, we do not even know whether we have the right format. We thus
-        # use a try/except and filter out all warnings.
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
-            try:
-                fh.seek(0)
-                return fh.read_header()
-            except Exception:
-                return None
-            finally:
-                fh.seek(old_offset)
+        with fh.seek_temporary(0):
+            # Here, we do not even know whether we have the right format.
+            # We thus use a try/except and filter out all warnings.
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore')
+                try:
+                    return fh.read_header()
+                except Exception:
+                    return None
 
     def _get_format(self):
         return self._parent.__class__.__name__.split('File')[0].lower()

--- a/baseband/vlbi_base/file_info.py
+++ b/baseband/vlbi_base/file_info.py
@@ -189,13 +189,13 @@ class VLBIFileReaderInfo(VLBIInfoBase):
                       'sample_shape')
 
     def _get_header0(self):
-        fh = self._parent
-        with fh.seek_temporary(0):
+        with self._parent.temporary_offset() as fh:
             # Here, we do not even know whether we have the right format.
             # We thus use a try/except and filter out all warnings.
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore')
                 try:
+                    fh.seek(0)
                     return fh.read_header()
                 except Exception:
                     return None


### PR DESCRIPTION
Created a context manager for temporarily seeking to another part of the file.  The decorated context manager by default doesn't handle exceptions in the same way that managers with explicitly defined `__enter__` and `__exit__`, but apparently using a `try/finally` block resolves this issue for our purposes. Slightly surprised that this works!

Not entirely happy with `seek_temporary` as a name - `temporary_seek` is more consistent with what we've done with other multi-word names. I'm also open to other, more compact possibilities.  Also, not entirely happy that `seek_temporary` is a public method, since it can't be used like `seek`.  On the other hand, the user is now also free to use it.

Addresses #232.

