### PR TITLE
Refactor header and base

### DIFF
--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -210,16 +210,6 @@ class DADAStreamBase(VLBIStreamBase):
 
     _sample_shape_maker = DADAPayload._sample_shape_maker
 
-    def __init__(self, fh_raw, header0, squeeze=True, subset=(), verify=True):
-
-        super().__init__(
-            fh_raw=fh_raw, header0=header0, sample_rate=header0.sample_rate,
-            samples_per_frame=header0.samples_per_frame,
-            frame_nbytes=header0.frame_nbytes,
-            unsliced_shape=header0.sample_shape, bps=header0.bps,
-            complex_data=header0.complex_data, squeeze=squeeze, subset=subset,
-            fill_value=0., verify=verify)
-
     def _get_index(self, header):
         # Override for faster calculation of frame index.
         return int(round((header['OBS_OFFSET']

--- a/baseband/dada/base.py
+++ b/baseband/dada/base.py
@@ -215,6 +215,7 @@ class DADAStreamBase(VLBIStreamBase):
         super().__init__(
             fh_raw=fh_raw, header0=header0, sample_rate=header0.sample_rate,
             samples_per_frame=header0.samples_per_frame,
+            frame_nbytes=header0.frame_nbytes,
             unsliced_shape=header0.sample_shape, bps=header0.bps,
             complex_data=header0.complex_data, squeeze=squeeze, subset=subset,
             fill_value=0., verify=verify)

--- a/baseband/gsb/base.py
+++ b/baseband/gsb/base.py
@@ -258,9 +258,9 @@ class GSBStreamBase(VLBIStreamBase):
 
         super().__init__(
             fh_raw, header0, sample_rate=sample_rate,
-            samples_per_frame=samples_per_frame, unsliced_shape=unsliced_shape,
-            bps=bps, complex_data=complex_data, squeeze=squeeze, subset=subset,
-            fill_value=0., verify=verify)
+            samples_per_frame=samples_per_frame, frame_nbytes=payload_nbytes,
+            unsliced_shape=unsliced_shape, bps=bps, complex_data=complex_data,
+            squeeze=squeeze, subset=subset, fill_value=0., verify=verify)
 
         self._payload_nbytes = payload_nbytes
 

--- a/baseband/gsb/header.py
+++ b/baseband/gsb/header.py
@@ -13,7 +13,7 @@ import numpy as np
 from astropy import units as u, _erfa as erfa
 from astropy.time import Time, TimeString
 
-from ..vlbi_base.header import VLBIHeaderBase, HeaderParser
+from ..vlbi_base.header import HeaderBase, HeaderParser
 
 
 __all__ = ['TimeGSB', 'GSBHeader', 'GSBRawdumpHeader', 'GSBPhasedHeader']
@@ -105,7 +105,7 @@ def get_default(index, length, forward, backward, default=None):
     return default
 
 
-class GSBHeader(VLBIHeaderBase):
+class GSBHeader(HeaderBase):
     """GSB Header, based on a line from a timestamp file.
 
     Parameters
@@ -143,22 +143,19 @@ class GSBHeader(VLBIHeaderBase):
 
             cls = cls._gsb_header_classes.get(mode)
 
-        # We intialise VDIFHeader subclasses, so their __init__ will be called.
+        # We intialise GSBHeader subclasses, so their __init__ will be called.
         return super().__new__(cls)
 
     def __init__(self, words, mode=None, nbytes=None, utc_offset=5.5*u.hr,
                  verify=True):
         if words is None:
-            self.words = [''] * self._number_of_words
-        else:
-            self.words = words
+            words = [''] * self._number_of_words
         if nbytes is not None:
             self._nbytes = nbytes
         if mode is not None:
             self._mode = mode
         self.utc_offset = utc_offset
-        if verify:
-            self.verify()
+        super().__init__(words, verify=verify)
 
     def verify(self):
         assert self.mode == self.__class__._mode
@@ -242,10 +239,6 @@ class GSBHeader(VLBIHeaderBase):
         if nbytes is None:
             nbytes = self.nbytes
         return n * nbytes
-
-    def __eq__(self, other):
-        return (type(self) is type(other)
-                and tuple(self.words) == tuple(other.words))
 
 
 class GSBRawdumpHeader(GSBHeader):

--- a/baseband/guppi/base.py
+++ b/baseband/guppi/base.py
@@ -211,12 +211,9 @@ class GUPPIStreamBase(VLBIStreamBase):
         samples_per_frame = header0.samples_per_frame - header0.overlap
 
         super().__init__(
-            fh_raw=fh_raw, header0=header0, sample_rate=header0.sample_rate,
+            fh_raw=fh_raw, header0=header0,
             samples_per_frame=samples_per_frame,
-            frame_nbytes=header0.frame_nbytes,
-            unsliced_shape=header0.sample_shape, bps=header0.bps,
-            complex_data=header0.complex_data, squeeze=squeeze, subset=subset,
-            fill_value=0., verify=verify)
+            squeeze=squeeze, subset=subset, verify=verify)
 
     # Overriding so the docstring indicates the exclusion of the overlap.
     samples_per_frame = property(VLBIStreamBase.samples_per_frame.fget,

--- a/baseband/guppi/base.py
+++ b/baseband/guppi/base.py
@@ -213,6 +213,7 @@ class GUPPIStreamBase(VLBIStreamBase):
         super().__init__(
             fh_raw=fh_raw, header0=header0, sample_rate=header0.sample_rate,
             samples_per_frame=samples_per_frame,
+            frame_nbytes=header0.frame_nbytes,
             unsliced_shape=header0.sample_shape, bps=header0.bps,
             complex_data=header0.complex_data, squeeze=squeeze, subset=subset,
             fill_value=0., verify=verify)

--- a/baseband/guppi/header.py
+++ b/baseband/guppi/header.py
@@ -203,10 +203,6 @@ class GUPPIHeader(fits.Header):
         if not self.mutable:
             raise TypeError("immutable {0} does not support assignment."
                             .format(type(self).__name__))
-        if isinstance(value, tuple):
-            value, comment = value
-            self.comments[key.upper()] = comment
-
         super().__setitem__(key.upper(), value)
 
     @property

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -263,10 +263,6 @@ class Mark4StreamBase(VLBIStreamBase):
             bps=header0.bps, complex_data=False, squeeze=squeeze,
             subset=subset, fill_value=fill_value, verify=verify)
 
-    def _set_time(self, header, time):
-        # Use update to ensure CRC is updated as well.
-        header.update(time=time)
-
 
 class Mark4StreamReader(Mark4StreamBase, VLBIStreamReaderBase):
     """VLBI Mark 4 format reader.

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -258,11 +258,9 @@ class Mark4StreamBase(VLBIStreamBase):
                  subset=(), fill_value=0., verify=True):
         super().__init__(
             fh_raw, header0=header0, sample_rate=sample_rate,
-            samples_per_frame=header0.samples_per_frame,
-            frame_nbytes=header0.frame_nbytes,
-            unsliced_shape=(header0.nchan,),
-            bps=header0.bps, complex_data=False, squeeze=squeeze,
-            subset=subset, fill_value=fill_value, verify=verify)
+            unsliced_shape=(header0.nchan,), complex_data=False,
+            squeeze=squeeze, subset=subset, fill_value=fill_value,
+            verify=verify)
 
 
 class Mark4StreamReader(Mark4StreamBase, VLBIStreamReaderBase):

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -259,6 +259,7 @@ class Mark4StreamBase(VLBIStreamBase):
         super().__init__(
             fh_raw, header0=header0, sample_rate=sample_rate,
             samples_per_frame=header0.samples_per_frame,
+            frame_nbytes=header0.frame_nbytes,
             unsliced_shape=(header0.nchan,),
             bps=header0.bps, complex_data=False, squeeze=squeeze,
             subset=subset, fill_value=fill_value, verify=verify)

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -258,7 +258,7 @@ class Mark4StreamBase(VLBIStreamBase):
                  subset=(), fill_value=0., verify=True):
         super().__init__(
             fh_raw, header0=header0, sample_rate=sample_rate,
-            unsliced_shape=(header0.nchan,), complex_data=False,
+            unsliced_shape=(header0.nchan,),
             squeeze=squeeze, subset=subset, fill_value=fill_value,
             verify=verify)
 

--- a/baseband/mark4/file_info.py
+++ b/baseband/mark4/file_info.py
@@ -104,7 +104,6 @@ class Mark4FileReaderInfo(VLBIFileReaderInfo):
                   + VLBIFileReaderInfo.attr_names[-4:])
     """Attributes that the container provides."""
 
-    _header0_attrs = ('bps', 'samples_per_frame')
     _parent_attrs = ('ntrack', 'decade', 'ref_time')
 
     @info_item
@@ -151,13 +150,6 @@ class Mark4FileReaderInfo(VLBIFileReaderInfo):
                 'file contains non-integer number ({}) of frames'
                 .format(number_of_frames))
             return None
-
-    complex_data = False
-
-    @info_item(needs='header0')
-    def sample_shape(self):
-        """Dimensions of each complete sample."""
-        return (self.header0.nchan,)
 
     # Override just to replace what it "needs".
     @info_item(needs=('header0', 'time_info'))

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -171,6 +171,7 @@ class Mark5BStreamBase(VLBIStreamBase):
         super().__init__(
             fh_raw, header0=header0, sample_rate=sample_rate,
             samples_per_frame=header0.payload_nbytes * 8 // bps // nchan,
+            frame_nbytes=header0.frame_nbytes,
             unsliced_shape=(nchan,), bps=bps, complex_data=False,
             squeeze=squeeze, subset=subset, fill_value=fill_value,
             verify=verify)

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -171,7 +171,7 @@ class Mark5BStreamBase(VLBIStreamBase):
         super().__init__(
             fh_raw, header0=header0, sample_rate=sample_rate,
             samples_per_frame=header0.payload_nbytes * 8 // bps // nchan,
-            unsliced_shape=(nchan,), bps=bps, complex_data=False,
+            unsliced_shape=(nchan,), bps=bps,
             squeeze=squeeze, subset=subset, fill_value=fill_value,
             verify=verify)
 

--- a/baseband/mark5b/base.py
+++ b/baseband/mark5b/base.py
@@ -171,7 +171,6 @@ class Mark5BStreamBase(VLBIStreamBase):
         super().__init__(
             fh_raw, header0=header0, sample_rate=sample_rate,
             samples_per_frame=header0.payload_nbytes * 8 // bps // nchan,
-            frame_nbytes=header0.frame_nbytes,
             unsliced_shape=(nchan,), bps=bps, complex_data=False,
             squeeze=squeeze, subset=subset, fill_value=fill_value,
             verify=verify)

--- a/baseband/mark5b/file_info.py
+++ b/baseband/mark5b/file_info.py
@@ -10,7 +10,7 @@ __all__ = ['Mark5BFileReaderInfo']
 
 
 class Mark5BFileReaderInfo(VLBIFileReaderInfo):
-    _header0_attrs = ()
+    _header0_attrs = ('complex_data',)
     _parent_attrs = ('nchan', 'bps', 'ref_time', 'kday')
 
     bps = info_item('bps', needs='_parent', missing='needed to decode data')
@@ -49,5 +49,3 @@ class Mark5BFileReaderInfo(VLBIFileReaderInfo):
     def frame0(self):
         """First frame from the file."""
         return super().frame0
-
-    complex_data = False

--- a/baseband/mark5b/header.py
+++ b/baseband/mark5b/header.py
@@ -75,8 +75,8 @@ class Mark5BHeader(VLBIHeaderBase):
 
     _struct = four_word_struct
 
-    _properties = ('payload_nbytes', 'frame_nbytes', 'kday', 'jday', 'seconds',
-                   'fraction', 'time')
+    _properties = ('payload_nbytes', 'frame_nbytes', 'complex_data',
+                   'kday', 'jday', 'seconds', 'fraction', 'time')
     """Properties accessible/usable in initialisation."""
 
     kday = None
@@ -177,13 +177,18 @@ class Mark5BHeader(VLBIHeaderBase):
 
     @fixedvalue
     def payload_nbytes(cls):
-        """Size of the payload in bytes (10000 for Mark5B)."""
+        """Size of the payload in bytes (always 10000 for Mark5B)."""
         return 10000  # 2500 words
 
     @fixedvalue
     def frame_nbytes(cls):
-        """Size of the frame in bytes."""
+        """Size of the frame in bytes (always 10016 for Mark5B)."""
         return cls.nbytes + cls.payload_nbytes
+
+    @fixedvalue
+    def complex_data(cls):
+        """Whether the data are complex (always False for Mark5B)."""
+        return False
 
     @property
     def jday(self):

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -59,6 +59,7 @@ class TestMark5B:
         with open(SAMPLE_FILE, 'rb') as fh:
             header = mark5b.Mark5BHeader.fromfile(fh, kday=56000)
         assert header.nbytes == 16
+        assert not header.complex_data
         assert header.kday == 56000.
         assert header.jday == 821
         mjd, frac = divmod(header.time.mjd, 1)
@@ -95,10 +96,13 @@ class TestMark5B:
         header6.time == header.time
         header6.payload_nbytes = 10000
         header6.frame_nbytes = 10016
+        header6.complex_data = False
         with pytest.raises(ValueError):
             header6.payload_nbytes = 9999
         with pytest.raises(ValueError):
             header6.frame_nbytes = 20
+        with pytest.raises(ValueError):
+            header6.complex_data = True
         # Regression tests
         header7 = header.copy()
         assert header7 == header  # This checks header.words

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -373,6 +373,7 @@ class VDIFStreamBase(VLBIStreamBase):
         super().__init__(
             fh_raw=fh_raw, header0=header0, sample_rate=sample_rate,
             samples_per_frame=samples_per_frame,
+            frame_nbytes=header0.frame_nbytes,
             unsliced_shape=(nthread, header0.nchan), bps=header0.bps,
             complex_data=header0['complex_data'], squeeze=squeeze,
             subset=subset, fill_value=fill_value, verify=verify)

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -368,13 +368,10 @@ class VDIFStreamBase(VLBIStreamBase):
 
     def __init__(self, fh_raw, header0, sample_rate=None, nthread=1,
                  squeeze=True, subset=(), fill_value=0., verify=True):
-        samples_per_frame = header0.samples_per_frame
 
         super().__init__(
             fh_raw=fh_raw, header0=header0, sample_rate=sample_rate,
-            samples_per_frame=samples_per_frame,
-            frame_nbytes=header0.frame_nbytes,
-            unsliced_shape=(nthread, header0.nchan), bps=header0.bps,
+            unsliced_shape=(nthread, header0.nchan),
             complex_data=header0['complex_data'], squeeze=squeeze,
             subset=subset, fill_value=fill_value, verify=verify)
 

--- a/baseband/vdif/base.py
+++ b/baseband/vdif/base.py
@@ -371,8 +371,7 @@ class VDIFStreamBase(VLBIStreamBase):
 
         super().__init__(
             fh_raw=fh_raw, header0=header0, sample_rate=sample_rate,
-            unsliced_shape=(nthread, header0.nchan),
-            complex_data=header0['complex_data'], squeeze=squeeze,
+            unsliced_shape=(nthread, header0.nchan), squeeze=squeeze,
             subset=subset, fill_value=fill_value, verify=verify)
 
     def _get_time(self, header):

--- a/baseband/vdif/header.py
+++ b/baseband/vdif/header.py
@@ -113,8 +113,8 @@ class VDIFHeader(VLBIHeaderBase, metaclass=VDIFHeaderMeta):
     # are broken for some threads of the EVN 2014 data, so apparently
     # that is not a safe bet.
 
-    _properties = ('frame_nbytes', 'payload_nbytes', 'bps', 'nchan',
-                   'samples_per_frame', 'station', 'ref_time', 'time')
+    _properties = ('frame_nbytes', 'payload_nbytes', 'bps', 'complex_data',
+                   'nchan', 'samples_per_frame', 'station', 'ref_time', 'time')
     """Properties accessible/usable in initialisation for all VDIF headers."""
 
     _edv = None
@@ -320,6 +320,15 @@ class VDIFHeader(VLBIHeaderBase, metaclass=VDIFHeaderMeta):
             raise ValueError("bits per sample that is not a power of two "
                              "is only possible for single-channel data.")
         self['bits_per_sample'] = int(bps) - 1
+
+    @property
+    def complex_data(self):
+        """Whether the data are complex."""
+        return self['complex_data']
+
+    @complex_data.setter
+    def complex_data(self, complex_data):
+        self['complex_data'] = complex_data
 
     @property
     def nchan(self):

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -966,7 +966,6 @@ class VLBIStreamReaderBase(VLBIStreamBase):
         # to jump over a bad bit.
         while header_index >= index:
             raw_pos = self.fh_raw.tell()
-            header1 = header
             header1_index = header_index
             self.fh_raw.seek(-1, 1)
             try:
@@ -980,17 +979,17 @@ class VLBIStreamReaderBase(VLBIStreamBase):
             # While we are at it, update the list of known indices.
             self._raw_offsets[header1_index] = raw_pos
 
-        # Move back to position of last good header (header1).
+        # Move back to position of last good header (header1_index).
         self.fh_raw.seek(raw_pos)
 
         if header1_index > index:
             # Frame is missing!
             msg += ' The frame seems to be missing.'
-            # Construct a missing frame.
-            header = header1.copy()
-            self._set_index(header, index)
-            frame = self._frame.__class__(header, self._frame.payload,
-                                          valid=False)
+            # Just reuse old frame with new index and set to invalid.
+            frame = self._frame
+            frame.header.mutable = True
+            frame.valid = False
+            self._set_index(frame, index)
 
         else:
             assert header1_index == index, \

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -429,8 +429,9 @@ class VLBIStreamBase:
     def _set_time(self, header, time):
         """Set time in a header."""
         # Subclasses can override this if information is needed beyond that
-        # provided in the header.
-        header.time = time
+        # provided in the header.  Use update since that some classes will
+        # do extra work after any setting (e.g., CRC update).
+        header.update(time=time)
 
     def _get_index(self, header):
         """Infer the index of the frame header relative to the first frame."""

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -642,15 +642,14 @@ class VLBIStreamReaderBase(VLBIStreamBase):
         # Now apply subset to a dummy sample that has the sample number as its
         # value (where 13 is to bring bad luck to over-complicated subsets).
         dummy_data = np.arange(13.)
-        dummy_sample = np.rollaxis(  # Use moveaxis when numpy_min>=1.11
-            (np.zeros(sample_shape)[..., np.newaxis] + dummy_data), -1)
+        dummy_sample = np.moveaxis(
+            (np.zeros(sample_shape)[..., np.newaxis] + dummy_data), -1, 0)
         try:
             dummy_subset = dummy_sample[(slice(None),) + self.subset]
             # Check whether subset was in range and whether sample numbers were
             # preserved (latter should be, but check anyway).
             assert 0 not in dummy_subset.shape
-            assert np.all(dummy_subset == dummy_data.reshape(
-                (-1,) + (1,) * (dummy_subset.ndim - 1)))
+            assert np.all(np.moveaxis(dummy_subset, 0, -1) == dummy_data)
         except (IndexError, AssertionError) as exc:
             exc.args += ("subset {} cannot be used to properly index "
                          "{}samples with shape {}.".format(

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -354,7 +354,7 @@ class VLBIStreamBase:
     _sample_shape_maker = None
     _frame_index = None
 
-    def __init__(self, fh_raw, header0, sample_rate, samples_per_frame,
+    def __init__(self, fh_raw, header0, *, sample_rate, samples_per_frame,
                  frame_nbytes, unsliced_shape, bps, complex_data, squeeze,
                  subset=(), fill_value=0., verify=True):
         self.fh_raw = fh_raw
@@ -576,9 +576,9 @@ class VLBIStreamBase:
 
 class VLBIStreamReaderBase(VLBIStreamBase):
 
-    def __init__(self, fh_raw, header0, sample_rate, samples_per_frame,
-                 frame_nbytes, unsliced_shape, bps, complex_data, squeeze,
-                 subset, fill_value, verify):
+    def __init__(self, fh_raw, header0, *, sample_rate, samples_per_frame,
+                 frame_nbytes, unsliced_shape, bps, complex_data,
+                 squeeze=False, subset=(), fill_value=0., verify=True):
 
         if sample_rate is None:
             try:
@@ -594,8 +594,10 @@ class VLBIStreamReaderBase(VLBIStreamBase):
                 raise
 
         super().__init__(
-            fh_raw, header0, sample_rate, samples_per_frame, frame_nbytes,
-            unsliced_shape, bps, complex_data, squeeze, subset, fill_value,
+            fh_raw, header0, sample_rate=sample_rate,
+            samples_per_frame=samples_per_frame, frame_nbytes=frame_nbytes,
+            unsliced_shape=unsliced_shape, bps=bps, complex_data=complex_data,
+            squeeze=squeeze, subset=subset, fill_value=fill_value,
             verify=verify)
 
         self._raw_offsets = RawOffsets(frame_nbytes=frame_nbytes)
@@ -1027,7 +1029,7 @@ class VLBIStreamReaderBase(VLBIStreamBase):
 
 class VLBIStreamWriterBase(VLBIStreamBase):
 
-    def __init__(self, fh_raw, header0, sample_rate, samples_per_frame,
+    def __init__(self, fh_raw, header0, *, sample_rate, samples_per_frame,
                  frame_nbytes, unsliced_shape, bps, complex_data, squeeze,
                  subset, fill_value, verify):
 
@@ -1035,9 +1037,11 @@ class VLBIStreamWriterBase(VLBIStreamBase):
             raise ValueError("must pass in an explicit `sample_rate`.")
 
         super().__init__(
-            fh_raw, header0, sample_rate, samples_per_frame,
-            frame_nbytes, unsliced_shape, bps, complex_data, squeeze,
-            subset, fill_value, verify)
+            fh_raw, header0, sample_rate=sample_rate,
+            samples_per_frame=samples_per_frame, frame_nbytes=frame_nbytes,
+            unsliced_shape=unsliced_shape, bps=bps, complex_data=complex_data,
+            squeeze=squeeze, subset=subset, fill_value=fill_value,
+            verify=verify)
 
     def _unsqueeze(self, data):
         new_shape = list(data.shape)

--- a/baseband/vlbi_base/frame.py
+++ b/baseband/vlbi_base/frame.py
@@ -217,6 +217,14 @@ class VLBIFrameBase:
             # Raise appropriate error.
             return self.__getattribute__(attr)
 
+    def __setattr__(self, attr, value):
+        if (attr not in {'header', 'payload', 'valid'}
+                and attr in getattr(getattr(self, 'header', None),
+                                    '_properties', ())):
+            return setattr(self.header, attr, value)
+        else:
+            return super().__setattr__(attr, value)
+
     # For tests, it is useful to define equality.
     def __eq__(self, other):
         return (type(self) is type(other)

--- a/baseband/vlbi_base/tests/test_vlbi_base.py
+++ b/baseband/vlbi_base/tests/test_vlbi_base.py
@@ -553,8 +553,8 @@ class TestSqueezeAndSubset:
     def setup(self):
         self.other_args = dict(fh_raw=None, header0=None, bps=1,
                                complex_data=False, samples_per_frame=1000,
-                               sample_rate=10000*u.Hz, fill_value=0.,
-                               verify=True)
+                               frame_nbytes=1000, sample_rate=10000*u.Hz,
+                               fill_value=0., verify=True)
         self.sample_shape_maker = namedtuple('SampleShape',
                                              'n0, n1, n2, n3, n4')
         self.unsliced_shape = (1, 21, 33, 1, 2)


### PR DESCRIPTION
Mostly to make GSBHeader not have unnecessary pieces, and to make the work in the stream readers and writers a bit more uniform. Furthermore, added some  properties to mark4, mark5b and vdif headers which are usefully defined (`complex_data` for all, also `sample_shape` for mark4).