### PR TITLE
Don't warn on line break after operator.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,9 @@ ignore=
     # line too long
     E501,
     # unused import (for __init__.py)
-    F401
+    F401,
+    # line break after binary operator (have to choose before or after)
+    W504
 exclude=
     # part of astropy affilliated package helpers, not our worry.
     baseband/conftest.py,baseband/version.py,baseband/__init__.py,


### PR DESCRIPTION
Need to choose one or the other.  Possibly switch to always
having the operator on the next line later.