### PR TITLE
Allow pathlib path in opener

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,16 @@ Other Changes and Additions
 ---------------------------
 
 
+4.0.3 (unreleased)
+==================
+
+Bug Fixes
+---------
+
+- Ensure that ``pathlib.Path`` objects are recognized as valid in the various
+  openers. [#467]
+
+
 4.0.2 (2020-10-23)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@ Bug Fixes
 - Ensure that ``pathlib.Path`` objects are recognized as valid in the various
   openers. [#467]
 
+- Raise a proper ``FileNotFoundError`` instead of an obscure ``AttributeError``
+  if trying to get ``file_info`` on a non-existing file. [#467]
+
 
 4.0.2 (2020-10-23)
 ==================

--- a/baseband/base/base.py
+++ b/baseband/base/base.py
@@ -1335,6 +1335,8 @@ class FileInfo:
             with self.open(name, mode=mode, **kwargs) as fh:
                 return fh.info
         except Exception as exc:
+            if isinstance(exc, FileNotFoundError):
+                raise
             return exc
 
     def is_ok(self, info):
@@ -1361,10 +1363,15 @@ class FileInfo:
             Information on the file.  Will evaluate as `False` if the
             file was not in the right format.
 
+        Raises
+        ------
+        FileNotFoundError
+            If the file does not exist.
+
         Notes
         -----
-        Getting information should never fail. If an `Exception` is
-        raised or returned, it is a bug in the file reader.
+        Getting information for an existing file should never fail. If an
+        `Exception` is raised or returned, it is a bug in the file reader.
         """
         info = self._get_info(name, 'rb')
         # If right format, check if arguments were missing.

--- a/baseband/base/tests/test_opener.py
+++ b/baseband/base/tests/test_opener.py
@@ -1,5 +1,6 @@
 # Licensed under the GPLv3 - see LICENSE
 import io
+import pathlib
 
 import pytest
 import numpy as np
@@ -109,14 +110,19 @@ class TestFileOpener:
                                        dict(payload_nbytes=2, bla='aha'))
         assert fns[1] == '1_aha.bare'
 
-    def test_binary_name(self, tmpdir):
-        name = str(tmpdir.join('test.bare'))
-        with self.file_opener(name, 'wb') as fw:
+    @pytest.mark.parametrize('path_type', [str, None, pathlib.Path])
+    def test_binary_name(self, path_type, tmpdir):
+        path = tmpdir.join('test.bare')
+        if path_type:
+            path = path_type(path)
+        name = str(path)
+
+        with self.file_opener(path, 'wb') as fw:
             assert isinstance(fw, BareFileWriter)
             assert fw.fh_raw.name == name
             fw.write(b'abcde')
 
-        with self.file_opener(name, 'rb') as fr:
+        with self.file_opener(path, 'rb') as fr:
             assert isinstance(fr, BareFileReader)
             assert fr.fh_raw.name == name
             assert fr.read() == b'abcde'

--- a/baseband/base/tests/test_opener.py
+++ b/baseband/base/tests/test_opener.py
@@ -127,6 +127,11 @@ class TestFileOpener:
             assert fr.fh_raw.name == name
             assert fr.read() == b'abcde'
 
+    @pytest.mark.parametrize('mode', ['rb', 'rs'])
+    def test_file_not_found(self, mode):
+        with pytest.raises(FileNotFoundError):
+            self.file_opener('does_not_exist', mode)
+
     def test_binary_fh(self, tmpdir):
         # Also flip mode, and use constructed open
         name = str(tmpdir.join('test.bare'))

--- a/baseband/tests/test_file_info.py
+++ b/baseband/tests/test_file_info.py
@@ -1,5 +1,7 @@
 # Licensed under the GPLv3 - see LICENSE
 import importlib
+import pathlib
+
 import pytest
 from astropy import units as u
 from astropy.time import Time
@@ -147,6 +149,13 @@ def test_unsupported_file(tmpdir):
     info = file_info(name, format='vdif')
     assert 'errors' in str(info)
     assert 'Not parsable' in str(info)
+
+
+@pytest.mark.parametrize('path', ['does_not_exst',
+                                  pathlib.Path('does_not_exist')])
+def test_non_existing_file(path):
+    with pytest.raises(FileNotFoundError):
+        file_info(path)
 
 
 def test_format_with_no_info(monkeypatch):


### PR DESCRIPTION
Also raise `FileNotFoundError` if trying to get `file_info` on a non-existing file.

fixes #465