### PR TITLE
Refactor gsb writer to use _set_index.

### DIFF
--- a/baseband/gsb/base.py
+++ b/baseband/gsb/base.py
@@ -281,6 +281,17 @@ class GSBStreamBase(VLBIStreamBase):
         #  __getattribute__ to raise appropriate error.
         return self.__getattribute__(attr)
 
+    def _set_index(self, header, index):
+        if self.header0.mode == 'phased':
+            time_offset = index / self._frame_rate
+            # mem_block is a rotating modulo-8 value with no meaning.
+            header.update(gps_time=self.header0.gps_time + time_offset,
+                          pc_time=self.header0.pc_time + time_offset,
+                          seq_nr=self.header0['seq_nr'] + index,
+                          mem_block=(self.header0['mem_block'] + index) % 8)
+        else:
+            super()._set_index(header, index)
+
     def close(self):
         self.fh_ts.close()
         try:
@@ -552,26 +563,10 @@ class GSBStreamWriter(GSBStreamBase, VLBIStreamWriterBase):
             fh_ts, fh_raw, header0, sample_rate=sample_rate,
             samples_per_frame=samples_per_frame, payload_nbytes=payload_nbytes,
             nchan=nchan, bps=bps, complex_data=complex_data, squeeze=squeeze)
-        self._payload = GSBPayload.fromdata(
+        self._frame = GSBFrame.fromdata(
             np.zeros((self.samples_per_frame,) + self._unsliced_shape,
                      (np.complex64 if self.complex_data else np.float32)),
-            bps=self.bps)
-
-    def _make_frame(self, index):
-        # Set up header for new frame.  (mem_block is set to a rotating
-        # modulo-8 value with no meaning.)
-        time_offset = index * self.samples_per_frame / self.sample_rate
-        if self.header0.mode == 'phased':
-            header = self.header0.fromvalues(
-                gps_time=self.header0.gps_time + time_offset,
-                pc_time=self.header0.pc_time + time_offset,
-                seq_nr=(index + self.header0['seq_nr']),
-                mem_block=((self.header0['mem_block'] + index) % 8))
-        else:
-            header = self.header0.fromvalues(time=self.start_time
-                                             + time_offset)
-
-        return GSBFrame(header, self._payload, valid=True, verify=False)
+            header=self.header0.copy(), bps=self.bps)
 
     def _fh_raw_write_frame(self, frame):
         assert frame.valid

--- a/baseband/mark4/base.py
+++ b/baseband/mark4/base.py
@@ -263,10 +263,6 @@ class Mark4StreamBase(VLBIStreamBase):
             bps=header0.bps, complex_data=False, squeeze=squeeze,
             subset=subset, fill_value=fill_value, verify=verify)
 
-    def _set_time(self, header, time):
-        # Use update to ensure CRC is updated as well.
-        header.update(time=time)
-
 
 class Mark4StreamReader(Mark4StreamBase, VLBIStreamReaderBase):
     """VLBI Mark 4 format reader.

--- a/baseband/vlbi_base/base.py
+++ b/baseband/vlbi_base/base.py
@@ -429,8 +429,9 @@ class VLBIStreamBase:
     def _set_time(self, header, time):
         """Set time in a header."""
         # Subclasses can override this if information is needed beyond that
-        # provided in the header.
-        header.time = time
+        # provided in the header.  Use update since that some classes will
+        # do extra work after any setting (e.g., CRC update).
+        header.update(time=time)
 
     def _get_index(self, header):
         """Infer the index of the frame header relative to the first frame."""

--- a/baseband/vlbi_base/frame.py
+++ b/baseband/vlbi_base/frame.py
@@ -217,6 +217,14 @@ class VLBIFrameBase:
             # Raise appropriate error.
             return self.__getattribute__(attr)
 
+    def __setattr__(self, attr, value):
+        if (attr not in {'header', 'payload', 'valid'}
+                and attr in getattr(getattr(self, 'header', None),
+                                    '_properties', ())):
+            return setattr(self.header, attr, value)
+        else:
+            return super().__setattr__(attr, value)
+
     # For tests, it is useful to define equality.
     def __eq__(self, other):
         return (type(self) is type(other)


### PR DESCRIPTION
Mostly a left-over from the previous PR to make writing simpler.
Also rewrote the base _set_time to use update instead of setting
time directly, as this way is more likely to always work (and
one can remove the override in mark4).