### PR TITLE
Mark all header cards read from file as verified, to reduce warnings.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,9 @@ Bug Fixes
 - All stream readers now have a proper ``dtype`` attribute, not a
   corresponding ``np.float32`` or ``np.complex64``. [#280]
 
+- GUPPI stream readers no longer emit warnings on not quite FITS compliant
+  headers. [#283]
+
 1.2 (2018-07-27)
 ================
 

--- a/baseband/guppi/header.py
+++ b/baseband/guppi/header.py
@@ -125,6 +125,11 @@ class GUPPIHeader(fits.Header):
         # This calls cls.__init__, which automatically runs cls.verify().
         self = cls.fromstring(hdr)
         self.mutable = False
+        # GUPPI headers are not a proper FITS standard, and we're reading
+        # from a file that the user likely cannot control, so let's not bother
+        # with card verification (this avoids warnings in repr(); gh-282)
+        for c in self.cards:
+            c._verified = True
         return self
 
     def tofile(self, fh):


### PR DESCRIPTION
fixes #282 

There seems to be no point to warn if headers read from files are not quite on the FITS standard; the user almost certainly cannot do much about it anyway, and we're not sure the fix is even correct.

p.s. Cannot bother to write a test case for this... Though perhaps it should actually do the verification and fixing (`c.verify("silentfix+ignore")`)