### PR TITLE
Correctly apply astropy units to the GUPPI header offset getter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,16 @@ Other Changes and Additions
 ---------------------------
 
 
+4.0.2 (2020-09-25)
+==================
+
+Bug Fixes
+---------
+
+- Fix the GUPPIHeader class incorrectly ignoring the STT_OFFS header
+  keyword. [#457]
+
+
 4.0.1 (2020-07-31)
 ==================
 

--- a/baseband/guppi/tests/test_guppi.py
+++ b/baseband/guppi/tests/test_guppi.py
@@ -4,13 +4,13 @@ import pickle
 
 import pytest
 import numpy as np
-import astropy.units as u
+from astropy import units as u
+from astropy.time import Time
 
 from ... import guppi
 from ...helpers import sequentialfile as sf
 from ..base import GUPPIFileNameSequencer
 from ...data import SAMPLE_PUPPI as SAMPLE_FILE
-from ...data import SAMPLE_PUPPI_HEADER as SAMPLE_HEADER
 
 
 class TestGUPPI:
@@ -172,20 +172,30 @@ class TestGUPPI:
     def test_fractional_time_header(self, tmpdir):
         """Check that we can represent fractional time in headers."""
         with open(SAMPLE_FILE, 'rb') as fh:
-            header = guppi.GUPPIHeader.fromfile(fh)
+            header0 = guppi.GUPPIHeader.fromfile(fh)
         # Check setting attributes.
-        header.mutable = True
-        header.start_time = header.start_time - 0.25 * u.s
-        assert header['STT_IMJD'] == 58132
-        assert header['STT_SMJD'] == 51092
-        assert header['STT_OFFS'] == 0.75
-        assert header.time.isot == '2018-01-14T14:11:32.750'
+        header1 = header0.copy()
+        header1.start_time = header0.start_time + (1.25+2**-10) * u.day
+        assert header1['STT_IMJD'] == 58132+1
+        assert header1['STT_SMJD'] == 51093+0.25*24*3600+84
+        assert header1['STT_OFFS'] == 2**-10*24*3600-84
+        assert header1.time.isot == '2018-01-15T20:12:57.375'
         with open(str(tmpdir.join('testguppi.raw')), 'w+b') as s:
-            header.tofile(s)
+            header1.tofile(s)
             s.seek(0)
             header2 = guppi.GUPPIHeader.fromfile(s)
-        assert header2 == header
-        assert header2.time.isot == '2018-01-14T14:11:32.750'
+        assert header2 == header1
+        assert header2.time.isot == header1.time.isot
+
+    @pytest.mark.parametrize('time', [
+        '2012-06-30T23:59:60',
+        '2012-06-30T23:59:60.375',
+        '2012-07-01T00:00:00.125'])
+    def test_leap_seconds(self, time):
+        # Check leap second.
+        time = Time(time)
+        header = guppi.GUPPIHeader.fromvalues(start_time=time)
+        assert abs(header.start_time - time) < 1. * u.ns
 
     def test_header_impossible_samples_per_frame(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
This fixes an issue with the GUPPI header parser, where previously any headers that had a key of `STT_OFFS` that was non-zero would raise an error due to incompatible addition of a unit quantity / unit-less quantity.

Previously, this would prevent several header attributes from being calculated correctly:

``` 'errors': {'start_time': astropy.units.core.UnitConversionError("Can only apply 'add' function to dimensionless quantities when other argument is not a quantity (unless the latter is all zero/infinity/nan)"),
  'stop_time': astropy.units.core.UnitConversionError("Can only apply 'add' function to dimensionless quantities when other argument is not a quantity (unless the latter is all zero/infinity/nan)"),
  'shape': astropy.units.core.UnitConversionError("Can only apply 'add' function to dimensionless quantities when other argument is not a quantity (unless the latter is all zero/infinity/nan)"),
  'continuous': 'While reading at 0: UnitConversionError("Can only apply \'add\' function to dimensionless quantities when other argument is not a quantity (unless the latter is all zero/infinity/nan)")'},
```

This was not caught by the test cases as the sample PUPPI file has `STT_OFFS=0`, which is ignored by astropy calculations (as mentioned in the error messages above).

```
In [1]: from baseband.data import SAMPLE_PUPPI

In [2]: import baseband

In [3]: test = baseband.open(SAMPLE_PUPPI)

In [4]: test.header0['STT_OFFS']
Out[4]: 0
```

