### PR TITLE
Simplify header parser classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,18 @@ New Features
   packages to make new readers accessible to baseband by defining an entry
   point in their ``setup.cfg``. [#418]
 
+API Changes
+-----------
+
+- Following python 3.9, ``HeaderParser`` instances (which are subclasses of
+  ``dict``), can now be merged together using the ``|`` operator. For
+  backward compatibility, using the ``+`` operator will remain supported.
+  [#424]
+
+- All ``StreamWriters`` now require an explicit ``header0`` to be passed
+  in (as was already the case for DADA and GUPPI). Creation of a ``header0``
+  from keyword arguments is now done inside the opener. [#417]
+
 Bug Fixes
 ---------
 
@@ -22,10 +34,6 @@ Other Changes and Additions
 
 - All baseband formats now support passing in template strings for stream
   readers and writers (e.g., ``'{file_nr:07d}.vdif'``). [#417]
-
-- All ``StreamWriters`` now require an explicit ``header0`` to be passed
-  in (as was already the case for DADA and GUPPI). Creation of a ``header0``
-  from keyword arguments is now done inside the opener. [#417]
 
 - The headers for VDIF and Mark 4 now expose standard ``complex_data``
   and ``sample_shape`` properties, to match what is done for the other

--- a/baseband/vdif/header.py
+++ b/baseband/vdif/header.py
@@ -543,7 +543,7 @@ class VDIFLegacyHeader(VDIFNoSampleRateHeader):
 class VDIFBaseHeader(VDIFHeader):
     """Base for non-legacy VDIF headers that use 8 32-bit words."""
 
-    _header_parser = VDIFLegacyHeader._header_parser + HeaderParser(
+    _header_parser = VDIFLegacyHeader._header_parser | HeaderParser(
         (('legacy_mode', (0, 30, 1, False)),  # Repeat, to change default.
          ('edv', (4, 24, 8))))
 
@@ -581,7 +581,7 @@ class VDIFHeader0(VDIFBaseHeader, VDIFNoSampleRateHeader):
 class VDIFSampleRateHeader(VDIFBaseHeader):
     """Base for VDIF headers that include the sample rate (EDV= 1, 3, 4)."""
 
-    _header_parser = VDIFBaseHeader._header_parser + HeaderParser(
+    _header_parser = VDIFBaseHeader._header_parser | HeaderParser(
         (('sampling_unit', (4, 23, 1)),
          ('sampling_rate', (4, 0, 23)),
          ('sync_pattern', (5, 0, 32, 0xACABFEED))))
@@ -687,7 +687,7 @@ class VDIFHeader1(VDIFSampleRateHeader):
     See https://vlbi.org/wp-content/uploads/2019/03/vdif_extension_0x01.pdf
     """
     _edv = 1
-    _header_parser = VDIFSampleRateHeader._header_parser + HeaderParser(
+    _header_parser = VDIFSampleRateHeader._header_parser | HeaderParser(
         (('das_id', (6, 0, 64, 0x0)),))
 
     _invariants = (VDIFSampleRateHeader._invariants
@@ -701,7 +701,7 @@ class VDIFHeader3(VDIFSampleRateHeader):
     See https://vlbi.org/wp-content/uploads/2019/03/vdif_extension_0x03.pdf
     """
     _edv = 3
-    _header_parser = VDIFSampleRateHeader._header_parser + HeaderParser(
+    _header_parser = VDIFSampleRateHeader._header_parser | HeaderParser(
         (('frame_length', (2, 0, 24, 629)),  # Repeat, to set default.
          ('loif_tuning', (6, 0, 32, 0x0)),
          ('_7_28_4', (7, 28, 4, 0x0)),
@@ -746,7 +746,7 @@ class VDIFHeader2(VDIFBaseHeader, VDIFNoSampleRateHeader):
     """
     _edv = 2
 
-    _header_parser = VDIFBaseHeader._header_parser + HeaderParser(
+    _header_parser = VDIFBaseHeader._header_parser | HeaderParser(
         (('complex_data', (3, 31, 1, 0x0)),  # Repeat, to set default.
          ('bits_per_sample', (3, 26, 5, 0x1)),  # Repeat, to set default.
          ('pol', (4, 0, 1)),
@@ -777,8 +777,8 @@ class VDIFMark5BHeader(VDIFBaseHeader, VDIFNoSampleRateHeader, Mark5BHeader):
     _edv = 0xab
     # Repeat 'frame_length' to set default.
     _header_parser = (VDIFBaseHeader._header_parser
-                      + HeaderParser((('frame_length', (2, 0, 24, 1254)),))
-                      + HeaderParser(tuple(
+                      | HeaderParser((('frame_length', (2, 0, 24, 1254)),))
+                      | HeaderParser(tuple(
                           ((k if k != 'frame_nr' else 'mark5b_frame_nr'),
                            (v[0] + 4,) + v[1:])
                           for (k, v) in Mark5BHeader._header_parser.items())))

--- a/baseband/vdif/tests/test_vdif.py
+++ b/baseband/vdif/tests/test_vdif.py
@@ -263,7 +263,7 @@ class TestVDIF:
         class VDIFHeaderX(vdif.header.VDIFSampleRateHeader):
             _edv = 0x58
             _header_parser = (vdif.header.VDIFSampleRateHeader._header_parser
-                              + vlbi_base.header.HeaderParser(
+                              | vlbi_base.header.HeaderParser(
                                   (('nonsense_0', (6, 0, 32, 0x0)),
                                    ('nonsense_1', (7, 0, 8, None)),
                                    ('nonsense_2', (7, 8, 24, 0x1)))))

--- a/baseband/vlbi_base/header.py
+++ b/baseband/vlbi_base/header.py
@@ -7,6 +7,7 @@ corresponding to a frame header, providing access to the values encoded in
 via a dict-like interface.  Definitions for headers are constructed using
 the HeaderParser class.
 """
+import sys
 import struct
 import warnings
 from copy import copy
@@ -228,12 +229,19 @@ class HeaderParser(dict):
     they are precalculated on first access rather than calculated on the fly.
 
     """
-    def __add__(self, other):
-        if not isinstance(other, HeaderParser):
+    def __or__(self, other):
+        if not isinstance(other, type(self)):
             return NotImplemented
+
+        if sys.version_info >= (3, 9):
+            return self.__class__(super().__or__(other))
+
         result = self.__class__(self)
         result.update(other)
         return result
+
+    # Backwards compatibility for code written for baseband < 4.0.
+    __add__ = __or__
 
     parsers = ParserDict(make_parser)
     setters = ParserDict(make_setter)

--- a/baseband/vlbi_base/tests/test_vlbi_base.py
+++ b/baseband/vlbi_base/tests/test_vlbi_base.py
@@ -207,7 +207,7 @@ class TestVLBIBase:
 
     def test_header_with_implicit_invariants(self):
         class SyncHeader(self.Header):
-            _header_parser = self.Header._header_parser + HeaderParser(
+            _header_parser = self.Header._header_parser | HeaderParser(
                 (('sync_pattern', (1, 0, 32, 0x12345678)),))
 
         assert SyncHeader.invariants() == {'sync_pattern'}
@@ -228,6 +228,9 @@ class TestVLBIBase:
             SyncHeader.invariant_pattern({'x0_16_4', 'sync_pattern'})
 
     def test_header_with_explicit_invariants(self):
+        # On purpose, check the old way of "adding" HeaderParser,
+        # instead of following python 3.9 and using "|" for update,
+        # to be sure we support code written against baseband < 4.0.
         class SyncHeader(self.Header):
             _header_parser = self.Header._header_parser + HeaderParser(
                 (('sync_pattern', (1, 0, 32, 0x12345678)),))

--- a/docs/tutorials/new_edv.rst
+++ b/docs/tutorials/new_edv.rst
@@ -175,18 +175,18 @@ subclasses, namely :mod:`~baseband.vdif.header.VDIFBaseHeader` and
 :mod:`~baseband.vdif.header.VDIFSampleRateHeader`.  This is because many
 EDV specifications share common header values, and so their functions and
 derived properties should be shared as well.  Moreover, header parsers can be
-appended to one another, which saves repetitious coding because the first four
+appended to one another [*]_, which saves repetitious coding because the first four
 words of any VDIF header are the same.  Indeed, we can create the same header
 as above by subclassing :mod:`~baseband.vdif.header.VDIFBaseHeader`::
 
     >>> class VDIFHeader4Enhanced(vdif.header.VDIFBaseHeader):
     ...     _edv = 42
     ...
-    ...     _header_parser = vdif.header.VDIFBaseHeader._header_parser +\
-    ...                      vlbi.header.HeaderParser((
-    ...                             ('validity_mask_length', (4, 16, 8, 0)),
-    ...                             ('sync_pattern', (5, 0, 32, 0xACABFEED)),
-    ...                             ('validity_mask', (6, 0, 64, 0))))
+    ...     _header_parser = (vdif.header.VDIFBaseHeader._header_parser
+    ...                       | vlbi.header.HeaderParser((
+    ...                           ('validity_mask_length', (4, 16, 8, 0)),
+    ...                           ('sync_pattern', (5, 0, 32, 0xACABFEED)),
+    ...                           ('validity_mask', (6, 0, 64, 0)))))
     ...
     ...     _properties = vdif.header.VDIFBaseHeader._properties + ('validity',)
     ...
@@ -211,6 +211,10 @@ as above by subclassing :mod:`~baseband.vdif.header.VDIFBaseHeader`::
     ...         bitmask[:len(validity)] = validity
     ...         self['validity_mask_length'] = len(validity)
     ...         self['validity_mask'] = np.packbits(bitmask[::-1]).view('>u8')
+
+.. [*] In baseband < 4.0, header parsers were appended to each other using
+       the ``+`` operator.  It was changed to ``|`` to match the syntax in
+       python 3.9, but adding remains supported for backwards compatibility.
 
 Here, we set ``edv = 42`` because :class:`~baseband.vdif.header.VDIFHeader`'s
 metaclass is designed to prevent accidental overwriting of existing
@@ -350,10 +354,11 @@ We then define a replacement class::
     ...     The header also corrects 'bits_per_sample' to be properly bps-1.
     ...     """
     ...
-    ...     _header_parser = vdif.header.VDIFHeader0._header_parser + \
-    ...         vlbi.header.HeaderParser((('link', (3, 16, 4)),
-    ...                                   ('slot', (3, 20, 6)),
-    ...                                   ('eud2', (5, 0, 32))))
+    ...     _header_parser = (vdif.header.VDIFHeader0._header_parser
+    ...                       | vlbi.header.HeaderParser((
+    ...                           ('link', (3, 16, 4)),
+    ...                           ('slot', (3, 20, 6)),
+    ...                           ('eud2', (5, 0, 32)))))
     ...
     ...     def verify(self):
     ...         pass  # this is a hack, don't bother with verification...
@@ -413,10 +418,11 @@ class, and define a replacement::
     ...
     ...     The header also corrects 'bits_per_sample' to be properly bps-1.
     ...     """
-    ...     _header_parser = vdif.header.VDIFHeader0._header_parser + \
-    ...         vlbi.header.HeaderParser((('link', (3, 16, 4)),
-    ...                                   ('slot', (3, 20, 6)),
-    ...                                   ('eud2', (5, 0, 32))))
+    ...     _header_parser = (vdif.header.VDIFHeader0._header_parser
+    ...                       | vlbi.header.HeaderParser((
+    ...                           ('link', (3, 16, 4)),
+    ...                           ('slot', (3, 20, 6)),
+    ...                           ('eud2', (5, 0, 32)))))
     ...
     ...     def __init__(self, words, edv=None, verify=True, **kwargs):
     ...         super(DRAOVDIFHeaderEnhanced, self).__init__(


### PR DESCRIPTION
They are really just a `dict` with a few `ParserDict` descriptors, so might as well make that more obvious. Also means we do not need to subclass in GSB.