### PR TITLE
Make GSB info work better for partial last headers

### DIFF
--- a/baseband/gsb/base.py
+++ b/baseband/gsb/base.py
@@ -217,6 +217,8 @@ class GSBStreamBase(VLBIStreamBase):
 
         self.fh_ts = fh_ts
         rawdump = header0.mode == 'rawdump'
+        if not rawdump and not isinstance(fh_raw, (tuple, list)):
+            fh_raw = ((fh_raw,),)
         complex_data = (complex_data if complex_data is not None else
                         (False if rawdump else True))
         bps = bps if bps is not None else (4 if rawdump else 8)

--- a/baseband/gsb/file_info.py
+++ b/baseband/gsb/file_info.py
@@ -20,18 +20,44 @@ class GSBTimeStampInfo(VLBIFileReaderInfo):
     @info_item(needs='header0')
     def number_of_frames(self):
         with self._parent.temporary_offset() as fh:
-            file_nbytes = fh.seek(0, 2)
-            if file_nbytes == self.header0.nbytes:
+            fh_size = fh.seek(0, 2)
+            if fh_size == self.header0.nbytes:
                 return 1
 
-            guess = max(int(round(file_nbytes / self.header0.nbytes)) - 2, 0)
-            while True:
+            # Guess based on a fixed header size.  In reality, this
+            # may be an overestimate as the headers can grow in size,
+            # or an underestimate as the last header may be partial.
+            # So, search around to be sure.
+            guess = max(fh_size // self.header0.nbytes, 1)
+            while self.header0.seek_offset(guess) > fh_size:
+                guess -= 1
+            while self.header0.seek_offset(guess) < fh_size:
                 guess += 1
-                fh.seek(self.header0.seek_offset(guess))
+
+            # Now see if there is indeed a nice header before.
+            fh.seek(self.header0.seek_offset(guess-1))
+            line_tuple = fh.readline().split()
+            # But realize that sometimes an incomplete header is written.
+            if (len(" ".join(line_tuple))
+                    < len(" ".join(self.header0.words))):
+                self.warnings['number_of_frames'] = (
+                    'last header is incomplete and is ignored')
+                retry = True
+            else:
+                # Check last header is readable.
                 try:
-                    self.header0.fromfile(fh).time
-                except EOFError:
-                    break
+                    self.header0.__class__(line_tuple).time
+                except Exception as exc:
+                    self.warnings['number_of_frames'] = (
+                        'last header failed to read ({}) and is ignored'
+                        .format(str(exc)))
+                    retry = True
+                else:
+                    retry = False
+            if retry:
+                guess -= 1
+                fh.seek(self.header0.seek_offset(guess-1))
+                self.header0.fromfile(fh).time
 
         return guess
 

--- a/baseband/gsb/file_info.py
+++ b/baseband/gsb/file_info.py
@@ -84,4 +84,6 @@ class GSBStreamReaderInfo(VLBIStreamReaderInfo):
 
     @info_item
     def file_info(self):
-        return self._parent.fh_ts.info
+        fh_ts_info = self._parent.fh_ts.info
+        fh_ts_info.missing.pop('raw', None)
+        return fh_ts_info

--- a/baseband/gsb/file_info.py
+++ b/baseband/gsb/file_info.py
@@ -21,9 +21,6 @@ class GSBTimeStampInfo(VLBIFileReaderInfo):
     def number_of_frames(self):
         with self._parent.temporary_offset() as fh:
             fh_size = fh.seek(0, 2)
-            if fh_size == self.header0.nbytes:
-                return 1
-
             # Guess based on a fixed header size.  In reality, this
             # may be an overestimate as the headers can grow in size,
             # or an underestimate as the last header may be partial.

--- a/baseband/gsb/tests/test_gsb.py
+++ b/baseband/gsb/tests/test_gsb.py
@@ -924,6 +924,7 @@ class TestGSB:
         (SAMPLE_PHASED_HEADER, [SAMPLE_PHASED[0][:1],
                                 SAMPLE_PHASED[1][:1]], 'unsplit-2pol'),
         (SAMPLE_PHASED_HEADER, [SAMPLE_PHASED[0][1:]], 'unsplit-1pol'),
+        (SAMPLE_PHASED_HEADER, SAMPLE_PHASED[0][1], 'unsplit-1pol'),
     ])
     def test_stream_info(self, ts, raw, mode):
         bps = 4 if mode == 'rawdump' else 8

--- a/baseband/gsb/tests/test_gsb.py
+++ b/baseband/gsb/tests/test_gsb.py
@@ -869,7 +869,8 @@ class TestGSB:
 
             info = fh_r.info
             assert info.errors == {}
-            assert len(info.warnings) == 1
+            assert info.warnings.keys() == {'number_of_frames'}
+            assert 'incomplete' in info.warnings['number_of_frames']
 
     def test_stream_reader_defaults(self):
         # Test not passing a sample rate and samples per frame to reader
@@ -916,9 +917,10 @@ class TestGSB:
             assert info.readable
             assert info.errors == {}
             assert info.warnings == {}
+            assert info.file_info.missing == {}
             assert info.checks == {'decodable': True}
             assert info.bps == bps
-            assert abs(info.sample_rate - sample_rate) < 1. * u.nHz
+            assert u.isclose(info.sample_rate, sample_rate)
             if mode == 'rawdump':
                 assert not info.complex_data
                 assert info.shape == (81920,)

--- a/baseband/gsb/tests/test_gsb.py
+++ b/baseband/gsb/tests/test_gsb.py
@@ -867,6 +867,10 @@ class TestGSB:
 
             assert shape[0] == nframes * fh_r.samples_per_frame
 
+            info = fh_r.info
+            assert info.errors == {}
+            assert len(info.warnings) == 1
+
     def test_stream_reader_defaults(self):
         # Test not passing a sample rate and samples per frame to reader
         # (can't test reading, since the sample file is tiny).


### PR DESCRIPTION
Also add much more complete tests for the stream info.

fixes most of #398, though not quite the documentation, though just being able to pass in a single file will allow things to work more obviously.