### PR TITLE
Fix incorrect sample rate in guppi raw file info. 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,9 @@ Bug Fixes
 - Bits per complete sample for VDIF payloads are now calculated correctly also
   for non power-of-two bits per sample. [#315]
 
+- Guppi raw file info now presents the correct sample rate, corrected for
+  overlap. [#319]
+
 2.0 (2018-12-12)
 ================
 

--- a/baseband/guppi/base.py
+++ b/baseband/guppi/base.py
@@ -11,6 +11,7 @@ from ..vlbi_base.base import (make_opener, VLBIFileBase, VLBIFileReaderBase,
 from .header import GUPPIHeader
 from .payload import GUPPIPayload
 from .frame import GUPPIFrame
+from .file_info import GUPPIFileReaderInfo
 
 
 __all__ = ['GUPPIFileNameSequencer', 'GUPPIFileReader', 'GUPPIFileWriter',
@@ -87,6 +88,7 @@ class GUPPIFileReader(VLBIFileReaderBase):
     fh_raw : filehandle
         Filehandle of the raw binary data file.
     """
+    info = GUPPIFileReaderInfo()
 
     def read_header(self):
         """Read a single header from the file.

--- a/baseband/guppi/file_info.py
+++ b/baseband/guppi/file_info.py
@@ -1,0 +1,8 @@
+# Licensed under the GPLv3 - see LICENSE
+from ..vlbi_base.file_info import VLBIFileReaderInfo
+
+
+class GUPPIFileReaderInfo(VLBIFileReaderInfo):
+    # Get sample_rate from header rather than calculate it from frame_rate
+    # and samples_per_frame, since we need to correct for overlap.
+    _header0_attrs = VLBIFileReaderInfo._header0_attrs + ('sample_rate',)

--- a/baseband/vlbi_base/file_info.py
+++ b/baseband/vlbi_base/file_info.py
@@ -277,7 +277,8 @@ class VLBIFileReaderInfo(VLBIInfoBase):
                 setattr(self, attr, getattr(self.header0, attr))
             self.format = self._get_format()
             self.frame_rate = self._get_frame_rate()
-            if (self.frame_rate is not None and
+            if ('sample_rate' not in self._header0_attrs and
+                    self.frame_rate is not None and
                     self.samples_per_frame is not None):
                 self.sample_rate = self.frame_rate * self.samples_per_frame
             self.start_time = self._get_start_time()


### PR DESCRIPTION
@theXYZT - OK, the fix was indeed not difficult once it was clear what number was wrong. And it turns out that one can test it just with the small sample file we include already.