### PR TITLE
GSB reader payload_nbytes calculation fixup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,15 @@
 - This future version will likely only support python 3.7, numpy 1.17 and
   astropy 4.0.
 
+3.2.1 (unreleased)
+==================
+
+Bug Fixes
+---------
+
+- For GSB phased data, fix the interpretation of ``sample_rate`` in
+  calculating ``payload_nbytes``. [#410]
+
 3.2 (2020-06-11)
 ================
 

--- a/baseband/gsb/tests/test_gsb.py
+++ b/baseband/gsb/tests/test_gsb.py
@@ -675,8 +675,11 @@ class TestGSB:
         (SAMPLE_RAWDUMP_HEADER, SAMPLE_RAWDUMP),
         (SAMPLE_PHASED_HEADER, SAMPLE_PHASED)])
     def test_pickle(self, sample_header, sample_data):
+        if sample_header is SAMPLE_RAWDUMP_HEADER:
+            sample_rate = self.frame_rate * self.payload_nbytes * 2
+        else:
+            sample_rate = self.frame_rate * self.payload_nbytes / 512
         # Only simple tests here; more complete ones in vdif.
-        sample_rate = self.frame_rate * self.payload_nbytes * 2
         with gsb.open(sample_header, 'rs', raw=sample_data,
                       sample_rate=sample_rate,
                       payload_nbytes=self.payload_nbytes,

--- a/baseband/tests/test_file_info.py
+++ b/baseband/tests/test_file_info.py
@@ -98,8 +98,8 @@ def test_gsb_with_raw_files(sample, raw, mode):
     assert list(bad_info.errors.keys()) == ['frame0']
     # But with the correct sample_rate, it works.
     base_info = file_info(sample)
-    sample_rate = (2**12 * base_info.frame_rate
-                   / (1 if base_info.mode == 'rawdump' else 1024))
+    sample_rate = (base_info.frame_rate
+                   * (8192 if base_info.mode == 'rawdump' else 8))
     info = file_info(sample, raw=raw, sample_rate=sample_rate)
     assert info.format == 'gsb'
     assert info.readable is True


### PR DESCRIPTION
follow-up of #401. Also guards against regressions by doing a sanity check in `_read_frame`