### PR TITLE
Use fixedvalue for complex in Mark4,5B payloads

### DIFF
--- a/baseband/base/header.py
+++ b/baseband/base/header.py
@@ -15,10 +15,12 @@ import functools
 from copy import copy
 
 import numpy as np
-from astropy.utils import sharedmethod, classproperty
+from astropy.utils import sharedmethod
+
+from .utils import fixedvalue
 
 
-__all__ = ['fixedvalue', 'four_word_struct', 'eight_word_struct',
+__all__ = ['four_word_struct', 'eight_word_struct',
            'make_parser', 'make_setter', 'get_default',
            'ParserDict', 'HeaderParserBase', 'HeaderParser',
            'ParsedHeaderBase', 'VLBIHeaderBase']
@@ -28,20 +30,6 @@ four_word_struct = struct.Struct('<4I')
 """Struct instance that packs/unpacks 4 unsigned 32-bit integers."""
 eight_word_struct = struct.Struct('<8I')
 """Struct instance that packs/unpacks 8 unsigned 32-bit integers."""
-
-
-class fixedvalue(classproperty):
-    """Property that is fixed for all instances of a class.
-
-    Based on `astropy.utils.decorators.classproperty`, but with
-    a setter that passes if the value is identical to the fixed
-    value, and otherwise raises a `ValueError`.
-    """
-    def __set__(self, instance, value):
-        fixed_value = self.__get__(instance, type(instance))
-        if value != fixed_value:
-            raise ValueError(
-                f"'{self.fget.__name__}' can only be set to {fixed_value}.")
 
 
 def make_parser(word_index, bit_index, bit_length, default=None):
@@ -305,7 +293,7 @@ class ParsedHeaderBase:
       _properties : tuple of properties accessible/usable in initialisation
 
     It also should define properties that tell the size (getters *and*
-    setters, or use a `baseband.base.header.fixedvalue` if the
+    setters, or use a `baseband.base.utils.fixedvalue` if the
     value is the same for all instances):
 
       payload_nbytes : number of bytes used by payload
@@ -536,7 +524,7 @@ class VLBIHeaderBase(ParsedHeaderBase):
       _stream_invarants : set of keys of invariant header parts for a stream.
 
     It also should define properties that tell the size (getters *and*
-    setters, or use a `baseband.base.header.fixedvalue` if the
+    setters, or use a `baseband.base.utils.fixedvalue` if the
     value is the same for all instances):
 
       payload_nbytes : number of bytes used by payload

--- a/baseband/base/utils.py
+++ b/baseband/base/utils.py
@@ -3,9 +3,11 @@ from operator import index
 from math import gcd
 
 import numpy as np
+from astropy.utils import classproperty
 
 
-__all__ = ['lcm', 'bcd_decode', 'bcd_encode', 'byte_array', 'CRC', 'CRCStack']
+__all__ = ['lcm', 'bcd_decode', 'bcd_encode', 'fixedvalue', 'byte_array',
+           'CRC', 'CRCStack']
 
 
 def lcm(a, b):
@@ -72,6 +74,20 @@ def byte_array(pattern):
             or pattern.max() >= 1 << 32):
         raise ValueError('values have to fit in 32 bit unsigned int.')
     return pattern.astype('<u4').view('u1')
+
+
+class fixedvalue(classproperty):
+    """Property that is fixed for all instances of a class.
+
+    Based on `astropy.utils.decorators.classproperty`, but with
+    a setter that passes if the value is identical to the fixed
+    value, and otherwise raises a `ValueError`.
+    """
+    def __set__(self, instance, value):
+        fixed_value = self.__get__(instance, type(instance))
+        if value != fixed_value:
+            raise ValueError(
+                f"'{self.fget.__name__}' can only be set to {fixed_value}.")
 
 
 class CRC:

--- a/baseband/mark4/header.py
+++ b/baseband/mark4/header.py
@@ -16,8 +16,8 @@ import numpy as np
 from astropy.time import Time
 from astropy.utils import sharedmethod
 
-from ..base.header import HeaderParser, VLBIHeaderBase, fixedvalue
-from ..base.utils import bcd_decode, bcd_encode, CRCStack
+from ..base.header import HeaderParser, VLBIHeaderBase
+from ..base.utils import bcd_decode, bcd_encode, fixedvalue, CRCStack
 
 __all__ = ['CRC12', 'crc12', 'stream2words', 'words2stream',
            'Mark4TrackHeader', 'Mark4Header']

--- a/baseband/mark4/payload.py
+++ b/baseband/mark4/payload.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from ..base.payload import PayloadBase
 from ..base.encoding import encode_2bit_base, decoder_levels
-from ..base.header import fixedvalue
+from ..base.utils import fixedvalue
 from .header import MARK4_DTYPES
 
 

--- a/baseband/mark4/payload.py
+++ b/baseband/mark4/payload.py
@@ -15,6 +15,7 @@ import numpy as np
 
 from ..base.payload import PayloadBase
 from ..base.encoding import encode_2bit_base, decoder_levels
+from ..base.header import fixedvalue
 from .header import MARK4_DTYPES
 
 
@@ -344,9 +345,6 @@ class Mark4Payload(PayloadBase):
 
     def __init__(self, words, header=None, *, sample_shape=(1,), bps=2,
                  fanout=1, magnitude_bit=None, complex_data=False):
-        if complex_data:
-            raise ValueError("Mark4 format does not support complex data.")
-
         if header is not None:
             magnitude_bit = header['magnitude_bit']
             bps = 2 if magnitude_bit.any() else 1
@@ -368,10 +366,14 @@ class Mark4Payload(PayloadBase):
         self._dtype_word = MARK4_DTYPES[ntrack]
         self.fanout = fanout
         super().__init__(words, sample_shape=sample_shape,
-                         bps=bps, complex_data=False)
+                         bps=bps, complex_data=complex_data)
         self._coder = (self.sample_shape.nchan,
                        (self.bps if magnitude_bit is None else magnitude_bit),
                        self.fanout)
+
+    @fixedvalue
+    def complex_data(self):
+        return False
 
     @classmethod
     def fromfile(cls, fh, header=None, **kwargs):

--- a/baseband/mark5b/header.py
+++ b/baseband/mark5b/header.py
@@ -12,9 +12,8 @@ import numpy as np
 import astropy.units as u
 from astropy.time import Time
 
-from ..base.header import (HeaderParser, VLBIHeaderBase,
-                           four_word_struct, fixedvalue)
-from ..base.utils import bcd_decode, bcd_encode, CRC
+from ..base.header import HeaderParser, VLBIHeaderBase, four_word_struct
+from ..base.utils import bcd_decode, bcd_encode, fixedvalue, CRC
 
 
 __all__ = ['CRC16', 'crc16', 'Mark5BHeader']

--- a/baseband/mark5b/payload.py
+++ b/baseband/mark5b/payload.py
@@ -14,6 +14,7 @@ import numpy as np
 
 from ..base.payload import PayloadBase
 from ..base.encoding import encode_2bit_base, decoder_levels
+from ..base.header import fixedvalue
 
 
 __all__ = ['init_luts', 'decode_1bit', 'decode_2bit',
@@ -130,10 +131,9 @@ class Mark5BPayload(PayloadBase):
 
     _sample_shape_maker = namedtuple('SampleShape', 'nchan')
 
-    def __init__(self, words, sample_shape=(1,), bps=2, complex_data=False):
-        if complex_data:
-            raise ValueError("Mark5B format does not support complex data.")
-        super().__init__(words, sample_shape=sample_shape, bps=bps)
+    @fixedvalue
+    def complex_data(self):
+        return False
 
     @classmethod
     def fromdata(cls, data, *, bps=2):

--- a/baseband/mark5b/payload.py
+++ b/baseband/mark5b/payload.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from ..base.payload import PayloadBase
 from ..base.encoding import encode_2bit_base, decoder_levels
-from ..base.header import fixedvalue
+from ..base.utils import fixedvalue
 
 
 __all__ = ['init_luts', 'decode_1bit', 'decode_2bit',

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -189,7 +189,8 @@ class TestMark5B:
         assert payload3 == payload
         # Complex data should fail.
         with pytest.raises(ValueError):
-            mark5b.Mark5BPayload(payload3.words, complex_data=True)
+            mark5b.Mark5BPayload(payload3.words, sample_shape=(1,),
+                                 complex_data=True)
         with pytest.raises(ValueError):
             mark5b.Mark5BPayload.fromdata(np.zeros((5000, 8), np.complex64),
                                           bps=2)

--- a/baseband/vdif/header.py
+++ b/baseband/vdif/header.py
@@ -13,7 +13,8 @@ import astropy.units as u
 from astropy.time import Time, TimeDelta
 
 from ..base.header import (four_word_struct, eight_word_struct,
-                           fixedvalue, HeaderParser, VLBIHeaderBase)
+                           HeaderParser, VLBIHeaderBase)
+from ..base.utils import fixedvalue
 from ..mark5b.header import Mark5BHeader
 
 


### PR DESCRIPTION
Also move fixedvalue to utils, which is more logical, especially now it is no longer used only in headers.