### PR TITLE
VDIF verification speed ups

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,13 @@ Bug Fixes
   ``verify=False``. This is needed for astropy 3.2, which initializes an empty
   header in its revamped ``.fromstring`` method. [#314]
 
+Other Changes and Additions
+---------------------------
+
+- Increased speed of VDIF stream reading by removing redundant verification.
+  Reduces the overhead for verification for VDIF CHIME data from 50% (factor
+  1.5) to 13%. [#321]
+
 2.0.1 (unreleased)
 ==================
 

--- a/baseband/vdif/frame.py
+++ b/baseband/vdif/frame.py
@@ -239,7 +239,9 @@ class VDIFFrameSet:
             thread_id = header['thread_id']
             if thread_ids is None or thread_id in thread_ids:
                 payload = VDIFPayload.fromfile(fh, header=header)
-                frames[thread_id] = VDIFFrame(header, payload, verify=verify)
+                # Since header was (optionally) verified, and payload was
+                # initialized using header, no frame verification is needed.
+                frames[thread_id] = VDIFFrame(header, payload, verify=False)
             else:
                 fh.seek(header.payload_nbytes, 1)
 

--- a/baseband/vdif/payload.py
+++ b/baseband/vdif/payload.py
@@ -185,8 +185,11 @@ class VDIFPayload(VLBIPayloadBase):
             Used to infer the payload size, number of channels, bits per
             sample, and whether the data are complex.
         """
-        s = fh.read(header.payload_nbytes)
-        if len(s) < header.payload_nbytes:
+        nbytes = header.payload_nbytes
+        # Could do super().fromfile(fh, header, payload_nbytes=nbytes),
+        # but that is rather more costly.
+        s = fh.read(nbytes)
+        if len(s) < nbytes:
             raise EOFError("could not read full payload.")
         return cls(np.frombuffer(s, dtype=cls._dtype_word), header)
 

--- a/baseband/vlbi_base/frame.py
+++ b/baseband/vlbi_base/frame.py
@@ -66,10 +66,9 @@ class VLBIFrameBase:
         """Simple verification.  To be added to by subclasses."""
         assert isinstance(self.header, self._header_class)
         assert isinstance(self.payload, self._payload_class)
-        assert (self.payload.nbytes ==
-                self.payload.words.size * self.payload.words.dtype.itemsize)
-        assert (self.payload.nbytes == getattr(self.header, 'payload_nbytes',
-                                               self.payload.nbytes))
+        payload_nbytes = getattr(self.header, 'payload_nbytes', None)
+        if payload_nbytes is not None:
+            assert self.payload.nbytes == payload_nbytes
 
     @property
     def valid(self):


### PR DESCRIPTION
For CHIME data, this reduces the overhead of verification from 50% (factor 1.5) to 13%. For non-VDIF data, the improvements are likely minimal.