### PR TITLE
Correct default used for GSB payload_nbytes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@
 - This future version will likely only support python 3.7, numpy 1.17 and
   astropy 4.0.
 
+3.2 (unreleased)
+================
+
 New Features
 ------------
 
@@ -15,6 +18,13 @@ Bug Fixes
 
 - Mark 4 data written with the non-standard channel assignment used at Ft
   can now be read and written. [#380]
+
+- For GSB phased data, the default ``payload_nbytes`` has now been corrected
+  so that it is always 4 MiB. [#401]
+
+- For GSB phased data, the ``sample_rate`` argument is now correctly
+  interpreted as the rate of complete samples (previously, the number of
+  channels were ignored). [#401]
 
 Other Changes and Additions
 ---------------------------

--- a/baseband/tests/test_file_info.py
+++ b/baseband/tests/test_file_info.py
@@ -98,7 +98,8 @@ def test_gsb_with_raw_files(sample, raw, mode):
     assert list(bad_info.errors.keys()) == ['frame0']
     # But with the correct sample_rate, it works.
     base_info = file_info(sample)
-    sample_rate = 2**12 * base_info.frame_rate
+    sample_rate = (2**12 * base_info.frame_rate
+                   / (1 if base_info.mode == 'rawdump' else 1024))
     info = file_info(sample, raw=raw, sample_rate=sample_rate)
     assert info.format == 'gsb'
     assert info.readable is True


### PR DESCRIPTION
Addresses more problems found as part of #398