### PR TITLE
Test that deepcopy actually works

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,7 @@ Overview
    install
    tutorials/getting_started
    tutorials/using_baseband
+   tutorials/performance_tips
    tutorials/glossary
 
 .. _specific_file_formats_toc:

--- a/docs/tutorials/performance_tips.rst
+++ b/docs/tutorials/performance_tips.rst
@@ -1,0 +1,31 @@
+.. _performance_tips:
+
+.. include:: ../tutorials/glossary_substitutions.rst
+
+****************
+Performance Tips
+****************
+
+Reading and decoding the data stored in baseband files can be somewhat slow,
+especially if the analysis itself is simple.  So far, code development
+has focussed more on correctness than on performance, but a few things
+can help.
+
+.. note:: If you have other tips on performance or contributions that
+          help improve it, please raise an issue or make a pull request!
+
+Minimize Verification
+=====================
+
+Once you know a file does not have missing frames or is otherwise
+slighly corrupted, you can speed up reading by turning off
+verification of headers, by passing in ``verify=False`` when opening
+the stream reader.
+
+Parallel Processing
+===================
+
+Like python file readers in general, baseband's stream readers cannot
+be used in parallel threads.  They can, however, be sent from process
+to process using `pickle <https://docs.python.org/3/library/pickle.html>`_
+(or copied using `copy.deepcopy`).


### PR DESCRIPTION
Fixes #461 - at least that this works, not that one can also change a stream reader after the fact (which is unlikely to happen)

Also adds a minimal performance section to the docs.