### PR TITLE
Test vdif custom header robustness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ matrix:
         - python: 3.5
           env: NUMPY_VERSION=1.10
         - python: 2.7
-          env: NUMPY_VERSION=1.9 ASTROPY_VERSION=lts
+          env: NUMPY_VERSION=1.10 ASTROPY_VERSION=lts
 
         # Make sure that egg_info works without dependencies
         - env: SETUP_CMD='egg_info'

--- a/baseband/vdif/header.py
+++ b/baseband/vdif/header.py
@@ -69,7 +69,7 @@ class VDIFHeaderMeta(type):
                 raise ValueError("EDV {0} already registered in "
                                  "VDIF_HEADER_CLASSES".format(edv))
 
-            VDIFHeaderMeta._registry.update({edv: cls})
+            VDIFHeaderMeta._registry[edv] = cls
 
         # If header parser has a sync pattern, append it as a private
         # attribute for cls.verify.

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -197,6 +197,9 @@ class TestVDIF(object):
                 pass
 
         # Working header with nonsense data in the last two words.
+        # Clear out entry in registry just in case we test twice.
+        vdif.header.VDIFHeaderMeta._registry.pop(0x58, None)
+
         class VDIFHeaderX(vdif.header.VDIFSampleRateHeader):
             _edv = 0x58
             _header_parser = (vdif.header.VDIFSampleRateHeader._header_parser +


### PR DESCRIPTION
Also bumped minimum numpy version to 1.10, since `broadcast_to` is used quite frequently (somehow, testing had missed this).