### PR TITLE
Use https where possible; flake8 cleanup

### DIFF
--- a/baseband/dada/__init__.py
+++ b/baseband/dada/__init__.py
@@ -1,6 +1,6 @@
 # Licensed under the GPLv3 - see LICENSE.rst
 """Distributed Acquisition and Data Analysis (DADA) format reader/writer."""
-from .base import open
-from .header import DADAHeader
-from .payload import DADAPayload
-from .frame import DADAFrame
+from .base import open  # noqa
+from .header import DADAHeader  # noqa
+from .payload import DADAPayload  # noqa
+from .frame import DADAFrame  # noqa

--- a/baseband/gsb/__init__.py
+++ b/baseband/gsb/__init__.py
@@ -3,7 +3,7 @@
 
 See http://gmrt.ncra.tifr.res.in/gmrt_hpage/sub_system/gmrt_gsb/index.htm
 """
-from .base import open
-from .header import GSBHeader
-from .payload import GSBPayload
-from .frame import GSBFrame
+from .base import open  # noqa
+from .header import GSBHeader  # noqa
+from .payload import GSBPayload  # noqa
+from .frame import GSBFrame  # noqa

--- a/baseband/guppi/__init__.py
+++ b/baseband/guppi/__init__.py
@@ -2,7 +2,7 @@
 """Green Bank Ultimate Pulsar Processing Instrument (GUPPI) format
 reader/writer.
 """
-from .base import open
-from .header import GUPPIHeader
-from .payload import GUPPIPayload
-from .frame import GUPPIFrame
+from .base import open  # noqa
+from .header import GUPPIHeader  # noqa
+from .payload import GUPPIPayload  # noqa
+from .frame import GUPPIFrame  # noqa

--- a/baseband/mark4/__init__.py
+++ b/baseband/mark4/__init__.py
@@ -5,9 +5,9 @@ Code inspired by Walter Brisken's mark5access.  See
 https://github.com/demorest/mark5access.
 
 The format itself is described in detail in
-http://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
+https://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
 """
-from .base import open
-from .header import Mark4Header
-from .payload import Mark4Payload
-from .frame import Mark4Frame
+from .base import open  # noqa
+from .header import Mark4Header  # noqa
+from .payload import Mark4Payload  # noqa
+from .frame import Mark4Frame  # noqa

--- a/baseband/mark4/frame.py
+++ b/baseband/mark4/frame.py
@@ -6,7 +6,7 @@ Implements a Mark4Payload class used to store payload words, and decode to
 or encode from a data array.
 
 For the specification, see
-http://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
+https://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
 """
 import operator
 

--- a/baseband/mark4/header.py
+++ b/baseband/mark4/header.py
@@ -5,10 +5,10 @@ Implements a Mark4Header class used to store header words, and decode/encode
 the information therein.
 
 For the specification of tape Mark 4 format, see
-http://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
+https://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
 
 A little bit on the disk representation is at
-http://adsabs.harvard.edu/abs/2003ASPC..306..123W
+https://ui.adsabs.harvard.edu/abs/2003ASPC..306..123W
 """
 
 import numpy as np
@@ -34,7 +34,7 @@ CRC12 = 0x180f
 """CRC polynomial used for Mark 4 Headers.
 
 x^12 + x^11 + x^3 + x^2 + x + 1, i.e., 0x180f.
-See page 4 of http://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
+See page 4 of https://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
 
 This is also a 'standard' CRC-12 mentioned in
 https://en.wikipedia.org/wiki/Cyclic_redundancy_check
@@ -89,7 +89,7 @@ def words2stream(words):
 class Mark4TrackHeader(VLBIHeaderBase):
     """Decoder/encoder of a Mark 4 Track Header.
 
-    See http://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
+    See https://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
 
     Parameters
     ----------
@@ -189,7 +189,7 @@ class Mark4TrackHeader(VLBIHeaderBase):
         """Fractional seconds (decoded from 'bcd_fraction')."""
         ms = bcd_decode(self['bcd_fraction'])
         # The last digit encodes a fraction -- see table 2 in
-        # http://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
+        # https://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
         # 0: 0.00      5: 5.00
         # 1: 1.25      6: 6.25
         # 2: 2.50      7: 7.50
@@ -214,7 +214,7 @@ class Mark4TrackHeader(VLBIHeaderBase):
         'bcd_hour', 'bcd_minute', 'bcd_second' header items, as well as
         the ``fraction`` property (inferred from 'bcd_fraction') and
         ``decade`` from the initialisation.  See
-        See http://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
+        See https://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
         """
         return Time('{decade:03d}{uy:1x}:{d:03x}:{h:02x}:{m:02x}:{s:08.5f}'
                     .format(decade=self.decade//10, uy=self['bcd_unit_year'],
@@ -245,7 +245,7 @@ class Mark4TrackHeader(VLBIHeaderBase):
 class Mark4Header(Mark4TrackHeader):
     """Decoder/encoder of a Mark 4 Header, containing all streams.
 
-    See http://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
+    See https://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
 
     Parameters
     ----------
@@ -276,7 +276,7 @@ class Mark4Header(Mark4TrackHeader):
     _dtypes = MARK4_DTYPES
 
     # keyed with bps, fanout; Tables 10-14 in reference documentation:
-    # http://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
+    # https://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
     # rows are channels with Sign, Mag for each for bps=2, columns fanout.
     # So for bps=2, fanout=4 (abbreviating channel a Sign, Mag as aS, aM):
     # Channel a has samples (aS, aM) in tracks (2, 10), (4,12), etc.
@@ -361,7 +361,7 @@ class Mark4Header(Mark4TrackHeader):
         """Assignments of tracks to channels and fanout items.
 
         The assignments are inferred from tables 10-14 in
-        http://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
+        https://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
         except that 2 has been subtracted so that tracks start at 0,
         and that for 64 tracks the arrays are suitably enlarged by adding
         another set of channels.
@@ -681,7 +681,7 @@ class Mark4Header(Mark4TrackHeader):
 
         Uses bcd-encoded 'unit_year', 'day', 'hour', 'minute', 'second' and
         'frac_sec', plus ``decade`` from the initialisation to calculate the
-        time.  See http://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
+        time.  See https://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
         """
         if len(set(self['bcd_fraction'])) == 1:
             return self[0].time

--- a/baseband/mark4/payload.py
+++ b/baseband/mark4/payload.py
@@ -6,7 +6,7 @@ Implements a Mark4Payload class used to store payload words, and decode to
 or encode from a data array.
 
 For the specification, see
-http://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
+https://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
 """
 import sys
 from collections import namedtuple

--- a/baseband/mark5b/__init__.py
+++ b/baseband/mark5b/__init__.py
@@ -5,9 +5,9 @@ Code inspired by Walter Brisken's mark5access.  See
 https://github.com/demorest/mark5access.
 
 Also, for the Mark5B design, see
-http://www.haystack.mit.edu/tech/vlbi/mark5/mark5_memos/019.pdf
+https://www.haystack.mit.edu/tech/vlbi/mark5/mark5_memos/019.pdf
 """
-from .base import open
-from .header import Mark5BHeader
-from .payload import Mark5BPayload
-from .frame import Mark5BFrame
+from .base import open  # noqa
+from .header import Mark5BHeader  # noqa
+from .payload import Mark5BPayload  # noqa
+from .frame import Mark5BFrame  # noqa

--- a/baseband/mark5b/frame.py
+++ b/baseband/mark5b/frame.py
@@ -6,7 +6,7 @@ Implements a Mark5BFrame class that can be used to hold a header and a
 payload, providing access to the values encoded in both.
 
 For the specification, see
-http://www.haystack.edu/tech/vlbi/mark5/docs/Mark%205B%20users%20manual.pdf
+https://www.haystack.mit.edu/tech/vlbi/mark5/docs/Mark%205B%20users%20manual.pdf
 """
 import numpy as np
 

--- a/baseband/mark5b/header.py
+++ b/baseband/mark5b/header.py
@@ -6,7 +6,7 @@ Implements a Mark5BHeader class used to store header words, and decode/encode
 the information therein.
 
 For the specification, see
-http://www.haystack.edu/tech/vlbi/mark5/docs/Mark%205B%20users%20manual.pdf
+https://www.haystack.mit.edu/tech/vlbi/mark5/docs/Mark%205B%20users%20manual.pdf
 """
 import numpy as np
 import astropy.units as u
@@ -22,7 +22,7 @@ CRC16 = 0x18005
 """CRC polynomial used for Mark 5B Headers, as a check on the time code.
 
 x^16 + x^15 + x^2 + 1, i.e., 0x18005.
-See page 11 of http://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
+See page 11 of https://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
 (defined there for VLBA headers).
 
 This is also CRC-16-IBM mentioned in
@@ -35,7 +35,7 @@ class Mark5BHeader(VLBIHeaderBase):
     """Decoder/encoder of a Mark5B Frame Header.
 
     See page 15 of
-    http://www.haystack.edu/tech/vlbi/mark5/docs/Mark%205B%20users%20manual.pdf
+    https://www.haystack.mit.edu/tech/vlbi/mark5/docs/Mark%205B%20users%20manual.pdf
 
     Parameters
     ----------
@@ -241,7 +241,7 @@ class Mark5BHeader(VLBIHeaderBase):
         Calculate time using `jday`, `seconds`, and `fraction` properties
         (which reflect the bcd-encoded 'bcd_jday', 'bcd_seconds' and
         'bcd_fraction' header items), plus `kday` from the initialisation.  See
-        http://www.haystack.edu/tech/vlbi/mark5/docs/Mark%205B%20users%20manual.pdf
+        https://www.haystack.mit.edu/tech/vlbi/mark5/docs/Mark%205B%20users%20manual.pdf
 
         Note that some non-compliant files do not have 'bcd_fraction' set.
         For those, the time can still be calculated using the header's

--- a/baseband/mark5b/payload.py
+++ b/baseband/mark5b/payload.py
@@ -6,7 +6,7 @@ Implements a Mark5BPayload class used to store payload words, and decode to
 or encode from a data array.
 
 For the specification, see
-http://www.haystack.edu/tech/vlbi/mark5/docs/Mark%205B%20users%20manual.pdf
+https://www.haystack.mit.edu/tech/vlbi/mark5/docs/Mark%205B%20users%20manual.pdf
 """
 from collections import namedtuple
 
@@ -47,9 +47,9 @@ def init_luts():
     Note that the sign bit is flipped for 1-bit mode from what one might
     expect from the 2-bit encodings (at least, as implemented in mark5access;
     the docs are rather unclear).  For more details, see Table 13 in
-    http://library.nrao.edu/public/memos/vlba/up/VLBASU_13.pdf
+    https://library.nrao.edu/public/memos/vlba/up/VLBASU_13.pdf
     and
-    http://www.haystack.edu/tech/vlbi/mark5/docs/Mark%205B%20users%20manual.pdf
+    https://www.haystack.mit.edu/tech/vlbi/mark5/docs/Mark%205B%20users%20manual.pdf
     Appendix A: sign always on even bit stream (0, 2, 4, ...), and magnitude
     on adjacent odd stream (1, 3, 5, ...).
 

--- a/baseband/vdif/__init__.py
+++ b/baseband/vdif/__init__.py
@@ -10,9 +10,9 @@
 #
 """VLBI Data Interchange Format (VDIF) reader/writer
 
-For the VDIF specification, see http://www.vlbi.org/vdif
+For the VDIF specification, see https://vlbi.org/vlbi-standards/vdif/
 """
-from .base import open
-from .header import VDIFHeader
-from .payload import VDIFPayload
-from .frame import VDIFFrame, VDIFFrameSet
+from .base import open  # noqa
+from .header import VDIFHeader  # noqa
+from .payload import VDIFPayload  # noqa
+from .frame import VDIFFrame, VDIFFrameSet  # noqa

--- a/baseband/vlbi_base/tests/test_utils.py
+++ b/baseband/vlbi_base/tests/test_utils.py
@@ -52,7 +52,7 @@ class TestCRC12:
 
     def setup(self):
         # Test example from page 4 of
-        # http://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
+        # https://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
         stream_hex = '0000 002D 0330 0000' + 'FFFF FFFF' + '4053 2143 3805 5'
         self.crc_hex = '284'
         self.crc12 = CRC(0x180f)

--- a/docs/guppi/index.rst
+++ b/docs/guppi/index.rst
@@ -9,14 +9,13 @@ GUPPI
 The GUPPI format is the output of the `Green Bank Ultimate Pulsar Processing
 Instrument <https://safe.nrao.edu/wiki/bin/view/CICADA/NGNPP>`_ and any clones
 operating at other telescopes, such as `PUPPI at the Arecibo Observatory
-<http://www.naic.edu/puppi-observing/>`_.  Baseband specifically supports GUPPI
-data **taken in baseband mode**, and is based off of `DSPSR's implementation
-<https://github.com/demorest/dspsr>`_.  While general format specifications can
-be found at the `SERA Project
-<http://seraproject.org/mw/index.php?title=GBT_FIle_Formats>`_ and on `Paul
-Demorest's site <https://www.cv.nrao.edu/~pdemores/GUPPI_Raw_Data_Format>`_,
-some of the header information could be invalid or not applicable,
-particularly with older files.
+<https://www.naic.edu/puppi-observing/>`_.  Baseband specifically supports
+GUPPI data **taken in baseband mode**, and is based off of `DSPSR's
+implementation <https://github.com/demorest/dspsr>`_.  While general format
+specifications can be found on `Paul Demorest's site
+<https://www.cv.nrao.edu/~pdemores/GUPPI_Raw_Data_Format>`_, some of the
+header information could be invalid or not applicable, particularly with older
+files.
 
 Baseband currently only supports 8-bit |elementary samples|.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,8 +5,8 @@ Baseband
 ********
 
 Welcome to the Baseband documentation!  Baseband is a package
-`affiliated <http://www.astropy.org/affiliated/index.html>`_ with the
-`Astropy project <http://www.astropy.org>`_ for reading and
+`affiliated <https://www.astropy.org/affiliated/index.html>`_ with the
+`Astropy project <https://www.astropy.org>`_ for reading and
 writing VLBI and other radio baseband files, with the aim of simplifying and
 streamlining data conversion and standardization.  It provides:
 
@@ -89,8 +89,8 @@ publishing new code releases.
 Project Details
 ===============
 
-.. image:: http://img.shields.io/badge/powered%20by-AstroPy-orange.svg?style=flat
-    :target: http://www.astropy.org
+.. image:: https://img.shields.io/badge/powered%20by-AstroPy-orange.svg?style=flat
+    :target: https://www.astropy.org/
     :alt: Powered by Astropy Badge
 
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.1214268.svg
@@ -103,7 +103,7 @@ Project Details
    :target: https://coveralls.io/github/mhvk/baseband
 
 .. image:: https://readthedocs.org/projects/baseband/badge/?version=latest
-   :target: http://baseband.readthedocs.io/en/latest/?badge=latest
+   :target: https://baseband.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation Status
 
 .. toctree::

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -12,14 +12,14 @@ Requirements
 Baseband requires:
 
     - `Astropy`_ v3.0 or later
-    - `Numpy <http://www.numpy.org/>`_ v1.10 or later
+    - `Numpy <https://www.numpy.org/>`_ v1.10 or later
 
 .. _install_baseband:
 
 Installing Baseband
 ===================
 
-To install Baseband with `pip <http://www.pip-installer.org/en/latest/>`_,
+To install Baseband with `pip <https://pip.pypa.io/>`_,
 run::
 
     pip3 install baseband
@@ -85,7 +85,7 @@ or, inside of Python::
     import baseband
     baseband.test()
 
-These tests require `pytest <http://pytest.org>`_ to be installed. Further
+These tests require `pytest <https://pytest.org>`_ to be installed. Further
 documentation can be found on the `Astropy running tests documentation
 <https://astropy.readthedocs.io/en/stable/development/testguide.html#running-tests>`_
 .
@@ -107,5 +107,5 @@ the root directory::
 
     python3 setup.py build_docs
 
-This requires to have `Sphinx <http://sphinx.pocoo.org>`_ installed (and its
+This requires to have `Sphinx <https://www.sphinx-doc.org>`_ installed (and its
 dependencies).

--- a/docs/mark4/index.rst
+++ b/docs/mark4/index.rst
@@ -14,7 +14,7 @@ in the Mark IIIA/IV/VLBA `design specifications`_.
 Baseband currently only supports files that have been parity-stripped and
 corrected for barrel roll and data modulation.
 
-.. _design specifications: http://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
+.. _design specifications: https://www.haystack.mit.edu/tech/vlbi/mark5/docs/230.3.pdf
 
 .. _mark4_file_structure:
 

--- a/docs/mark5b/index.rst
+++ b/docs/mark5b/index.rst
@@ -9,7 +9,7 @@ MARK 5B
 The Mark 5B format is the output format of the Mark 5B disk-based VLBI data
 system.  It is described in its `design specifications`_.
 
-.. _design specifications: http://www.haystack.mit.edu/tech/vlbi/mark5/mark5_memos/019.pdf
+.. _design specifications: https://www.haystack.mit.edu/tech/vlbi/mark5/mark5_memos/019.pdf
 
 .. _mark5b_file_structure:
 

--- a/docs/tutorials/getting_started.rst
+++ b/docs/tutorials/getting_started.rst
@@ -30,7 +30,7 @@ For this tutorial, we'll use two sample files::
 
     >>> from baseband.data import SAMPLE_VDIF, SAMPLE_MARK5B
 
-The first file is a VDIF one created from `EVN <http://www.evlbi.org/>`_/`VLBA
+The first file is a VDIF one created from `EVN <https://www.evlbi.org/>`_/`VLBA
 <https://public.nrao.edu/telescopes/vlba/>`_ observations of `Black Widow
 pulsar PSR B1957+20 <https://en.wikipedia.org/wiki/Black_Widow_Pulsar>`_,
 while the second is a Mark 5B from EVN/`WSRT

--- a/docs/tutorials/release_procedure.rst
+++ b/docs/tutorials/release_procedure.rst
@@ -5,7 +5,7 @@ Release Procedure
 *****************
 
 This procedure is based off of `Astropy's
-<http://docs.astropy.org/en/stable/development/releasing.html>`_, and
+<https://docs.astropy.org/en/stable/development/releasing.html>`_, and
 additionally uses information from the `PyPI packaging tutorial
 <https://packaging.python.org/tutorials/packaging-projects/>`_.
 
@@ -24,7 +24,7 @@ To make releases, you will need
   associated with your GitHub account.  While releases do not need to be
   signed, we recommend doing so to ensure they are trustworthy.  To make a GPG
   key and associate it with your GitHub account, see the `Astropy documentation
-  <http://docs.astropy.org/en/stable/development/releasing.html#creating-a-gpg-signing-key-and-a-signed-tag>`_.
+  <https://docs.astropy.org/en/stable/development/releasing.html#creating-a-gpg-signing-key-and-a-signed-tag>`_.
 
 Versioning
 ==========
@@ -95,7 +95,7 @@ main development branch.  Then, for each::
     git cherry-pick -m 1 <SHA-1>
 
 For more information, see `Astropy's documentation
-<http://docs.astropy.org/en/stable/development/releasing.html#backporting-fixes-from-master>`_.
+<https://docs.astropy.org/en/stable/development/releasing.html#backporting-fixes-from-master>`_.
 
 Once you have cherry-picked, check the following:
 

--- a/docs/tutorials/using_baseband.rst
+++ b/docs/tutorials/using_baseband.rst
@@ -24,7 +24,7 @@ basics of :ref:`inspecting files <using_baseband_inspecting>`, :ref:`reading
 <using_baseband_reading>` from and :ref:`writing <using_baseband_writing>`
 to files, and :ref:`converting <using_baseband_converting>` from one format
 to another.  We assume that Baseband as well as `NumPy
-<http://www.numpy.org/>`_ and the `Astropy`_ units module have been imported::
+<https://www.numpy.org/>`_ and the `Astropy`_ units module have been imported::
 
     >>> import baseband
     >>> import numpy as np

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,6 @@ exclude =
     docs/conf.py,
     ah_bootstrap.py,setup.py,ez_setup.py,
     astropy_helpers,
-    __init__.py,
     # standard things to ignore
     __pycache__,build,dist,htmlcov,licenses
 


### PR DESCRIPTION
The readthedocs page suggested our documentation was not completely safe, since one image was gotten through http rather than https. So, updating it all. Plus some cleanup.