### PR TITLE
Make VLBI baseband file reading more robust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ matrix:
 
         # Comprehensive tests.
         # Check for sphinx doc build warnings.
-        - env: SETUP_CMD='build_sphinx -w'
+        - env: SETUP_CMD='build_docs -w'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_DOC
 
         # Check everything, including coverage, with oldest supported versions.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,11 @@ Bug Fixes
 Other Changes and Additions
 ---------------------------
 
+- The Mark 4, Mark 5B, and VDIF stream readers are now able to replace
+  missing pieces of files with zeros using ``verify='fix'``. This is
+  also the new default; use ``verify=True`` for the old behaviour of
+  raising an error on any inconsistency. [#357]
+
 - Much faster localization of Mark 5B frames. [#351]
 
 - VLBI file readers have gained a new method ``locate_frames`` that finds
@@ -30,7 +35,7 @@ Other Changes and Additions
 - For VLBI file readers, ``find_header`` now raises an exception if no
   frame is found (rather than return `None`).
 
-- The the Mark 4 file reader's ``locate_frame`` has been deprecated. Its
+- The Mark 4 file reader's ``locate_frame`` has been deprecated. Its
   functionality is replaced by ``locate_frames`` and ``find_header``. [#354]
 
 - Custom stream readers can now override only part of reading a given frame

--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -283,7 +283,7 @@ class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase):
         with self.fh_raw.temporary_offset() as fh_raw:
             self._seek_frame(self._nframes - 1)
             header = fh_raw.read_header()
-            payload_nbytes = self._raw_file_size - self.fh_raw.tell()
+            payload_nbytes = self._raw_file_size - fh_raw.tell()
             assert payload_nbytes > 0, 'setup failed: no payload in last frame'
             if header.payload_nbytes > payload_nbytes:
                 # Truncated last frame.  Adjust header to give the actual
@@ -329,7 +329,7 @@ class DADAStreamReader(DADAStreamBase, VLBIStreamReaderBase):
 
     def _tell_frame(self, frame):
         # Override for faster calculation of frame index.
-        return int(round((frame.header['OBS_OFFSET']
+        return int(round((frame['OBS_OFFSET']
                           - self.header0['OBS_OFFSET'])
                          / self.header0.payload_nbytes))
 

--- a/baseband/guppi/base.py
+++ b/baseband/guppi/base.py
@@ -260,14 +260,15 @@ class GUPPIStreamReader(GUPPIStreamBase, VLBIStreamReaderBase):
         """Header of the last file for this stream."""
         # Seek forward rather than backward, as last frame often has missing
         # bytes.
-        nframes, fframe = divmod(self.fh_raw.seek(0, 2),
-                                 self.header0.frame_nbytes)
-        self.fh_raw.seek((nframes - 1) * self.header0.frame_nbytes)
-        return self.fh_raw.read_header()
+        with self.fh_raw.temporary_offset() as fh_raw:
+            nframes, fframe = divmod(fh_raw.seek(0, 2),
+                                     self.header0.frame_nbytes)
+            fh_raw.seek((nframes - 1) * self.header0.frame_nbytes)
+            return fh_raw.read_header()
 
     def _tell_frame(self, frame):
         # Override to avoid calculating index from time.
-        return int(round((frame.header['PKTIDX'] - self.header0['PKTIDX'])
+        return int(round((frame['PKTIDX'] - self.header0['PKTIDX'])
                          / self._packets_per_frame))
 
 

--- a/baseband/helpers/sequentialfile.py
+++ b/baseband/helpers/sequentialfile.py
@@ -212,6 +212,13 @@ class SequentialFileReader(SequentialFileBase):
         Function to open a single file (default: `io.open`).
     """
 
+    def __getattr__(self, attr):
+        if attr.startswith('read'):
+            # Ensure we skip to the next file if needed.
+            self.seek(0, 1)
+
+        return super().__getattr__(attr)
+
     @property
     def file_size(self):
         """Size of the underlying file currently open for reading."""
@@ -277,6 +284,8 @@ class SequentialFileReader(SequentialFileBase):
 
         data = b''
         while count > 0:
+            # Go to current offset, possibly opening new file.
+            self.seek(0, 1)
             extra = self.fh.read(count)
             if not extra:
                 break
@@ -285,8 +294,6 @@ class SequentialFileReader(SequentialFileBase):
                 data = extra
             else:
                 data += extra
-            # Go to current offset, possibly opening new file.
-            self.seek(0, 1)
 
         return data
     read.__doc__ = io.BufferedIOBase.read.__doc__

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -106,6 +106,7 @@ class Mark4FileReader(VLBIFileReaderBase):
     def locate_frames(self, pattern=None, *, mask=None, frame_nbytes=None,
                       offset=0, forward=True, maximum=None, check=1):
         """Use a pattern to locate frame starts near the current position.
+
         Parameters
         ----------
         pattern : header, ~numpy.ndaray, bytes, or (iterable of) int, optional

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -347,11 +347,11 @@ class Mark4StreamReader(Mark4StreamBase, VLBIStreamReaderBase):
                              .format(ntrack),)
             raise exc
 
-        self._offset0 = fh_raw.tell()
         super().__init__(
             fh_raw, header0=header0, sample_rate=sample_rate,
             squeeze=squeeze, subset=subset, fill_value=fill_value,
             verify=verify)
+        self._raw_offsets[0] = fh_raw.tell()
         # Use reference time in preference to decade so that a stream wrapping
         # a decade will work.
         self.fh_raw.decade = None
@@ -365,11 +365,6 @@ class Mark4StreamReader(Mark4StreamBase, VLBIStreamReaderBase):
         # 4 years away from the start.
         last_header.infer_decade(self.start_time)
         return last_header
-
-    def _seek_frame(self, index):
-        # Override vlbi_base version to include offset.
-        return self.fh_raw.seek(self._offset0
-                                + index*self.header0.frame_nbytes)
 
 
 class Mark4StreamWriter(Mark4StreamBase, VLBIStreamWriterBase):

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -319,16 +319,17 @@ class Mark4StreamReader(Mark4StreamBase, VLBIStreamReaderBase):
         squeezing).  If an empty tuple (default), all channels are read.
     fill_value : float or complex, optional
         Value to use for invalid or missing data. Default: 0.
-    verify : bool, optional
-        Whether to do basic checks of frame integrity when reading.  The first
-        frame of the stream is always checked.  Default: `True`.
+    verify : bool or str, optional
+        Whether to do basic checks of frame integrity when reading.
+        Default: 'fix', which implies basic verification and replacement
+        of gaps with zeros.
     """
 
     _sample_shape_maker = Mark4Payload._sample_shape_maker
 
     def __init__(self, fh_raw, sample_rate=None, ntrack=None, decade=None,
                  ref_time=None, squeeze=True, subset=(), fill_value=0.,
-                 verify=True):
+                 verify='fix'):
 
         if decade is None and ref_time is None:
             raise TypeError("Mark 4 stream reader requires either decade or "
@@ -452,9 +453,10 @@ subset : indexing object, optional
     squeezing).  If an empty tuple (default), all channels are read.
 fill_value : float or complex, optional
     Value to use for invalid or missing data. Default: 0.
-verify : bool, optional
-    Whether to do basic checks of frame integrity when reading.  The first
-    frame of the stream is always checked.  Default: `True`.
+verify : bool or 'fix', optional
+    Whether to do basic checks of frame integrity when reading.
+    Default: 'fix', which implies basic verification and replacement
+    of gaps with zeros.
 
 --- For writing a stream : (see `~baseband.mark4.base.Mark4StreamWriter`)
 

--- a/baseband/mark4/tests/test_corrupt_files.py
+++ b/baseband/mark4/tests/test_corrupt_files.py
@@ -1,0 +1,116 @@
+# Licensed under the GPLv3 - see LICENSE
+import pytest
+import numpy as np
+from astropy import units as u
+from astropy.time import Time
+
+from ... import mark4
+
+
+class TestCorruptFile:
+    def setup(self):
+        time = Time('2010-11-12T13:14:15')
+        self.nchan = 2
+        self.header0 = mark4.Mark4Header.fromvalues(
+            time=time, ntrack=16, nchan=self.nchan, fanout=4)
+        self.data = np.zeros((2*self.header0.frame_nbytes, 2))
+        self.data.reshape(-1, 4, 2)[160:] = [
+            [-1, 1], [-3, 3], [1, -1], [3, -3]]
+        self.sample_rate = 100 * u.kHz
+        self.kwargs = dict(sample_rate=self.sample_rate,
+                           ref_time=time)
+
+    def fake_file(self, tmpdir, nframes=8):
+        filename = str(tmpdir.join('fake.mark4'))
+        with mark4.open(filename, 'ws', header0=self.header0,
+                        sample_rate=self.sample_rate) as fw:
+            for _ in range(nframes):
+                fw.write(self.data)
+        return filename
+
+    def test_fake_file(self, tmpdir):
+        fake_file = self.fake_file(tmpdir)
+        with mark4.open(fake_file, 'rs', **self.kwargs) as fr:
+            data = fr.read()
+
+        data = data.reshape((-1,) + self.data.shape)
+        assert np.all(data.astype(int) == self.data)
+
+    def corrupt_copy(self, filename, missing):
+        corrupt_name = filename.replace('.mark4', '_corrupt.mark4')
+        with open(filename, 'rb') as fr, \
+                open(corrupt_name, 'wb') as fw:
+            fw.write(fr.read(missing.start))
+            fr.seek(missing.stop)
+            fw.write(fr.read())
+        return corrupt_name
+
+    @pytest.mark.parametrize('frame_nr', [1, 3, slice(3, 5)])
+    def test_missing_frames(self, frame_nr, tmpdir):
+        if not isinstance(frame_nr, slice):
+            frame_nr = slice(frame_nr, frame_nr+1)
+        missing = slice(frame_nr.start * self.header0.frame_nbytes,
+                        frame_nr.stop * self.header0.frame_nbytes)
+        fake_file = self.fake_file(tmpdir)
+        corrupt_file = self.corrupt_copy(fake_file, missing)
+        with mark4.open(corrupt_file, 'rs', **self.kwargs) as fr:
+            with pytest.warns(UserWarning, match='problem loading'):
+                data = fr.read()
+
+        data = data.reshape((-1,) + self.data.shape)
+        assert np.all(data[:frame_nr.start].astype(int) == self.data)
+        assert np.all(data[frame_nr.stop:].astype(int) == self.data)
+        assert np.all(data[frame_nr] == 0.)
+
+    @pytest.mark.parametrize('missing_bytes', [
+        slice(0, 40000),  # Remove whole last frame set.
+        slice(0, 320),  # Remove header of last frame.
+        slice(8, 16),  # Corrupt header of last frame.
+        slice(0, 1),  # Corrupt header byte of last frame.
+        slice(10, 11),  # Corrupt header byte of last frame.
+        slice(319, 320),  # Corrupt header byte of last frame.
+        slice(400, 401),  # Corrupt payload byte of last frame.
+        slice(39999, 40000),  # last byte of last frame.
+    ])
+    def test_missing_end(self, missing_bytes, tmpdir):
+        # In all these cases, the data read should just be short, but
+        # it varies by how much: If the sync pattern is still there,
+        # or the whole last frame is missing, we'll lose the last
+        # frame.  Otherwise, the one-but-last header will not be
+        # considered OK and we lose that frame too.
+        if missing_bytes.start > 192 or (missing_bytes.start == 0
+                                         and missing_bytes.stop == 40000):
+            expected = 7
+        else:
+            expected = 6
+        missing = slice(missing_bytes.start + 7*self.header0.frame_nbytes,
+                        missing_bytes.stop + 7*self.header0.frame_nbytes)
+        fake_file = self.fake_file(tmpdir)
+        corrupt_file = self.corrupt_copy(fake_file, missing)
+        with mark4.open(corrupt_file, 'rs', **self.kwargs) as fr:
+            assert len(fr.fh_raw.locate_frames(
+                fr.header0, maximum=1000000)) == expected
+            assert fr.size == expected * self.data.size
+            data = fr.read()
+
+        data = data.reshape((-1,) + self.data.shape)
+        assert np.all(data.astype(int) == self.data)
+
+    @pytest.mark.parametrize('missing_bytes,missing_frames', [
+        (slice(40000, 80000), slice(1, 2)),  # Remove frame 1.
+        (slice(78000, 82000), slice(1, 3)),  # Corrupt frames 1,2.
+        (slice(80010, 80100), slice(1, 3)),  # Corrupted header 2.
+    ])
+    def test_missing_middle(self, missing_bytes, missing_frames, tmpdir):
+        # In all these cases, some data will be missing.
+        fake_file = self.fake_file(tmpdir)
+        corrupt_file = self.corrupt_copy(fake_file, missing_bytes)
+        with mark4.open(corrupt_file, 'rs', **self.kwargs) as fr:
+            assert fr.size == 8 * self.data.size
+            with pytest.warns(UserWarning, match='problem loading frame'):
+                data = fr.read()
+
+        data = data.reshape((-1,) + self.data.shape)
+        expected = np.stack([self.data] * 8)
+        expected[missing_frames] = 0.
+        assert np.all(data.astype(int) == expected)

--- a/baseband/mark4/tests/test_mark4.py
+++ b/baseband/mark4/tests/test_mark4.py
@@ -844,6 +844,13 @@ class TestMark4:
                                    np.zeros_like(frame1.data), frame1.data))
         assert_array_equal(data, expected)
 
+        with mark4.open(corrupt_file, 'rs', sample_rate=32*u.MHz,
+                        ntrack=64, decade=2010, verify=True) as f3:
+            assert f3.start_time == frame0.header.time
+            assert abs(f3.stop_time - frame1.header.time - dt) < 1*u.ns
+            with pytest.raises(ValueError, match='wrong frame number'):
+                data = f3.read()
+
     def test_stream_invalid(self):
         with pytest.raises(ValueError):
             mark4.open('ts.dat', 's')

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -210,16 +210,17 @@ class Mark5BStreamReader(Mark5BStreamBase, VLBIStreamReaderBase):
         squeezing). If an empty tuple (default), all channels are read.
     fill_value : float or complex
         Value to use for invalid or missing data. Default: 0.
-    verify : bool, optional
-        Whether to do basic checks of frame integrity when reading.  The first
-        frame of the stream is always checked.  Default: `True`.
+    verify : bool or 'fix', optional
+        Whether to do basic checks of frame integrity when reading.
+        Default: 'fix', which implies basic verification and replacement
+        of gaps with zeros.
     """
 
     _sample_shape_maker = Mark5BPayload._sample_shape_maker
 
     def __init__(self, fh_raw, sample_rate=None, kday=None, ref_time=None,
                  nchan=None, bps=2, squeeze=True, subset=(), fill_value=0.,
-                 verify=True):
+                 verify='fix'):
 
         if nchan is None:
             raise TypeError("Mark 5B stream reader requires nchan to be "
@@ -354,9 +355,10 @@ subset : indexing object, optional
     squeezing). If an empty tuple (default), all channels are read.
 fill_value : float or complex
     Value to use for invalid or missing data. Default: 0.
-verify : bool, optional
-    Whether to do basic checks of frame integrity when reading.  The first
-    frame of the stream is always checked.  Default: `True`.
+verify : bool or 'fix', optional
+    Whether to do basic checks of frame integrity when reading.
+    Default: 'fix', which implies basic verification and replacement
+    of gaps with zeros.
 
 --- For writing a stream : (see `~baseband.mark5b.base.Mark5BStreamWriter`)
 

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -250,6 +250,9 @@ class Mark5BStreamReader(Mark5BStreamBase, VLBIStreamReaderBase):
         last_header.infer_kday(self.start_time)
         return last_header
 
+    def _set_time(self, header, time):
+        header.set_time(time, frame_rate=self._frame_rate)
+
     def _tell_frame(self, frame):
         # Override to provide index faster, without calculating times.
         # TODO: OK to ignore leap seconds? Not sure what writer does.

--- a/baseband/mark5b/tests/test_corrupt_files.py
+++ b/baseband/mark5b/tests/test_corrupt_files.py
@@ -1,0 +1,232 @@
+# Licensed under the GPLv3 - see LICENSE
+import pytest
+import numpy as np
+from astropy import units as u
+from astropy.time import Time
+
+from ... import mark5b
+from ...data import SAMPLE_MARK5B as SAMPLE_FILE
+from ...vlbi_base.base import HeaderNotFoundError
+
+
+class TestCorruptSampleCopy:
+    def setup(self):
+        with open(SAMPLE_FILE, 'rb') as fh:
+            self.sample_bytes = fh.read()
+        with mark5b.open(SAMPLE_FILE, 'rs', sample_rate=32*u.MHz,
+                         kday=56000, nchan=8, bps=2) as fs:
+            self.frame_nbytes = fs.header0.frame_nbytes
+            self.frame_rate = fs._frame_rate
+            self.start_time = fs.start_time
+            self.stop_time = fs.stop_time
+            self.data = fs.read()
+            self.frame3 = fs._frame
+
+    def expected_bad_frames(self, missing):
+        (start_f, start_r), (stop_f, stop_r) = [
+            divmod(s, self.frame_nbytes)
+            for s in (missing.start, missing.stop-1)]
+
+        if start_r < 5:  # invariants touched?
+            start_f -= 1
+
+        return start_f, stop_f+1
+
+    @pytest.mark.parametrize('missing,expected_bad_start,expected_bad_stop', [
+        (slice(20032, 20033), 1, 3),  # First byte of header of frame 2.
+        (slice(20096, 20100), 2, 3),  # Part of payload of frame 2.
+        (slice(12000, 22000), 1, 3),  # Parts of 1-2.
+        (slice(30060, 30070), 3, 4),  # Part of header of frame 3.
+        (slice(40063, 40064), 3, 4)])  # Last byte of last frame.
+    def test_expected_bad_frames(self, missing, expected_bad_start,
+                                 expected_bad_stop):
+        bad_start, bad_stop = self.expected_bad_frames(missing)
+        assert bad_start == expected_bad_start
+        assert bad_stop == expected_bad_stop
+
+    @pytest.mark.parametrize('missing', [
+        slice(20032, 20033),  # First byte of header of frame 2.
+        slice(20096, 20100),  # Part of payload of frame 2.
+        slice(12000, 22000),  # Parts of 1-2.
+        slice(30060, 30070),  # Part of header of frame 3.
+        slice(40063, 40064)])  # Last byte of last frame.
+    def test_bad_frames(self, missing, tmpdir):
+        corrupted = (self.sample_bytes[:missing.start]
+                     + self.sample_bytes[missing.stop:])
+        bad_start, bad_stop = self.expected_bad_frames(missing)
+
+        filename = str(tmpdir.join('corrupted.m5b'))
+        with open(filename, 'wb') as fw:
+            fw.write(corrupted)
+
+        with mark5b.open(filename, 'rb', nchan=8, bps=2) as fr:
+            for i in range(bad_start):
+                header = fr.find_header(forward=True, maximum=40000,
+                                        check=1)
+                assert header['frame_nr'] == i
+                fr.seek(16, 1)
+
+            if bad_stop < 4:
+                header = fr.find_header(forward=True, maximum=40000,
+                                        check=1)
+                assert header['frame_nr'] == bad_stop
+                fr.seek(16, 1)
+
+                for i in range(bad_stop+1, 4):
+                    header = fr.find_header(forward=True, maximum=40000,
+                                            check=1)
+                    assert header['frame_nr'] == i
+                    fr.seek(16, 1)
+            else:
+                with pytest.raises(HeaderNotFoundError):
+                    fr.find_header(forward=True, maximum=40000,
+                                   check=1)
+
+    # Have to keep frame 0 intact, as well as header of frame 1.
+    @pytest.mark.parametrize('missing', [
+        slice(20032, 20033),  # First byte of header of frame 2.
+        slice(20096, 20100),  # Part of payload of frame 2.
+        slice(12000, 22000),  # Parts of 1-2.
+        slice(30060, 30070),  # Part of header of frame 3.
+        slice(40063, 40064)])  # Last byte of last frame.
+    def test_missing_bytes(self, missing, tmpdir):
+        corrupted = (self.sample_bytes[:missing.start]
+                     + self.sample_bytes[missing.stop:])
+        bad_start, bad_stop = self.expected_bad_frames(missing)
+
+        filename = str(tmpdir.join('corrupted.m5b'))
+        with open(filename, 'wb') as fw:
+            fw.write(corrupted)
+            # Add four more frames to ensure that _last_header is OK.
+            for i in range(4, 8):
+                header = self.frame3.header.copy()
+                header.set_time(self.start_time + i/self.frame_rate,
+                                frame_rate=self.frame_rate)
+                header.update()
+                frame = self.frame3.__class__(header, self.frame3.payload,
+                                              valid=False)
+                frame.tofile(fw)
+
+        with mark5b.open(filename, 'rs', sample_rate=32*u.MHz,
+                         kday=56000, nchan=8, bps=2) as fr:
+            assert fr.start_time == self.start_time
+            assert abs(fr.stop_time - self.stop_time
+                       - 4 / self.frame_rate) < 1.*u.ns
+            with pytest.warns(UserWarning,
+                              match='problem loading frame'):
+                data = fr.read()
+
+        assert data.shape == (40000, 8)
+
+        expected = self.data.copy().reshape(-1, 5000, 8)
+        expected[bad_start:bad_stop] = 0.
+        expected.shape = -1, 8
+        expected = np.concatenate((expected, np.zeros_like(expected)))
+
+        assert np.all(data == expected)
+
+
+class TestCorruptFile:
+    def setup(self):
+        time = Time('2010-11-12T13:14:15')
+        self.header0 = mark5b.Mark5BHeader.fromvalues(time=time)
+        self.data = np.repeat([[-1, 1], [-3, 3]], 10000, axis=0)
+        self.nchan = 2
+        self.sample_rate = 100 * u.kHz
+        self.kwargs = dict(nchan=self.nchan,
+                           sample_rate=self.sample_rate,
+                           ref_time=time)
+
+    def fake_file(self, tmpdir, nframes=16):
+        filename = str(tmpdir.join('fake.mark5b'))
+        with mark5b.open(filename, 'ws', header0=self.header0,
+                         sample_rate=self.sample_rate,
+                         nchan=self.nchan) as fw:
+            for _ in range(nframes):
+                fw.write(self.data)
+        return filename
+
+    def test_fake_file(self, tmpdir):
+        fake_file = self.fake_file(tmpdir)
+        with mark5b.open(fake_file, 'rs', **self.kwargs) as fr:
+            data = fr.read()
+
+        data = data.reshape((-1,) + self.data.shape)
+        assert np.all(data.astype(int) == self.data)
+
+    def corrupt_copy(self, filename, missing):
+        corrupt_name = filename.replace('.mark5b', '_corrupt.mark5b')
+        with open(filename, 'rb') as fr, \
+                open(corrupt_name, 'wb') as fw:
+            fw.write(fr.read(missing.start))
+            fr.seek(missing.stop)
+            fw.write(fr.read())
+        return corrupt_name
+
+    @pytest.mark.parametrize('frame_nr', [1, 3, 5, slice(7, 10)])
+    def test_missing_frames(self, frame_nr, tmpdir):
+        if not isinstance(frame_nr, slice):
+            frame_nr = slice(frame_nr, frame_nr+1)
+        missing = slice(frame_nr.start * self.header0.frame_nbytes,
+                        frame_nr.stop * self.header0.frame_nbytes)
+        fake_file = self.fake_file(tmpdir)
+        corrupt_file = self.corrupt_copy(fake_file, missing)
+        with mark5b.open(corrupt_file, 'rs', **self.kwargs) as fr:
+            with pytest.warns(UserWarning, match='problem loading'):
+                data = fr.read()
+
+        data = data.reshape((-1,) + self.data.shape)
+        assert np.all(data[:frame_nr.start].astype(int) == self.data)
+        assert np.all(data[frame_nr.stop:].astype(int) == self.data)
+        assert np.all(data[frame_nr] == 0.)
+
+    @pytest.mark.parametrize('missing_bytes', [
+        slice(0, 10016),  # Remove whole last frame set.
+        slice(0, 16),  # Remove header of last frame.
+        slice(8, 16),  # Corrupt header of last frame.
+        slice(0, 1),  # Corrupt header byte of last frame.
+        slice(10, 11),  # Corrupt header byte of last frame.
+        slice(15, 16),  # Corrupt header byte of last frame.
+        slice(20, 21),  # Corrupt payload byte of last frame.
+        slice(10015, 10016),  # last byte of last frame.
+    ])
+    def test_missing_end(self, missing_bytes, tmpdir):
+        # In all these cases, the data read should just be short.
+        missing = slice(missing_bytes.start + 15*self.header0.frame_nbytes,
+                        missing_bytes.stop + 15*self.header0.frame_nbytes)
+        fake_file = self.fake_file(tmpdir)
+        corrupt_file = self.corrupt_copy(fake_file, missing)
+        # If the sync pattern is still there, or the whole last frame
+        # is missing, we'll get all but one.  Otherwise, the one-but-last
+        # header will not be considered OK and we loose that frame too.
+        if missing_bytes.start > 5 or (missing_bytes.start == 0
+                                       and missing_bytes.stop == 10016):
+            expected = 15
+        else:
+            expected = 14
+
+        with mark5b.open(corrupt_file, 'rs', **self.kwargs) as fr:
+            assert fr.size == expected * self.data.size
+            data = fr.read()
+
+        data = data.reshape((-1,) + self.data.shape)
+        assert np.all(data.astype(int) == self.data)
+
+    @pytest.mark.parametrize('missing_bytes,missing_frames', [
+        (slice(10016, 20032), slice(1, 2)),  # Remove frame 1.
+        (slice(20000, 20501), slice(1, 3)),  # Corrupt frames 1,2.
+        (slice(20032, 20048), slice(1, 3)),  # Missing header 2.
+    ])
+    def test_missing_middle(self, missing_bytes, missing_frames, tmpdir):
+        # In all these cases, some data will be missing.
+        fake_file = self.fake_file(tmpdir)
+        corrupt_file = self.corrupt_copy(fake_file, missing_bytes)
+        with mark5b.open(corrupt_file, 'rs', **self.kwargs) as fr:
+            assert fr.size == 16 * self.data.size
+            with pytest.warns(UserWarning, match='problem loading frame'):
+                data = fr.read()
+
+        data = data.reshape((-1,) + self.data.shape)
+        expected = np.stack([self.data] * 16)
+        expected[missing_frames] = 0.
+        assert np.all(data.astype(int) == expected)

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -368,7 +368,7 @@ class VDIFStreamReader(VDIFStreamBase, VLBIStreamReaderBase):
     """
 
     def __init__(self, fh_raw, sample_rate=None, squeeze=True, subset=(),
-                 fill_value=0., verify=True):
+                 fill_value=0., verify='fix'):
         fh_raw = VDIFFileReader(fh_raw)
         # We read the first frameset, since we need to know how many threads
         # there are, and what the frameset size is.

--- a/baseband/vdif/frame.py
+++ b/baseband/vdif/frame.py
@@ -248,13 +248,8 @@ class VDIFFrameSet:
 
             try:
                 header = VDIFHeader.fromfile(fh, edv, verify)
-            except EOFError:
+            except (EOFError, AssertionError):
                 if thread_ids is None or len(frames) == len(thread_ids):
-                    break
-                else:
-                    raise
-            except AssertionError:
-                if len(frames) == len(thread_ids):
                     break
                 else:
                     raise

--- a/baseband/vdif/tests/test_corrupt_files.py
+++ b/baseband/vdif/tests/test_corrupt_files.py
@@ -1,0 +1,197 @@
+# Licensed under the GPLv3 - see LICENSE
+import pytest
+import numpy as np
+from astropy import units as u
+from astropy.time import Time
+
+from ... import vdif
+from ...data import SAMPLE_VDIF as SAMPLE_FILE
+
+
+class TestCorruptSampleCopy:
+    def setup(self):
+        with open(SAMPLE_FILE, 'rb') as fh:
+            self.sample_bytes = fh.read()
+        with vdif.open(SAMPLE_FILE, 'rs') as fs:
+            self.frame_nbytes = fs.header0.frame_nbytes
+            self.data = fs.read()
+            self.start_time = fs.start_time
+            self.stop_time = fs.stop_time
+
+        self.thread_ids = [1, 3, 5, 7, 0, 2, 4, 6]
+        data = []
+        with vdif.open(SAMPLE_FILE, 'rb') as fr:
+            # Also create data in order of reading it from disk.
+            for i in range(0, fs.size, fs.samples_per_frame):
+                data.append(fr.read_frame().data)
+
+        self.disk_ordered = np.concatenate(data)
+        self.reverse_threads = [self.thread_ids.index(thread_id)
+                                for thread_id in range(8)]
+
+    def expected_bad_frames(self, missing):
+        (start_f, start_r), (stop_f, stop_i) = [
+            divmod(s, self.frame_nbytes)
+            for s in (missing.start, missing.stop-1)]
+
+        if start_r < 32 and start_f % 8 != 0:
+            start_f -= 1
+
+        return start_f, stop_f+1
+
+    @pytest.mark.parametrize('missing,expected_bad_start,expected_bad_stop', [
+        (slice(50320, 50321), 9, 11),  # First byte of header of frame 10.
+        (slice(50500, 50600), 10, 11),  # Part of payload of frame 10.
+        (slice(60000, 70000), 11, 14),  # Parts of 11-13.
+        (slice(75490, 75500), 14, 16),  # Part of header of frame 15.
+        (slice(80511, 80512), 15, 16)])  # Last byte of last frame.
+    def test_expected_bad_frames(self, missing, expected_bad_start,
+                                 expected_bad_stop):
+        bad_start, bad_stop = self.expected_bad_frames(missing)
+        assert bad_start == expected_bad_start
+        assert bad_stop == expected_bad_stop
+
+    # Have to keep first frameset intact, as well as the
+    # first frame of the seconds one.
+    @pytest.mark.parametrize('missing', [
+        (slice(50320, 50321)),  # First byte of header of frame 10.
+        (slice(50500, 50600)),  # Part of payload of frame 10.
+        (slice(60000, 70000)),  # Parts of 11-13.
+        (slice(75490, 75500)),  # Part of header of frame 15.
+        (slice(80511, 80512))])  # Last byte of last frame.
+    def test_missing_bytes(self, missing, tmpdir):
+        corrupted = (self.sample_bytes[:missing.start]
+                     + self.sample_bytes[missing.stop:])
+        bad_start, bad_stop = self.expected_bad_frames(missing)
+
+        filename = str(tmpdir.join('corrupted.vdif'))
+        with open(filename, 'wb') as fw:
+            fw.write(corrupted)
+
+        with vdif.open(filename, 'rs') as fr:
+            assert fr.start_time == self.start_time
+            assert fr.stop_time == self.stop_time
+            with pytest.warns(UserWarning,
+                              match='problem loading frame'):
+                data = fr.read()
+
+        expected = self.disk_ordered.copy().reshape(-1, 20000)
+        expected[bad_start:bad_stop] = 0.
+
+        # Mimic thread ordering
+        expected = (expected.reshape(-1, 8, 20000)
+                    .transpose(0, 2, 1).reshape(-1, 8)
+                    [:, self.reverse_threads])
+        assert np.all(data == expected)
+
+
+class TestCorruptFile:
+    def setup(self):
+        self.header0 = vdif.VDIFHeader.fromvalues(
+            edv=1, time=Time('2010-11-12T13:14:15'), nchan=2, bps=2,
+            complex_data=False, thread_id=0, samples_per_frame=16,
+            station='me', sample_rate=2*u.kHz)
+        self.nthread = 2
+        self.data = np.array([[[-1, 1],
+                               [-3, 3]]]*16)
+        self.frameset_nbytes = self.header0.frame_nbytes * self.nthread
+
+    def fake_file(self, tmpdir, nframes=16):
+        filename = str(tmpdir.join('fake.vdif'))
+        with vdif.open(filename, 'ws', header0=self.header0,
+                       nthread=self.nthread) as fw:
+            for _ in range(nframes):
+                fw.write(self.data)
+        return filename
+
+    def corrupt_copy(self, filename, missing):
+        corrupt_name = filename.replace('.vdif', '_corrupt.vdif')
+        with open(filename, 'rb') as fr, \
+                open(corrupt_name, 'wb') as fw:
+            fw.write(fr.read(missing.start))
+            fr.seek(missing.stop)
+            fw.write(fr.read())
+        return corrupt_name
+
+    @pytest.mark.parametrize('frame_nr', [1, 3, 5, slice(7, 10)])
+    def test_missing_frameset(self, frame_nr, tmpdir):
+        if not isinstance(frame_nr, slice):
+            frame_nr = slice(frame_nr, frame_nr+1)
+        missing = slice(frame_nr.start * self.frameset_nbytes,
+                        frame_nr.stop * self.frameset_nbytes)
+        fake_file = self.fake_file(tmpdir)
+        corrupt_file = self.corrupt_copy(fake_file, missing)
+        with vdif.open(corrupt_file, 'rs') as fr:
+            with pytest.warns(UserWarning, match='All threads'):
+                data = fr.read()
+
+        data = data.reshape((-1,) + self.data.shape)
+        assert np.all(data[:frame_nr.start].astype(int) == self.data)
+        assert np.all(data[frame_nr.stop:].astype(int) == self.data)
+        assert np.all(data[frame_nr] == 0.)
+
+    @pytest.mark.parametrize('frame_nr,thread', [
+        (3, 0), (3, 1), (1, 1), (15, 1)])
+    def test_missing_thread(self, frame_nr, thread, tmpdir):
+        frame = frame_nr * self.nthread + thread
+        missing = slice(frame * self.header0.frame_nbytes,
+                        (frame+1) * self.header0.frame_nbytes)
+        fake_file = self.fake_file(tmpdir)
+        corrupt_file = self.corrupt_copy(fake_file, missing)
+        with vdif.open(corrupt_file, 'rs') as fr:
+            with pytest.warns(UserWarning,
+                              match='Thread.*{0}.*missing'.format(thread)):
+                data = fr.read()
+
+        data = data.reshape((-1,) + self.data.shape)
+        assert np.all(data[:frame_nr].astype(int) == self.data)
+        assert np.all(data[frame_nr+1:].astype(int) == self.data)
+        assert np.all(data[frame_nr, :, thread] == 0.)
+        assert np.all(data[frame_nr, :, 1-thread].astype(int)
+                      == self.data[:, 1-thread])
+
+    @pytest.mark.parametrize('missing_bytes', [
+        slice(0, 80),  # Remove whole last frame set.
+        slice(0, 40),  # Remove first thread of last frame
+        slice(0, 32),  # Remove first header of last frame.
+        slice(16, 32),  # Corrupt first header of last frame.
+        slice(0, 16),  # Corrupt first header of last frame.
+        slice(0, 1),  # Corrupt header byte of last frame.
+        slice(10, 11),  # Corrupt header byte of last frame.
+        slice(15, 16),  # Corrupt header byte of last frame.
+        slice(20, 21),  # Corrupt header byte of last frame.
+        slice(23, 24),  # Corrupt header byte of last frame.
+    ])
+    def test_missing_end(self, missing_bytes, tmpdir):
+        # In all these cases, the data read should just be short.
+        missing = slice(missing_bytes.start + 15*self.frameset_nbytes,
+                        missing_bytes.stop + 15*self.frameset_nbytes)
+        fake_file = self.fake_file(tmpdir)
+        corrupt_file = self.corrupt_copy(fake_file, missing)
+        with vdif.open(corrupt_file, 'rs') as fr:
+            assert fr.size == 15 * self.data.size
+            data = fr.read()
+
+        data = data.reshape((-1,) + self.data.shape)
+        assert len(data) == 15
+        assert np.all(data.astype(int) == self.data)
+
+    @pytest.mark.parametrize('missing_bytes,missing_data', [
+        (slice(80, 160), slice(16, 32)),  # Remove frame set 1.
+        (slice(119, 121), slice(16, 32)),  # Corrupt frame set 1.
+        (slice(120, 121), slice(16, 32)),  # Corrupt frame 1, thread 1 header.
+        (slice(119, 120), slice(16, 32)),  # Corrupt frame 1, thread 0.
+        (slice(112, 205), slice(16, 48)),  # Corrupt frames 1, 2.
+    ])
+    def test_missing_middle(self, missing_bytes, missing_data, tmpdir):
+        # In all these cases, some data will be missing.
+        fake_file = self.fake_file(tmpdir)
+        corrupt_file = self.corrupt_copy(fake_file, missing_bytes)
+        with vdif.open(corrupt_file, 'rs') as fr:
+            assert fr.size == 16 * self.data.size
+            with pytest.warns(UserWarning, match='problem loading frame set'):
+                data = fr.read()
+
+        expected = np.concatenate([self.data] * 16)
+        expected[missing_data] = 0.
+        assert np.all(data.astype(int) == expected)

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -1118,7 +1118,7 @@ class TestVDIF:
             s.seek(0)
             with vdif.open(s, 'rs') as f2:
                 assert f2.header0 == frame.header
-                with pytest.raises(ValueError):
+                with pytest.raises(HeaderNotFoundError):
                     f2._last_header
 
     def test_invalid_last_frame(self, tmpdir):

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -1073,18 +1073,19 @@ class TestVDIF:
             fr.tofile(fw)
 
         with vdif.open(testverifyfile, 'rs') as fn:
-            assert fn.verify is True
-            # This should fail at the second frameset.
+            assert fn.verify
+            # This should fail at the first frameset, since its following
+            # one is corrupt.
             with pytest.raises(AssertionError):
                 fn.read()
-            assert fn.tell() == 20000
+            assert fn.tell() == 0
             fn.verify = False
-            assert fn.verify is False
-            assert np.all(fn.read() == data[20000:])
+            assert not fn.verify
+            assert np.all(fn.read() == data)
 
         # Check that we can pass verify=False.
         with vdif.open(testverifyfile, 'rs', verify=False) as fn:
-            assert fn.verify is False
+            assert not fn.verify
             assert np.all(fn.read() == data)
 
     # Test that writing an incomplete stream is possible, and that frame set is
@@ -1143,9 +1144,7 @@ class TestVDIF:
             assert f2.header0 == f1.header0
             assert f2.stop_time == f1.stop_time
             d1 = f1.read()
-            with pytest.warns(UserWarning,
-                              match='problem loading frame index 1'):
-                d2 = f2.read()
+            d2 = f2.read()
 
             assert np.all(d1 == d2)
 

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -1072,7 +1072,7 @@ class TestVDIF:
             fr.frames[2].header['sync_pattern'] = 0xabbaabba
             fr.tofile(fw)
 
-        with vdif.open(testverifyfile, 'rs') as fn:
+        with vdif.open(testverifyfile, 'rs', verify=True) as fn:
             assert fn.verify
             # This should fail at the first frameset, since its following
             # one is corrupt.

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -1143,7 +1143,10 @@ class TestVDIF:
             assert f2.header0 == f1.header0
             assert f2.stop_time == f1.stop_time
             d1 = f1.read()
-            d2 = f2.read()
+            with pytest.warns(UserWarning,
+                              match='problem loading frame index 1'):
+                d2 = f2.read()
+
             assert np.all(d1 == d2)
 
     def test_io_invalid(self, tmpdir):

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -609,7 +609,8 @@ class VLBIStreamReaderBase(VLBIStreamBase):
         with self.fh_raw.temporary_offset() as fh_raw:
             fh_raw.seek(-self.header0.frame_nbytes, 2)
             try:
-                return fh_raw.find_header(forward=False)
+                return fh_raw.find_header(self.header0, forward=False,
+                                          check=(-1, 1))
             except HeaderNotFoundError as exc:
                 exc.args += ("corrupt VLBI frame? No frame in last {0} bytes."
                              .format(10 * self.header0.frame_nbytes),)

--- a/baseband/vlbi_base/header.py
+++ b/baseband/vlbi_base/header.py
@@ -361,7 +361,7 @@ class VLBIHeaderBase:
             return set()
 
     @sharedmethod
-    def invariant_pattern(self, invariants=None):
+    def invariant_pattern(self, invariants=None, **kwargs):
         """Pattern and mask shared between headers of a type or stream.
 
         This is mostly for use inside
@@ -373,6 +373,9 @@ class VLBIHeaderBase:
             Set of keys to header parts that are shared between all headers
             of a given type or within a given stream/file.  Default: from
             `~baseband.vlbi_base.header.VLBIHeaderBase.invariants()`.
+        **kwargs
+            Keyword arguments needed to instantiate an empty header.
+            (Mostly for Mark 4).
 
         Returns
         -------
@@ -395,7 +398,7 @@ class VLBIHeaderBase:
         if isinstance(self, type):
             # If we are called as a classmethod, first get an instance
             # with all defaults set.  This will be our pattern.
-            self = self(None)
+            self = self(None, **kwargs)
             for invariant in invariants:
                 value = self._header_parser.defaults[invariant]
                 if value is None:
@@ -404,7 +407,7 @@ class VLBIHeaderBase:
                 self[invariant] = value
 
         # Create an all-zero version and set bits for all invariants.
-        mask = self.__class__(None)
+        mask = self.__class__(None, **kwargs)
         for invariant in invariants:
             mask[invariant] = True
 

--- a/baseband/vlbi_base/offsets.py
+++ b/baseband/vlbi_base/offsets.py
@@ -1,0 +1,101 @@
+# Licensed under the GPLv3 - see LICENSE
+import bisect
+
+
+class RawOffsets:
+    """File offset tracker.
+
+    Keeps track of offsets from expected file position as a
+    function of frame number, by keeping a joint list, of the
+    first frame number beyond which a certain offset will hold.
+
+    The offset for a given frame number is retrieved via ``__getitem__``,
+    while new offsets are added via ``__setitem__`` (keeping the
+    list of frame numbers minimal for identical offsets).
+
+    Parameters
+    ----------
+    frame_nr : list
+        Frame number for which one has offsets.
+    offset : list
+        Corresponding offsets.
+
+    Examples
+    --------
+    The usage is best seen through an example::
+
+      >>> from baseband.vlbi_base.offsets import RawOffsets
+      >>> offsets = RawOffsets([6], [5])
+      >>> offsets[3]  # Implicitly 0 before first entry
+      0
+      >>> offsets[10]  # Assumed the same as 6
+      5
+      >>> offsets[10] = 9  # But suppose we find 10 has 9.
+      >>> offsets[10]  # Then it takes that
+      9
+      >>> offsets[9]  # But before is still 5.
+      5
+      >>> offsets[8] = 9  # But if we find 8 has 9 too.
+      >>> offsets[9]  # Then 9 is the same.
+      9
+      >>> offsets  # And the list is kept minimal.
+      RawOffsets(frame_nr=[6, 8], offset=[5, 9])
+      >>> offsets[9] = 9  # This is a no-op.
+      >>> offsets[10] = 10  # But this is not.
+      >>> offsets
+      RawOffsets(frame_nr=[6, 8, 10], offset=[5, 9, 10])
+    """
+
+    def __init__(self, frame_nr=None, offset=None):
+        if frame_nr is None:
+            frame_nr = []
+        if offset is None:
+            offset = []
+        if len(frame_nr) != len(offset):
+            raise ValueError('must have equal number of frame numbers '
+                             'and offsets.')
+        self.frame_nr = frame_nr
+        self.offset = offset
+
+    def __getitem__(self, frame_nr):
+        # Keep default case of no offsets as fast as possible.
+        if not self.frame_nr:
+            return 0
+        # Find first index for which frame_nr < value-at-index,
+        # hence the offset at the previous index is the one we need.
+        index = bisect.bisect_right(self.frame_nr, frame_nr)
+        return 0 if index == 0 else self.offset[index - 1]
+
+    def __setitem__(self, frame_nr, offset):
+        # Find first index for which frame_nr < value-at-index.
+        # Hence, this is where we should be if we do not yet exist.
+        index = bisect.bisect_right(self.frame_nr, frame_nr)
+        # If the entry already exists (should not really happen),
+        # and the new value is different, replace it.
+        if index > 0 and self.frame_nr[index-1] == frame_nr:
+            if self.offset[index-1] == offset:
+                return
+
+            # Best to *remove* the entry, since the new value may
+            # be consistent with one of the surrounding values,
+            # in which case we can shorten our list.
+            self.frame_nr.pop(index-1)
+            self.offset.pop(index-1)
+            index -= 1
+
+        # If the offset at the next location is the same as ours,
+        # then we can keep everything consistent by just moving the
+        # frame number to our value.
+        if index < len(self) and self.offset[index] == offset:
+            self.frame_nr[index] = frame_nr
+        elif index == 0 or self.offset[index-1] != offset:
+            # Otherwise, if we add new information, insert ourserlves.
+            self.frame_nr.insert(index, frame_nr)
+            self.offset.insert(index, offset)
+
+    def __len__(self):
+        return len(self.frame_nr)
+
+    def __repr__(self):
+        return ('{0}(frame_nr={1}, offset={2})'
+                .format(type(self).__name__, self.frame_nr, self.offset))

--- a/docs/mark4/index.rst
+++ b/docs/mark4/index.rst
@@ -94,6 +94,7 @@ object::
                  track_roll_enabled: [False]*64,
                  sequence_suspended: [False]*64,
                  system_id: [108]*64,
+                 _1_0_1_sync: [False]*64,
                  sync_pattern: [0xffffffff]*64,
                  bcd_unit_year: [0x4]*64,
                  bcd_day: [0x167]*64,

--- a/docs/tutorials/new_edv.rst
+++ b/docs/tutorials/new_edv.rst
@@ -429,7 +429,8 @@ class, and define a replacement::
 
 We can then use the stream reader without further modification::
 
-    >>> fh2 = vdif.open(SAMPLE_DRAO_CORRUPT, 'rs', sample_rate=5**12*u.Hz)
+    >>> fh2 = vdif.open(SAMPLE_DRAO_CORRUPT, 'rs',
+    ...                 sample_rate=5**12*u.Hz, verify=False)
     >>> fh2.header0['eud2'] == header0['eud2']
     True
     >>> np.all(fh2.read(1) == payload0[0])


### PR DESCRIPTION
The Mark 4, Mark 5B, and VDIF stream readers are now able to replace missing pieces of files with zeros using `verify='fix'`. This is also the new default (`verify=True` gives the old behaviour of raising an error on any inconsistency).

fixes #272 