### PR TITLE
Update authors

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,45 @@
+{
+    "creators": [
+        {
+            "affiliation": "University of Toronto",
+            "name": "Marten van Kerkwijk",
+            "orcid": "0000-0002-5830-8505"
+        },
+        {
+            "affiliation": "City of Toronto Transportation Services",
+            "name": "Chenchong Charles Zhu"
+        },
+        {
+            "affiliation": "Shanghai Astronomical Observatory",
+            "name": "Shaoguang Guo"
+        },
+        {
+            "affiliation": "University of Toronto",
+            "name": "Rebecca Lin"
+        },
+        {
+            "affiliation": "University of Toronto",
+            "name": "Nikhil Mahajan"
+        },
+        {
+            "affiliation": "Dublin Institute for Advanced Studies",
+            "name": "David McKenna"
+        },
+        {
+            "affiliation": "Max-Plank-Institut f\u00fcr Radioastronomie",
+            "name": "Robert Main"
+        },
+        {
+            "affiliation": "California Institute of Technology",
+            "name": "Dana Simard"
+        },
+        {
+            "affiliation": "UC Berkeley",
+            "name": "George Stein"
+        },
+        {
+            "affiliation": "University of Toronto",
+            "name": "Rik van Lieshout"
+        }
+    ]
+}

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -26,8 +26,10 @@ Other contributors (alphabetical)
 * Rebecca Lin (@00rebe)
 * Nikhil Mahajan (@theXYZT)
 * Robert Main (@ramain)
+* David McKenna (@David-McKenna)
 * Dana Simard (@danasimard)
 * George Stein (@georgestein)
+* Rik van Lieshout (@rikvl)
 
 If you have contributed to Baseband but are not listed above, please send one
 of the authors an e-mail, or `open a pull request for this page

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
+include AUTHORS.rst
 include CHANGES.rst
 include setup.cfg
 include LICENSE.rst

--- a/docs/tutorials/release_procedure.rst
+++ b/docs/tutorials/release_procedure.rst
@@ -64,8 +64,8 @@ We begin in the main development branch (the local equivalent to
   Since ``CHANGES.rst`` is updated for each merge commit, in practice it is
   only necessary to change the date of the release you are working on from
   "unreleased" to the current date.
-- **Add authors and contributors to** ``AUTHORS.rst``.  To list contributors,
-  one can use::
+- **Add authors and contributors to** ``AUTHORS.rst`` and ``.zenodo.json``.
+  To list contributors, one can use::
 
       git shortlog -n -s -e
 


### PR DESCRIPTION
Leaving auto-generation of either AUTHORS.rst or `.zenodo.json` for another time.