### PR TITLE
Fix documentation header title

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,8 +105,8 @@ release = package.__version__
 
 # Please update these texts to match the name of your package.
 html_theme_options = {
-    'logotext1': 'package',  # white,  semi-bold
-    'logotext2': '-template',  # orange, light
+    'logotext1': 'base',  # white,  semi-bold
+    'logotext2': 'band',  # orange, light
     'logotext3': ':docs'   # white,  light
     }
 


### PR DESCRIPTION
Very important - change the Readthedocs header title from "package-template" to "baseband".