### PR TITLE
Add 1 bit mode to Mark 5B

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 2.0 (unreleased)
 ================
 
-- VDIF reader and writer now support 1 bit per sample. [#277]
+- VDIF and Mark 5B readers and writers now support 1 bit per sample.
+  [#277, #278]
 
 Other Changes and Additions
 ---------------------------

--- a/baseband/mark5b/payload.py
+++ b/baseband/mark5b/payload.py
@@ -16,7 +16,8 @@ from ..vlbi_base.payload import VLBIPayloadBase
 from ..vlbi_base.encoding import encode_2bit_base, decoder_levels
 
 
-__all__ = ['init_luts', 'decode_2bit', 'encode_2bit',
+__all__ = ['init_luts', 'decode_1bit', 'decode_2bit',
+           'encode_1bit', 'encode_2bit',
            'Mark5BPayload']
 
 
@@ -26,12 +27,12 @@ def init_luts():
     """Set up the look-up tables for levels as a function of input byte.
 
     For 1-bit mode, one has just the sign bit:
-      === =====
-       s  value
-      === =====
-       0  -1
-       1  +1
-      === =====
+     === =====
+      s  value
+     === =====
+      0  +1
+      1  -1
+     === =====
 
     For 2-bit mode, there is a sign and a magnitude, which encode:
      === === ===== =====
@@ -43,8 +44,10 @@ def init_luts():
       1   1  +Hi    3
      === === ===== =====
 
-    See Table 13 in
-    https://science.nrao.edu/facilities/vlba/publications/memos/upgrade/sensimemo13.pdf
+    Note that the sign bit is flipped for 1-bit mode from what one might
+    expect from the 2-bit encodings (at least, as implemented in mark5access;
+    the docs are rather unclear).  For more details, see Table 13 in
+    http://library.nrao.edu/public/memos/vlba/up/VLBASU_13.pdf
     and
     http://www.haystack.edu/tech/vlbi/mark5/docs/Mark%205B%20users%20manual.pdf
     Appendix A: sign always on even bit stream (0, 2, 4, ...), and magnitude
@@ -55,7 +58,10 @@ def init_luts():
     """
     b = np.arange(256)[:, np.newaxis]
     sl = np.arange(8)
-    lut1bit = decoder_levels[1][((b >> sl) & 1)]
+    # For 1-bit modes, like for Mark 4, if set, sign=-1, so need to get item 0.
+    # With this, one reproduces mark5access m5d, but must say that from the
+    # documentation, it is not obvious this is correct.
+    lut1bit = decoder_levels[1][((b >> sl) & 1) ^ 1]
     # 2-bit mode: sign bit in lower position thatn magnitude bit
     # ms=00,01,10,11 = -Hi, 1, -1, Hi (lut
     s = np.arange(0, 8, 2)  # 0, 2, 4, 6
@@ -68,11 +74,20 @@ def init_luts():
 lut1bit, lut2bit = init_luts()
 
 
-# def decode_1bit(frame, nvlbichan):
-#     return lut1bit[frame].reshape(-1, nvlbichan)
+def decode_1bit(words):
+    b = words.view(np.uint8)
+    return lut1bit.take(b, axis=0)
 
 
-# Decoders keyed by bits_per_sample, complex_data:
+shift1bit = np.arange(0, 8).astype(np.uint8)
+
+
+def encode_1bit(values):
+    """Encodes values using 1 bit per sample, packing the result into bytes."""
+    bitvalues = np.signbit(values.reshape(-1, 8)).view(np.uint8)
+    return np.packbits(bitvalues[:, ::-1])
+
+
 def decode_2bit(words):
     b = words.view(np.uint8)
     return lut2bit.take(b, axis=0)
@@ -108,8 +123,10 @@ class Mark5BPayload(VLBIPayloadBase):
     """
 
     _nbytes = 2500 * 4
-    _encoders = {2: encode_2bit}
-    _decoders = {2: decode_2bit}
+    _encoders = {1: encode_1bit,
+                 2: encode_2bit}
+    _decoders = {1: decode_1bit,
+                 2: decode_2bit}
 
     _sample_shape_maker = namedtuple('SampleShape', 'nchan')
 

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -136,11 +136,15 @@ class TestMark5B(object):
     def test_decoding(self):
         """Check that look-up levels are consistent with mark5access."""
         o2h = OPTIMAL_2BIT_HIGH
-        assert np.all(mark5b.payload.lut1bit[0] == -1.)
-        assert np.all(mark5b.payload.lut1bit[0xff] == 1.)
+        # Note that evaluation of sign bit for bps=1 is somewhat strange,
+        # in that set means negative, unlike what is the case for bps=2.
+        # This is as in mark5access, but not 100% sure this is correct --
+        # the documentation is rather unclear.
+        assert np.all(mark5b.payload.lut1bit[0] == 1.)
+        assert np.all(mark5b.payload.lut1bit[0xff] == -1.)
         assert np.all(mark5b.payload.lut1bit.astype(int) ==
-                      ((np.arange(256)[:, np.newaxis] >>
-                        np.arange(8)) & 1) * 2 - 1)
+                      (1 - 2 * ((np.arange(256)[:, np.newaxis] >>
+                                 np.arange(8)) & 1)))
         assert np.all(mark5b.payload.lut2bit[0] == -o2h)
         assert np.all(mark5b.payload.lut2bit[0x55] == 1.)
         assert np.all(mark5b.payload.lut2bit[0xaa] == -1.)


### PR DESCRIPTION
With a test that conversion from VDIF to it works correctly (the result also tested with mark5access `m5d` - hopefully consistent with the standard).