### PR TITLE
Require numpy >=1.17 explicitly (since astropy 4.0 doesn't do that).

### DIFF
--- a/baseband/__init__.py
+++ b/baseband/__init__.py
@@ -10,6 +10,7 @@ from ._astropy_init import *   # noqa
 # Define minima for the documentation, but do not bother to explicitly check.
 __minimum_python_version__ = '3.7'
 __minimum_astropy_version__ = '4.0'
+__minimum_numpy_version__ = '1.17'
 
 if not _ASTROPY_SETUP_:   # noqa
     # For egg_info test builds to pass, put package imports here.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,6 +74,7 @@ rst_epilog += """
 .. _baseband-tasks: https://baseband.readthedocs.io/projects/baseband-tasks/
 .. |minimum_python_version| replace:: {0.__minimum_python_version__}
 .. |minimum_astropy_version| replace:: {0.__minimum_astropy_version__}
+.. |minimum_numpy_version| replace:: {0.__minimum_numpy_version__}
 """.format(baseband)
 
 # -- Project information ------------------------------------------------------

--- a/docs/gsb/index.rst
+++ b/docs/gsb/index.rst
@@ -197,7 +197,7 @@ samples per frame and get very small ``sample_rate``, ``bandwidth``, and
     >>> fh_ph = gsb.open(SAMPLE_GSB_PHASED_HEADER, mode='rs',
     ...                  raw=SAMPLE_GSB_PHASED,
     ...                  samples_per_frame=phased_samples_per_frame)
-    >>> fh_ph.info
+    >>> fh_ph.info  # doctest: +FLOAT_CMP
     GSBStream information:
     start_time = 2013-07-27T21:23:55.324108800
     stop_time = 2013-07-27T21:23:57.840691200

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -13,6 +13,7 @@ Baseband requires:
 
 - Python_ |minimum_python_version| or later
 - Astropy_ |minimum_astropy_version| or later
+- Numpy_ |minimum_numpy_version| or later
 - `entrypoints <https://entrypoints.readthedocs.io/en/latest/>`_
 
 .. _install_baseband:

--- a/docs/tutorials/using_baseband.rst
+++ b/docs/tutorials/using_baseband.rst
@@ -651,7 +651,7 @@ frameset of the sample file::
     >>> fsf = vdif.open(filenames[1], mode='rs', sample_rate=fh.sample_rate)
     >>> fh.seek(fh.shape[0] // 2)    # Seek to start of second frameset.
     20000
-    >>> fsf.header0.time == fh.time
+    >>> abs(fsf.header0.time - fh.time) < 1.*u.ns
     True
     >>> np.all(fsf.read() == fh.read())
     True

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
     astropy>=4.0
+    numpy>=1.17
     entrypoints
 
 [options.entry_points]


### PR DESCRIPTION
fixes #458 
