### PR TITLE
Make mark5b find_header more robust.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ Bug Fixes
 
 - VDIF reader will now properly ignore corrupt last frames. [#273]
 
+- Mark5B reader more robust against headers not being parsed correctly
+  in ``Mark5BFileReader.find_header``. [#275]
+
 1.2 (2018-07-27)
 ================
 

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -143,7 +143,7 @@ class Mark5BFileReader(VLBIFileReaderBase):
             header = self.read_header()
             self.seek(-header.nbytes, 1)
             return header
-        except AssertionError:
+        except Exception:
             pass
 
         self.seek(0, 2)
@@ -159,7 +159,7 @@ class Mark5BFileReader(VLBIFileReaderBase):
             try:
                 self.seek(frame)
                 header1 = self.read_header()
-            except AssertionError:
+            except Exception:
                 continue
 
             # Get header from a frame up and check it is consistent (we always
@@ -177,7 +177,7 @@ class Mark5BFileReader(VLBIFileReaderBase):
             self.seek(next_frame)
             try:
                 header2 = self.read_header()
-            except AssertionError:
+            except Exception:
                 continue
 
             if(header2.jday == header1.jday and


### PR DESCRIPTION
As it was, errors in the Header reader could throw it off,
while it should just return without a header for that case.

fixes #274