### PR TITLE
Fix links to VDIF specification documents.

### DIFF
--- a/baseband/vdif/frame.py
+++ b/baseband/vdif/frame.py
@@ -6,7 +6,7 @@ Implements a VDIFFrame class  that can be used to hold a header and a
 payload, providing access to the values encoded in both.  Also, define
 a VDIFFrameSet class that combines a set of frames from different threads.
 
-For the VDIF specification, see http://www.vlbi.org/vdif
+For the VDIF specification, see https://www.vlbi.org/vdif
 """
 import numpy as np
 
@@ -150,7 +150,7 @@ class VDIFFrame(VLBIFrameBase):
         Any additional keywords can be used to set VDIF header properties
         not found in the Mark 5B header (such as station).
 
-        See http://www.vlbi.org/vdif/docs/vdif_extension_0xab.pdf
+        See https://vlbi.org/wp-content/uploads/2019/03/vdif_extension_0xab.pdf
         """
         m5h, m5pl = mark5b_frame.header, mark5b_frame.payload
         header = cls._header_class.from_mark5b_header(

--- a/baseband/vdif/header.py
+++ b/baseband/vdif/header.py
@@ -5,7 +5,7 @@ Definitions for VLBI VDIF Headers.
 Implements a VDIFHeader class used to store header words, and decode/encode
 the information therein.
 
-For the VDIF specification, see http://www.vlbi.org/vdif
+For the VDIF specification, see https://www.vlbi.org/vdif
 """
 import numpy as np
 import astropy.units as u
@@ -80,7 +80,7 @@ class VDIFHeader(VLBIHeaderBase, metaclass=VDIFHeaderMeta):
     """VDIF Header, supporting different Extended Data Versions.
 
     Will initialize a header instance appropriate for a given EDV.
-    See http://www.vlbi.org/vdif/docs/VDIF_specification_Release_1.1.1.pdf
+    See https://vlbi.org/wp-content/uploads/2019/03/VDIF_specification_Release_1.1.1.pdf
 
     Parameters
     ----------
@@ -254,7 +254,7 @@ class VDIFHeader(VLBIHeaderBase, metaclass=VDIFHeaderMeta):
     def from_mark5b_header(cls, mark5b_header, bps, nchan, **kwargs):
         """Construct an Mark5B over VDIF header (EDV=0xab).
 
-        See http://www.vlbi.org/vdif/docs/vdif_extension_0xab.pdf
+        See https://vlbi.org/wp-content/uploads/2019/03/vdif_extension_0xab.pdf
 
         Note that the Mark 5B header does not encode the bits-per-sample and
         the number of channels used in the payload, so these need to be given
@@ -456,7 +456,7 @@ class VDIFLegacyHeader(VDIFHeader):
     """Legacy VDIF header that uses only 4 32-bit words.
 
     See Section 6 of
-    http://www.vlbi.org/vdif/docs/VDIF_specification_Release_1.1.1.pdf
+    https://vlbi.org/wp-content/uploads/2019/03/VDIF_specification_Release_1.1.1.pdf
     """
     _struct = four_word_struct
 
@@ -616,7 +616,7 @@ class VDIFSampleRateHeader(VDIFBaseHeader):
 class VDIFHeader1(VDIFSampleRateHeader):
     """VDIF Header for EDV=1.
 
-    See http://www.vlbi.org/vdif/docs/vdif_extension_0x01.pdf
+    See https://vlbi.org/wp-content/uploads/2019/03/vdif_extension_0x01.pdf
     """
     _edv = 1
     _header_parser = VDIFSampleRateHeader._header_parser + HeaderParser(
@@ -626,7 +626,7 @@ class VDIFHeader1(VDIFSampleRateHeader):
 class VDIFHeader3(VDIFSampleRateHeader):
     """VDIF Header for EDV=3.
 
-    See http://www.vlbi.org/vdif/docs/vdif_extension_0x03.pdf
+    See https://vlbi.org/wp-content/uploads/2019/03/vdif_extension_0x03.pdf
     """
     _edv = 3
     _header_parser = VDIFSampleRateHeader._header_parser + HeaderParser(
@@ -649,7 +649,7 @@ class VDIFHeader3(VDIFSampleRateHeader):
 class VDIFHeader2(VDIFBaseHeader):
     """VDIF Header for EDV=2.
 
-    See http://www.vlbi.org/vdif/docs/alma-vdif-edv.pdf
+    See https://vlbi.org/wp-content/uploads/2019/03/alma-vdif-edv.pdf
 
     Notes
     -----
@@ -677,7 +677,7 @@ class VDIFHeader2(VDIFBaseHeader):
 class VDIFMark5BHeader(VDIFBaseHeader, Mark5BHeader):
     """Mark 5B over VDIF (EDV=0xab).
 
-    See http://www.vlbi.org/vdif/docs/vdif_extension_0xab.pdf
+    See https://vlbi.org/wp-content/uploads/2019/03/vdif_extension_0xab.pdf
     """
     _edv = 0xab
     # Repeat 'frame_length' to set default.

--- a/baseband/vdif/payload.py
+++ b/baseband/vdif/payload.py
@@ -5,7 +5,7 @@ Definitions for VLBI VDIF payloads.
 Implements a VDIFPayload class used to store payload words, and decode to
 or encode from a data array.
 
-See the `VDIF specification page <http://www.vlbi.org/vdif>`_ for payload
+See the `VDIF specification page <https://www.vlbi.org/vdif>`_ for payload
 specifications.
 """
 from collections import namedtuple
@@ -37,7 +37,7 @@ def init_luts():
     by byte value (in uint8 form) and whose second axis represents sample
     temporal order.  Table values are decoded sample values.  Sec. 10 in
     the `VDIF Specification
-    <http://vlbi.org/vdif/docs/VDIF_specification_Release_1.1.1.pdf>`_
+    <https://vlbi.org/wp-content/uploads/2019/03/VDIF_specification_Release_1.1.1.pdf>`_
     states that samples are encoded by offset-binary, such that all 0
     bits is lowest and all 1 bits is highest.  I.e., for 2-bit sampling,
     the order is 00, 01, 10, 11.  These are decoded using

--- a/docs/tutorials/new_edv.rst
+++ b/docs/tutorials/new_edv.rst
@@ -7,7 +7,7 @@ Supporting a New VDIF EDV
 Users may encounter VDIF files with unusual headers not currently supported by
 Baseband.  These may either have novel EDV, or they may purport to be a
 supported EDV but not conform to its `formal specification
-<http://www.vlbi.org/vdif/>`_.  To handle such situations, Baseband supports
+<https://www.vlbi.org/vdif/>`_.  To handle such situations, Baseband supports
 implementation of new EDVs and overriding of existing EDVs without the need to
 modify Baseband's source code.
 
@@ -30,7 +30,7 @@ header that is structured as follows:
 
    Schematic of the standard 32-bit VDIF header, from `VDIF specification
    release 1.1.1 document, Fig. 3
-   <http://www.vlbi.org/vdif/docs/VDIF_specification_Release_1.1.1.pdf>`_.
+   <https://vlbi.org/wp-content/uploads/2019/03/VDIF_specification_Release_1.1.1.pdf>`_.
    32-bit words are labelled on the left, while byte and bit numbers above
    indicate relative addresses within each word.  Subscripts indicate field
    length in bits.
@@ -46,11 +46,11 @@ where the abbreviated labels are
 - :math:`\mathrm{EDV}_8` - "extended data version" number; see below
 
 Detailed definitions of terms are found on pages 5 to 7 of the `VDIF specification
-document <http://www.vlbi.org/vdif/docs/VDIF_specification_Release_1.1.1.pdf>`_.
+document <https://vlbi.org/wp-content/uploads/2019/03/VDIF_specification_Release_1.1.1.pdf>`_.
 
 Words 4 - 7 hold optional extended user data, using a layout specified by the
 EDV, in word 4 of the header.  EDV formats can be registered on the `VDIF
-website <http://www.vlbi.org/vdif/>`_; Baseband aims to support all registered
+website <https://www.vlbi.org/vdif/>`_; Baseband aims to support all registered
 formats (but does not currently support EDV = 4).
 
 .. _new_edv_new_edv:
@@ -63,7 +63,7 @@ be a first and required step to support that format, but does not suffice, as
 it also needs a new frame class that allows the purpose of the EDV class,
 which is to independently store the validity of sub-band channels within a
 single data frame, rather than using the single invalid-data bit.  From the
-`EDV=4 specification <http://www.vlbi.org/vdif/docs/edv4description.pdf>`_, we
+`EDV=4 specification <https://vlbi.org/wp-content/uploads/2019/03/edv4description.pdf>`_, we
 see that we need to add the following to the standard VDIF header:
 
 - Validity header mask (word 4, bits 16 - 24): integer value between 1 and
@@ -272,7 +272,7 @@ so that we can use ``validity`` as a keyword in ``fromvalues``::
     If you have implemented support for a new EDV that is widely used, we
     encourage you to make a pull request to Baseband's `GitHub repository
     <https://github.com/mhvk/baseband>`_, as well as to `register it
-    <http://www.vlbi.org/vdif/>`_ (if it is not already registered) with the
+    <https://www.vlbi.org/vdif/>`_ (if it is not already registered) with the
     VDIF consortium!
 
 .. _new_edv_replacement:

--- a/docs/vdif/index.rst
+++ b/docs/vdif/index.rst
@@ -6,10 +6,10 @@
 VDIF
 ****
 
-The `VLBI Data Interchange Format (VDIF) <http://www.vlbi.org/vdif/>`_ was
+The `VLBI Data Interchange Format (VDIF) <https://www.vlbi.org/vdif/>`_ was
 introduced in 2009 to standardize VLBI data transfer and storage.  Detailed
 specifications are found in VDIF's `specification document
-<http://www.vlbi.org/vdif/docs/VDIF_specification_Release_1.1.1.pdf>`_.
+<https://vlbi.org/wp-content/uploads/2019/03/VDIF_specification_Release_1.1.1.pdf>`_.
 
 .. _vdif_file_structure:
 
@@ -127,7 +127,7 @@ For small files, one could just do::
     ...                   nthread=fr.sample_shape.nthread) as fw:
     ...     fw.write(fr.read())
 
-This copies everything to memory, though, and some header information is lost. 
+This copies everything to memory, though, and some header information is lost.
 
 .. _vdif_troubleshooting:
 
@@ -157,7 +157,7 @@ the class EDV.  If they do not, the following line
 returns an AssertionError.  If this occurs because the VDIF EDV is not yet
 supported by Baseband, support can be added by implementing a custom header
 class.  If the EDV is supported, but the header deviates from the format
-found in the `VLBI.org EDV registry <http://www.vlbi.org/vdif/>`_, the
+found in the `VLBI.org EDV registry <https://www.vlbi.org/vdif/>`_, the
 best solution is to create a custom header class, then override the
 subclass selector in `~baseband.vdif.header.VDIFHeader`.  Tutorials
 for doing either can be found :ref:`here <new_edv>`.


### PR DESCRIPTION
upstream web site has moved to wordpress, it seems, and only bothered to keep some links the same.