### PR TITLE
Allow "irrelevant" arguments to be passed on from general opener.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,10 @@ Bug Fixes
 - Raise a proper ``FileNotFoundError`` instead of an obscure ``AttributeError``
   if trying to get ``file_info`` on a non-existing file. [#467]
 
+- Pass on all "irrelevant" arguments not understood by ``file_info`` to the
+  general opener, so they can be used or raise ``TypeError`` in a place where
+  it will be clearer why that happens. [#468]
+
 
 4.0.2 (2020-10-23)
 ==================

--- a/baseband/base/base.py
+++ b/baseband/base/base.py
@@ -1410,7 +1410,9 @@ class FileInfo:
             the opening as a stream failed.
         """
         frame_rate = file_info.frame_rate
-        used_kwargs = file_info.used_kwargs
+        used_kwargs = file_info.used_kwargs.copy()
+
+        # Somewhat inelegant special-cases for sample_rate and verify.
         if frame_rate is None:
             if 'sample_rate' in kwargs:
                 used_kwargs['sample_rate'] = kwargs['sample_rate']
@@ -1418,6 +1420,9 @@ class FileInfo:
                 # frame rate will already be marked as missing in
                 # file_info.
                 return None
+
+        if 'verify' in kwargs:
+            used_kwargs['verify'] = kwargs['verify']
 
         stream_info = self._get_info(name, mode='rs', **used_kwargs)
         if self.is_ok(stream_info):

--- a/baseband/io/__init__.py
+++ b/baseband/io/__init__.py
@@ -210,11 +210,11 @@ def open(name, mode='rs', format=None, **kwargs):
             raise ValueError(f"arguments inconsistent with this {format} file "
                              f"were passed in: {info.inconsistent_kwargs}")
 
-        if getattr(info, 'irrelevant_kwargs', False):
-            raise TypeError(f"open() got unexpected keyword arguments "
-                            f"{info.irrelevant_kwargs}")
-
         kwargs = getattr(info, 'used_kwargs', kwargs)
+        # We add any arguments deemed irrelevant for opening the file, since
+        # either they might just give some extra information (say, squeeze)
+        # or they will just lead to a TypeError, in likely a more useful place.
+        kwargs.update(getattr(info, 'irrelevant_kwargs', {}))
 
     module = getattr(__self__, format)
     return module.open(name, mode=mode, **kwargs)

--- a/baseband/tests/test_core.py
+++ b/baseband/tests/test_core.py
@@ -32,6 +32,19 @@ def test_open_missing_args(sample):
     assert "missing required arguments" in str(exc.value)
 
 
+def test_open_squeeze():
+    with baseband_open(SAMPLE_VDIF, 'rs', squeeze=False) as fh:
+        assert fh.sample_shape == (8, 1)
+    with baseband_open(SAMPLE_VDIF, 'rs', squeeze=True) as fh:
+        assert fh.sample_shape == (8,)
+
+
+@pytest.mark.parametrize('verify', [True, False, 'fix'])
+def test_open_verify(verify):
+    with baseband_open(SAMPLE_VDIF, 'rs', verify=verify) as fh:
+        assert fh.verify == verify
+
+
 def test_open_wrong_args():
     # Use extra arguments that allow formats to succeed up to the stream
     # reader, but then fail on an incorrect sample rate.


### PR DESCRIPTION
These include not really irrelevant ones like 'squeeze'. Also, for ones that are actually wrong, it will give an error message in what likely will be a more useful place.

fixes #466 