### PR TITLE
Allow Mark 5B files to have some nonsense bytes at the start

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,16 @@ Other Changes and Additions
 ---------------------------
 
 
+4.1.1 (unreleased)
+==================
+
+Bug Fixes
+---------
+
+- Ensure that Mark 5B files with extra bytes at the start (i.e., with a
+  first frame that starts later) can be read. [#489]
+
+
 4.1 (2021-11-30)
 ================
 

--- a/baseband/base/base.py
+++ b/baseband/base/base.py
@@ -360,12 +360,18 @@ class VLBIFileReaderBase(FileBase):
         with self.temporary_offset():
             return self.read_header()
 
-    def get_frame_rate(self):
+    def get_frame_rate(self, offset=0):
         """Determine the number of frames per second.
 
         The method cycles through headers, starting from the start of the file,
         finding the largest frame number before it jumps back to 0 for a new
         second.
+
+        Parameters
+        ----------
+        offset : int or None, optional
+            Offset at which to start searching.  Default is 0, i.e., the start
+            of the file. Use `None` to start at the current position.
 
         Returns
         -------
@@ -377,7 +383,7 @@ class VLBIFileReaderBase(FileBase):
         `EOFError`
             If the file contains less than one second of data.
         """
-        with self.temporary_offset(0):
+        with self.temporary_offset(offset):
             header = header0 = self.read_header()
             frame_nr0 = header0['frame_nr']
             while header['frame_nr'] == frame_nr0:

--- a/baseband/base/offsets.py
+++ b/baseband/base/offsets.py
@@ -112,7 +112,7 @@ class RawOffsets:
         # frame number to our value.
         if index < len(self) and self.offset[index] == offset:
             self.frame_nr[index] = frame_nr
-        elif index == 0 or self.offset[index-1] != offset:
+        elif offset != (self.offset[index-1] if index > 0 else 0):
             # Otherwise, if we add new information, insert ourserlves.
             self.frame_nr.insert(index, frame_nr)
             self.offset.insert(index, offset)

--- a/baseband/base/tests/test_offsets.py
+++ b/baseband/base/tests/test_offsets.py
@@ -55,6 +55,8 @@ class TestRawOffsets:
         assert len(ro) == 2
         assert ro.frame_nr == [10, 14]
         assert ro.offset == [1, 10]
+        ro[0] = 0
+        assert len(ro) == 2
         # Though if it precedes a frame with the same offset, we move.
         ro[8] = 1 + 8*frame_nbytes
         assert ro.frame_nr == [8, 14]

--- a/baseband/mark5b/tests/test_mark5b.py
+++ b/baseband/mark5b/tests/test_mark5b.py
@@ -247,6 +247,7 @@ class TestMark5B:
             info = fh.info
 
         expected = {'format': 'mark5b',
+                    'offset0': 0,
                     'number_of_frames': number_of_frames,
                     'frame_rate': frame_rate,
                     'sample_rate': 32 * u.MHz,


### PR DESCRIPTION
Fixes the inability to open some of the problematic files found by @00rebe 