### PR TITLE
Determine VDIF thread IDs from scan rather than first frame set

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,12 @@ Other Changes and Additions
   also the new default; use ``verify=True`` for the old behaviour of
   raising an error on any inconsistency. [#357]
 
+- The ``VDIFFileReader`` gained a new ``get_thread_ids()`` method, which
+  will scan through frames to determine the threads present in the file.
+  This is now used inside ``VDIFStreamReader`` and, combined with the above,
+  allows reading of files that have missing threads in their first frame
+  set. [#361]
+
 - Much faster localization of Mark 5B frames. [#351]
 
 - VLBI file readers have gained a new method ``locate_frames`` that finds

--- a/baseband/vdif/tests/test_corrupt_files.py
+++ b/baseband/vdif/tests/test_corrupt_files.py
@@ -1,4 +1,6 @@
 # Licensed under the GPLv3 - see LICENSE
+import io
+
 import pytest
 import numpy as np
 from astropy import units as u
@@ -9,25 +11,31 @@ from ...data import SAMPLE_VDIF as SAMPLE_FILE
 
 
 class TestCorruptSampleCopy:
-    def setup(self):
-        with open(SAMPLE_FILE, 'rb') as fh:
-            self.sample_bytes = fh.read()
-        with vdif.open(SAMPLE_FILE, 'rs') as fs:
-            self.frame_nbytes = fs.header0.frame_nbytes
-            self.data = fs.read()
-            self.start_time = fs.start_time
-            self.stop_time = fs.stop_time
+    @classmethod
+    def setup_class(cls):
+        # Make a triply-long sample file - this since otherwise
+        # things already fail at the determination of thread_ids.
+        with vdif.open(SAMPLE_FILE, 'rs') as fs, \
+                io.BytesIO() as s, \
+                vdif.open(s, 'ws', header0=fs.header0, nthread=8) as fw:
 
-        self.thread_ids = [1, 3, 5, 7, 0, 2, 4, 6]
-        data = []
-        with vdif.open(SAMPLE_FILE, 'rb') as fr:
-            # Also create data in order of reading it from disk.
-            for i in range(0, fs.size, fs.samples_per_frame):
-                data.append(fr.read_frame().data)
+            data = fs.read()
+            for i in range(3):
+                fw.write(data)
 
-        self.disk_ordered = np.concatenate(data)
-        self.reverse_threads = [self.thread_ids.index(thread_id)
-                                for thread_id in range(8)]
+            cls.data = np.concatenate([data, data, data])
+
+            s.seek(0)
+            cls.sample_bytes = s.read()
+            cls.frame_nbytes = fw.header0.frame_nbytes
+            cls.start_time = fw.start_time
+            cls.stop_time = fw.tell('time')
+
+    def test_sample_bytes(self):
+        with io.BytesIO(self.sample_bytes) as s, \
+                vdif.open(s, 'rs') as fs:
+            data = fs.read()
+        assert np.all(data == self.data)
 
     def expected_bad_frames(self, missing):
         (start_f, start_r), (stop_f, stop_i) = [
@@ -51,14 +59,13 @@ class TestCorruptSampleCopy:
         assert bad_start == expected_bad_start
         assert bad_stop == expected_bad_stop
 
-    # Have to keep first frameset intact, as well as the
-    # first frame of the seconds one.
+    # Have to keep first three frameset intact for get_thread_ids()
     @pytest.mark.parametrize('missing', [
-        (slice(50320, 50321)),  # First byte of header of frame 10.
-        (slice(50500, 50600)),  # Part of payload of frame 10.
-        (slice(60000, 70000)),  # Parts of 11-13.
-        (slice(75490, 75500)),  # Part of header of frame 15.
-        (slice(80511, 80512))])  # Last byte of last frame.
+        (slice(5032*26, 5032*26+1)),  # First byte of header of frame 26.
+        (slice(5032*26+50, 5032*26+60)),  # Part of payload of frame 26.
+        (slice(5032*27+50, 5032*29+700)),  # Parts of 27-29
+        (slice(5032*31+10, 5032*31+20)),  # Part of header of frame 31.
+        (slice(5032*48-1, 5032*48))])  # Last byte of last frame.
     def test_missing_bytes(self, missing, tmpdir):
         corrupted = (self.sample_bytes[:missing.start]
                      + self.sample_bytes[missing.stop:])
@@ -75,26 +82,28 @@ class TestCorruptSampleCopy:
                               match='problem loading frame'):
                 data = fr.read()
 
-        expected = self.disk_ordered.copy().reshape(-1, 20000)
+        # Get data in frame order to zero expected bad frames.
+        expected = (self.data.copy().reshape(-1, 20000, 8)
+                    .transpose(0, 2, 1).reshape(-1, 20000))
         expected[bad_start:bad_stop] = 0.
-
-        # Mimic thread ordering
+        # Back into regular order
         expected = (expected.reshape(-1, 8, 20000)
-                    .transpose(0, 2, 1).reshape(-1, 8)
-                    [:, self.reverse_threads])
+                    .transpose(0, 2, 1).reshape(-1, 8))
+
         assert np.all(data == expected)
 
 
 class TestCorruptFile:
-    def setup(self):
-        self.header0 = vdif.VDIFHeader.fromvalues(
+    @classmethod
+    def setup_class(cls):
+        cls.header0 = vdif.VDIFHeader.fromvalues(
             edv=1, time=Time('2010-11-12T13:14:15'), nchan=2, bps=2,
             complex_data=False, thread_id=0, samples_per_frame=16,
             station='me', sample_rate=2*u.kHz)
-        self.nthread = 2
-        self.data = np.array([[[-1, 1],
-                               [-3, 3]]]*16)
-        self.frameset_nbytes = self.header0.frame_nbytes * self.nthread
+        cls.nthread = 2
+        cls.data = np.array([[[-1, 1],
+                              [-3, 3]]]*16)
+        cls.frameset_nbytes = cls.header0.frame_nbytes * cls.nthread
 
     def fake_file(self, tmpdir, nframes=16):
         filename = str(tmpdir.join('fake.vdif'))
@@ -176,12 +185,13 @@ class TestCorruptFile:
         assert len(data) == 15
         assert np.all(data.astype(int) == self.data)
 
+    # Note: keep frame sets 0--2 intact for get_thread_ids().
     @pytest.mark.parametrize('missing_bytes,missing_data', [
-        (slice(80, 160), slice(16, 32)),  # Remove frame set 1.
-        (slice(119, 121), slice(16, 32)),  # Corrupt frame set 1.
-        (slice(120, 121), slice(16, 32)),  # Corrupt frame 1, thread 1 header.
-        (slice(119, 120), slice(16, 32)),  # Corrupt frame 1, thread 0.
-        (slice(112, 205), slice(16, 48)),  # Corrupt frames 1, 2.
+        (slice(240, 320), slice(48, 64)),  # Remove frameset 3.
+        (slice(279, 281), slice(48, 64)),  # Corrupt frameset 3.
+        (slice(280, 281), slice(48, 64)),  # Corrupt frameset 3, thread 1.
+        (slice(279, 280), slice(48, 64)),  # Corrupt frameset 3, thread 0.
+        (slice(272, 365), slice(48, 80)),  # Corrupt framesets 3, 4
     ])
     def test_missing_middle(self, missing_bytes, missing_data, tmpdir):
         # In all these cases, some data will be missing.

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -1057,10 +1057,10 @@ class TestVDIF:
         subset_md = (np.array([5, 3])[:, np.newaxis], np.array([0, 2]))
         with vdif.open(test_file, 'rs', subset=subset_md) as fhn:
             assert fhn.sample_shape == (2, 2)
-            thread_ids = [frame.header['thread_id'] for frame in
-                          fhn._frameset.frames]
-            assert thread_ids == [5, 3]
             check = fhn.read()
+            thread_ids = [frame.header['thread_id'] for frame in
+                          fhn._frame.frames]
+            assert thread_ids == [5, 3]
             assert np.all(check == data4x[(slice(None),) + subset_md])
 
     def test_stream_verify(self, tmpdir):

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -434,6 +434,15 @@ class TestVDIF:
             assert abs(frame_rate
                        - 32. * u.MHz / header.samples_per_frame) < 1. * u.nHz
             assert fh.tell() == current_pos
+            # Test getting thread IDs.
+            fh.seek(0)
+            thread_ids = fh.get_thread_ids()
+            assert thread_ids == list(range(8))
+            assert fh.tell() == 0
+            fh.seek(5032*2)
+            thread_ids = fh.get_thread_ids()
+            assert thread_ids == list(range(8))
+            assert fh.tell() == 5032*2
             # The read_frame method is tested below, as is mode='wb'.
 
     def test_frame(self, tmpdir):

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -1071,31 +1071,33 @@ class TestVDIF:
             data = fh.read()
 
         testverifyfile = str(tmpdir.join('testverify.vdif'))
-        # Make a file with a sync pattern error in the second set of frames.
+        # Make a file with a sync pattern error in the sixth set of frames.
         with vdif.open(SAMPLE_FILE, 'rb') as fh, \
                 vdif.open(testverifyfile, 'wb') as fw:
             fr = fh.read_frameset()
-            fr.tofile(fw)
-            fr = fh.read_frameset()
-            fr.frames[2].header.mutable = True
-            fr.frames[2].header['sync_pattern'] = 0xabbaabba
-            fr.tofile(fw)
+            # Make mutable copy.
+            fr = fr.fromdata(fr.data, fr.frames[0].header)
+            for i in range(8):
+                fr['frame_nr'] = fr['frame_nr'] + 1
+                if i == 6:
+                    fr.frames[2].header['sync_pattern'] = 0xabbaabba
+                fr.tofile(fw)
 
         with vdif.open(testverifyfile, 'rs', verify=True) as fn:
             assert fn.verify
-            # This should fail at the first frameset, since its following
+            # This should fail at the fifth frameset, since its following
             # one is corrupt.
             with pytest.raises(AssertionError):
                 fn.read()
-            assert fn.tell() == 0
+            assert fn.tell() == 100000
             fn.verify = False
             assert not fn.verify
-            assert np.all(fn.read() == data)
+            assert np.all(fn.read().reshape(-1, 20000, 8) == data[:20000])
 
         # Check that we can pass verify=False.
         with vdif.open(testverifyfile, 'rs', verify=False) as fn:
             assert not fn.verify
-            assert np.all(fn.read() == data)
+            assert np.all(fn.read().reshape(-1, 20000, 8) == data[:20000])
 
     # Test that writing an incomplete stream is possible, and that frame set is
     # appropriately marked as invalid.
@@ -1103,30 +1105,36 @@ class TestVDIF:
     def test_incomplete_stream(self, tmpdir, fill_value):
         vdif_incomplete = str(tmpdir.join('incomplete.vdif'))
         with vdif.open(SAMPLE_FILE, 'rs') as fr:
-            record = fr.read(10)
+            record = fr.read(20010)
             with pytest.warns(UserWarning, match='partial buffer'):
                 with vdif.open(vdif_incomplete, 'ws', header0=fr.header0,
                                sample_rate=32*u.MHz, nthread=8) as fw:
                     fw.write(record)
         with vdif.open(vdif_incomplete, 'rs', fill_value=fill_value) as fwr:
-            assert all([not frame.valid for frame in fwr._frameset.frames])
+            valid = fwr.read(20000)
+            assert np.all(valid == record[:20000])
             assert fwr.fill_value == fill_value
-            assert np.all(fwr.read() == fill_value)
+            invalid = fwr.read()
+            assert invalid.shape == valid.shape
+            assert np.all(invalid == fill_value)
 
     def test_corrupt_stream(self, tmpdir):
+        corrupt_file = str(tmpdir.join('test.vdif'))
         with vdif.open(SAMPLE_FILE, 'rb') as fh, \
-                open(str(tmpdir.join('test.vdif')), 'w+b') as s:
-            frame = fh.read_frame()
-            frame.tofile(s)
-            # Now add lots of the next frame, i.e., with a different thread_id
-            # and different frame_nr
-            fh.seek(-frame.header.frame_nbytes, 2)
+                open(corrupt_file, 'w+b') as s:
+            frameset = fh.read_frameset()
+            header0 = frameset.frames[0].header
+            frameset.tofile(s)
+            frameset = fh.read_frameset()
+            frameset.tofile(s)
+            # Now add lots of the final frame, i.e., with the wrong thread_id.
+            fh.seek(-5032, 2)
             frame2 = fh.read_frame()
             for i in range(15):
                 frame2.tofile(s)
             s.seek(0)
             with vdif.open(s, 'rs') as f2:
-                assert f2.header0 == frame.header
+                assert f2.header0 == header0
                 with pytest.raises(HeaderNotFoundError):
                     f2._last_header
 
@@ -1135,27 +1143,31 @@ class TestVDIF:
         # header which is mostly zeros and marked invalid.  Check that we
         # properly ignore such a frame.  See gh-271.
         test_file = str(tmpdir.join('test2.vdif'))
-        with vdif.open(SAMPLE_FILE, 'rb') as fh, \
-                open(test_file, 'w+b') as s:
-            allbytes = fh.read()
-            s.write(allbytes)
+        with vdif.open(SAMPLE_FILE, 'rs') as fh, \
+                open(test_file, 'ab') as s, \
+                vdif.open(s, 'ws', header0=fh.header0, nthread=8) as fw:
+            data = fh.read()
+            for _ in range(5):
+                fw.write(data)
+
+            assert s.seek(0, 2) == 5032 * 8 * 2 * 5
             bad_header = vdif.VDIFHeader.fromvalues(edv=0, frame_nbytes=5032,
                                                     invalid_data=True)
             bad_header.tofile(s)
             s.write(b'\0' * 5000)
-            assert s.tell() == fh.tell() + 5032
+            assert s.tell() == 5032 * (8 * 2 * 5 + 1)
 
         # For this short test file, one gets the wrong sample rate by
         # looking for the frame number returning to zero; so we pass
-        # we pass the correct one in.
-        with vdif.open(SAMPLE_FILE, 'rs') as f1, \
-                vdif.open(test_file, 'rs', sample_rate=32*u.MHz) as f2:
-            assert f2.header0 == f1.header0
-            assert f2.stop_time == f1.stop_time
-            d1 = f1.read()
+        # the correct one in.
+        with vdif.open(test_file, 'rs', sample_rate=32*u.MHz) as f2:
+            assert f2.start_time == fh.start_time
+            assert f2.shape[0] == 5*fh.shape[0]
+            assert abs(f2.stop_time - fh.stop_time
+                       - 4*(fh.stop_time-fh.start_time)) < 1.*u.ns
             d2 = f2.read()
 
-            assert np.all(d1 == d2)
+        assert np.all(d2.reshape(5, -1, 8) == data)
 
     def test_io_invalid(self, tmpdir):
         tmp_file = str(tmpdir.join('ts.dat'))

--- a/docs/tutorials/getting_started.rst
+++ b/docs/tutorials/getting_started.rst
@@ -147,6 +147,7 @@ For an overview of the file, we can either print ``fh_vdif`` itself, or use the
     <BLANKLINE>
     File information:
     edv = 3
+    thread_ids = [0, 1, 2, 3, 4, 5, 6, 7]
     frame_rate = 1600.0 Hz
     samples_per_frame = 20000
     sample_shape = (8, 1)

--- a/docs/tutorials/new_edv.rst
+++ b/docs/tutorials/new_edv.rst
@@ -427,13 +427,15 @@ class, and define a replacement::
     ...     def verify(self):
     ...         pass
 
-We can then use the stream reader without further modification::
+If we had the whole corrupt file, this might be enough to use the stream
+reader without further modification.  It turns out, though, that the frame
+numbers are not monotonic and that the station ID changes between frames as
+well, so one would be better off making a new copy.  Here, we can at least
+now read frames::
 
-    >>> fh2 = vdif.open(SAMPLE_DRAO_CORRUPT, 'rs',
-    ...                 sample_rate=5**12*u.Hz, verify=False)
-    >>> fh2.header0['eud2'] == header0['eud2']
-    True
-    >>> np.all(fh2.read(1) == payload0[0])
+    >>> fh2 = vdif.open(SAMPLE_DRAO_CORRUPT, 'rb')
+    >>> frame0 = fh2.read_frame()
+    >>> np.all(frame0.data == payload0.data)
     True
     >>> fh2.close()
 

--- a/docs/tutorials/using_baseband.rst
+++ b/docs/tutorials/using_baseband.rst
@@ -54,6 +54,7 @@ files can all be found in the `baseband.data` module)::
     <BLANKLINE>
     File information:
     edv = 3
+    thread_ids = [0, 1, 2, 3, 4, 5, 6, 7]
     frame_rate = 1600.0 Hz
     samples_per_frame = 20000
     sample_shape = (8, 1)
@@ -222,6 +223,7 @@ Basic information about the file is obtained by either by ``fh.info`` or simply
     <BLANKLINE>
     File information:
     edv = 3
+    thread_ids = [0, 1, 2, 3, 4, 5, 6, 7]
     frame_rate = 1600.0 Hz
     samples_per_frame = 20000
     sample_shape = (8, 1)


### PR DESCRIPTION
Introduces `VDIFFileReader.get_thread_ids()`, which will scan through frames to determine the threads present in the file. Also use this inside `VDIFStreamReader` to be able to handle files that have missing threads in their first frame.

fixes #359 