### PR TITLE
Ensure that Mark4 frame rates are calculated correctly.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 3.1 (unreleaded)
 ================
 
+Bug Fixes
+---------
+
+- Frame rates are now calculated correctly also for Mark 4 data in which the
+  first frame is the last within a second. [#341]
 
 3.0 (2019-08-28)
 ================

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -100,7 +100,7 @@ class Mark4FileReader(VLBIFileReaderBase):
 
         # Mark 4 specification states frames-lengths range from 1.25 ms
         # to 160 ms.
-        tdelta = header1.fraction[0] - header0.fraction[0]
+        tdelta = (header1.fraction[0] - header0.fraction[0]) % 1.
         return u.Quantity(1 / tdelta, u.Hz).round()
 
     def locate_frame(self, forward=True, maximum=None):

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -1011,3 +1011,21 @@ class Test16TrackFanout4():
             orig_bytes = fr.read(number_of_bytes)
             conv_bytes = fh.read()
             assert conv_bytes == orig_bytes
+
+
+def test_start_at_last_frame(tmpdir):
+    """Regression test for files where first frame is last in a second.
+
+    Previously, this caused the frame rate and thus the sample rate to
+    be calculated wrongly.  See gh-340.
+    """
+    fl = str(tmpdir.join('test.m4'))
+    sample_rate = 32*u.MHz
+    frame_rate = sample_rate / 80000
+    start_time = Time('2012-01-02') - 1/frame_rate
+    with mark4.open(fl, 'ws', sample_rate=sample_rate, time=start_time,
+                    ntrack=32, nchan=4, fanout=4, bps=2) as fw:
+        fw.write(np.ones((80000*2, 4)))
+
+    with mark4.open(fl, 'rs', decade=2010) as fr:
+        assert fr.sample_rate == sample_rate


### PR DESCRIPTION
Also when the first frame in a file is the last within a second.

fixes #340