### PR TITLE
Enforce non-negative payloadsize in VDIF header verification

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Bug Fixes
 - Fixed a bug where a VDIF header was not found correctly if the file pointer
   was very close to the start of a header already. [#346]
 
+- In VDIF header verification, include that the implied payload must have
+  non-negative size. [#348]
+
 3.0 (2019-08-28)
 ================
 

--- a/baseband/vdif/header.py
+++ b/baseband/vdif/header.py
@@ -478,7 +478,7 @@ class VDIFLegacyHeader(VDIFHeader):
          ('frame_nr', (1, 0, 24, 0x0)),
          ('vdif_version', (2, 29, 3, 0x1)),
          ('lg2_nchan', (2, 24, 5)),
-         ('frame_length', (2, 0, 24)),
+         ('frame_length', (2, 0, 24, 0x80)),
          ('complex_data', (3, 31, 1)),
          ('bits_per_sample', (3, 26, 5)),
          ('thread_id', (3, 16, 10, 0x0)),

--- a/baseband/vdif/header.py
+++ b/baseband/vdif/header.py
@@ -213,8 +213,9 @@ class VDIFHeader(VLBIHeaderBase, metaclass=VDIFHeaderMeta):
         # the super chain doesn't work well.
         #
         # Some defaults that are not done by setting properties.
-        kwargs.setdefault('legacy_mode', True if edv is False else False)
-        kwargs['edv'] = edv
+        kwargs.setdefault('legacy_mode', edv is False)
+        if edv is not False:
+            kwargs['edv'] = edv
         # For setting time, one normally needs a frame rate.  If headers
         # provide this information, we can just proceed.
         if 'time' not in kwargs or 'frame_rate' in VDIF_HEADER_CLASSES.get(
@@ -490,6 +491,7 @@ class VDIFLegacyHeader(VDIFHeader):
         assert self.edv is False
         assert self['legacy_mode']
         assert len(self.words) == 4
+        assert self['frame_length'] >= 2
 
 
 class VDIFBaseHeader(VDIFHeader):
@@ -504,6 +506,7 @@ class VDIFBaseHeader(VDIFHeader):
         assert not self['legacy_mode']
         assert self.edv is None or self.edv == self['edv']
         assert len(self.words) == 8
+        assert self['frame_length'] >= 4
         # _sync_pattern is added by VDIFHeaderMeta.
         if 'sync_pattern' in self.keys():
             assert self['sync_pattern'] == self._sync_pattern
@@ -517,8 +520,8 @@ class VDIFHeader0(VDIFBaseHeader):
     _edv = 0
 
     def verify(self):
-        assert all(word == 0 for word in self.words[4:])
         super().verify()
+        assert all(word == 0 for word in self.words[4:])
 
 
 class VDIFSampleRateHeader(VDIFBaseHeader):

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -207,6 +207,24 @@ class TestVDIF:
             vdif.VDIFHeader.fromvalues(samples_per_frame=78125, nchan=2, edv=0,
                                        complex_data=True)
 
+    @pytest.mark.parametrize('edv', [0, 1])  # Others have fixed length
+    def test_header_minimal_length(self, edv):
+        for l in range(4):
+            with pytest.raises(AssertionError):
+                # Less than header length.
+                vdif.VDIFHeader.fromvalues(edv=edv, frame_length=l)
+
+        header = vdif.VDIFHeader.fromvalues(edv=edv, frame_length=4)
+        assert header.payload_nbytes == 0
+
+    def test_legacy_header_minimal_length(self):
+        for l in range(2):
+            with pytest.raises(AssertionError):
+                # Less than header length.
+                vdif.VDIFHeader.fromvalues(edv=False, frame_length=l)
+        header = vdif.VDIFHeader.fromvalues(edv=False, frame_length=2)
+        assert header.payload_nbytes == 0
+
     def test_custom_header(self, tmpdir):
         # Custom header with an EDV that already exists
         with pytest.raises(ValueError):

--- a/docs/tutorials/new_edv.rst
+++ b/docs/tutorials/new_edv.rst
@@ -143,7 +143,7 @@ For further details, see the documentation of
 Once defined, we can use our new header like any other::
 
     >>> myheader = vdif.header.VDIFHeader.fromvalues(
-    ...     edv=4, seconds=14363767, nchan=1,
+    ...     edv=4, seconds=14363767, nchan=1, samples_per_frame=1024,
     ...     station=65532, bps=2, complex_data=False,
     ...     thread_id=3, validity_mask_length=60,
     ...     validity_mask=(1 << 59) + 1)
@@ -156,7 +156,7 @@ Once defined, we can use our new header like any other::
                  frame_nr: 0,
                  vdif_version: 1,
                  lg2_nchan: 0,
-                 frame_length: 0,
+                 frame_length: 36,
                  complex_data: False,
                  bits_per_sample: 1,
                  thread_id: 3,
@@ -240,7 +240,7 @@ corresponding setter, and add this to the private ``_properties`` attribute,
 so that we can use ``validity`` as a keyword in ``fromvalues``::
 
     >>> myenhancedheader = vdif.header.VDIFHeader.fromvalues(
-    ...     edv=42, seconds=14363767, nchan=1,
+    ...     edv=42, seconds=14363767, nchan=1, samples_per_frame=1024,
     ...     station=65532, bps=2, complex_data=False,
     ...     thread_id=3, validity=[True]+[False]*58+[True])
     >>> myenhancedheader
@@ -252,7 +252,7 @@ so that we can use ``validity`` as a keyword in ``fromvalues``::
                          frame_nr: 0,
                          vdif_version: 1,
                          lg2_nchan: 0,
-                         frame_length: 0,
+                         frame_length: 36,
                          complex_data: False,
                          bits_per_sample: 1,
                          thread_id: 3,


### PR DESCRIPTION
Found while working on increasing the robustness of the VDIF reader.