### PR TITLE
Temporarily fix numpy-doc to older version to avoid warnings.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ cov =
     pytest-cov
 docs =
     sphinx-astropy
+    numpydoc<1.1.0
 
 [options.package_data]
 baseband = data/*, data/gsb/*

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ description = invoke sphinx-build to build the HTML docs
 extras = docs
 commands =
     pip freeze
-    sphinx-build -W -b html . _build/html
+    sphinx-build -W --keep-going -b html . _build/html
 
 [testenv:linkcheck]
 changedir = docs


### PR DESCRIPTION
Also set sphinx to always keep going so one gets all warnings in one go.

See #434 - eventually we can hopefully remove the version restriction.