### PR TITLE
Fix vdif.find_header problem for when one is close to a header.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Bug Fixes
 - Frame rates are now calculated correctly also for Mark 4 data in which the
   first frame is the last within a second. [#341]
 
+- Fixed a bug where a VDIF header was not found correctly if the file pointer
+  was very close to the start of a header already. [#346]
+
 3.0 (2019-08-28)
 ================
 

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -198,11 +198,8 @@ class VDIFFileReader(VLBIFileReaderBase):
         if maximum is None:
             maximum = 2 * frame_nbytes
 
-        # Determine file size.
-        file_pos = fh.tell()
-        fh.seek(0, 2)
-        nbytes = fh.tell()
         # Generate file pointer positions to test.
+        nbytes = fh.seek(0, 2)
         if forward:
             iterate = range(file_pos, min(file_pos + maximum - 31,
                                           nbytes - frame_nbytes + 1))

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -651,6 +651,16 @@ class TestVDIF:
             header_end = fh.find_header(template_header=header0,
                                         forward=True)
             assert header_end is None
+            # Just before a header.
+            fh.seek(40254)
+            header_40254f = fh.find_header(template_header=header0,
+                                           forward=True)
+            assert fh.tell() == 8 * header0.frame_nbytes
+            fh.seek(40254)
+            header_40254b = fh.find_header(template_header=header0,
+                                           forward=False)
+            assert fh.tell() == 7 * header0.frame_nbytes
+
         # thread order = 1,3,5,7,0,2,4,6
         assert header_16b == header_0
         # second frame
@@ -662,6 +672,12 @@ class TestVDIF:
         # fifth frame
         assert header_20128f['frame_nr'] == 0
         assert header_20128f['thread_id'] == 0
+        # seventh frame
+        assert header_40254b['frame_nr'] == 0
+        assert header_40254b['thread_id'] == 6
+        # eigth frame
+        assert header_40254f['frame_nr'] == 1
+        assert header_40254f['thread_id'] == 1
         # one but last frame
         assert header_m10000b['frame_nr'] == 1
         assert header_m10000b['thread_id'] == 4


### PR DESCRIPTION
Problem was that `file_pos` got redefined after trying to read the header on the spot.