### PR TITLE
Ensure dtype on stream is always a proper dtype.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@ Bug Fixes
 - Mark5B reader more robust against headers not being parsed correctly
   in ``Mark5BFileReader.find_header``. [#275]
 
+- All stream readers now have a proper ``dtype`` attribute, not a
+  corresponding ``np.float32`` or ``np.complex64``. [#280]
+
 1.2 (2018-07-27)
 ================
 

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -681,7 +681,9 @@ class TestVDIF(object):
             assert fh.start_time == fh.header0.time
             assert abs(fh.time - fh.start_time) < 1. * u.ns
             assert fh.time == fh.tell(unit='time')
+            assert isinstance(fh.dtype, np.dtype) and fh.dtype == np.dtype('f4')
             record = fh.read(12)
+            assert record.dtype == np.dtype('f4')
             assert fh.tell() == 12
             t12 = fh.time
             s12 = 12 / fh.sample_rate

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -515,7 +515,8 @@ class VLBIStreamReaderBase(VLBIStreamBase):
 
     @property
     def dtype(self):
-        return np.complex64 if self.complex_data else np.float32
+        # TODO: arguably, this should be inferred from an actual payload.
+        return np.dtype(np.complex64 if self.complex_data else np.float32)
 
     def read(self, count=None, out=None):
         """Read a number of complete (or subset) samples.


### PR DESCRIPTION
Rather than something like np.complex64.