### PR TITLE
Ensure we always use header.complex_data, not assume ['complex_data']

### DIFF
--- a/baseband/base/payload.py
+++ b/baseband/base/payload.py
@@ -167,7 +167,7 @@ class PayloadBase:
             if header.complex_data != complex_data:
                 raise ValueError("header is for {0} data but data are {1}"
                                  .format(*(('complex' if c else 'real') for c
-                                           in (header['complex_data'],
+                                           in (header.complex_data,
                                                complex_data))))
         try:
             encoder = cls._encoders[bps]

--- a/baseband/base/tests/test_base.py
+++ b/baseband/base/tests/test_base.py
@@ -410,6 +410,8 @@ class TestBase:
         payload3 = self.Payload.fromdata(self.payload.data,
                                          header=header)
         assert payload3 == self.payload
+        with pytest.raises(ValueError, match='data are complex'):
+            self.Payload.fromdata(self.payload.data.astype(complex), header)
         payload4 = self.Payload.fromdata(data.ravel(), bps=8)
         assert payload4.sample_shape == ()
         assert payload4.shape == (16,)


### PR DESCRIPTION
Bug only affects an error message, but really this should have been tested already... Does not affect pre-4.0.