### PR TITLE
Switch to `entry_points().select` to get rid of DeprecationWarning

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -17,20 +17,20 @@ jobs:
       matrix:
         include:
 
-          - name: Test basics on 3.9
-            python: 3.9
-            toxenv: py39-test
+          - name: Test basics and coverage on 3.10
+            python: "3.10"
+            toxenv: py310-test-cov
             toxposargs: --open-files
 
           - name: Code style checks
-            python: 3.x
+            python: "3.x"
             toxenv: codestyle
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
     - name: Install Python dependencies
@@ -53,24 +53,23 @@ jobs:
           #   toxenv: build_docs
           #   apt_packages: graphviz
 
-          - name: Coverage using oldest supported versions
-            python: 3.7
-            toxenv: py37-test-oldestdeps-cov
-            pip_packages: codecov
+          - name: Test oldest supported version
+            python: "3.7"
+            toxenv: py37-test-oldestdeps
 
-          - name: Windows on 3.8
+          - name: Windows on 3.9
             os: windows-latest
-            python: 3.8
-            toxenv: py38-test
+            python: "3.9"
+            toxenv: py39-test
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Install system dependencies
       if: matrix.apt_packages
       run: sudo apt-get install ${{ matrix.apt_packages }}
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
     - name: Install Python dependencies
@@ -79,6 +78,7 @@ jobs:
       run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
     - name: Upload coverage to codecov
       if: ${{ contains(matrix.toxenv,'-cov') }}
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         file: ./coverage.xml
+        verbose: true

--- a/baseband/base/header.py
+++ b/baseband/base/header.py
@@ -462,7 +462,7 @@ class ParsedHeaderBase:
         except KeyError:
             raise KeyError("{0} header does not contain {1}"
                            .format(self.__class__.__name__, item))
-        except(TypeError, ValueError):
+        except (TypeError, ValueError):
             if not self.mutable:
                 raise TypeError("header is immutable. Set '.mutable` attribute"
                                 " or make a copy.")

--- a/baseband/dada/header.py
+++ b/baseband/dada/header.py
@@ -458,6 +458,6 @@ class DADAHeader(OrderedDict):
                      == float(other.get('MJD_START', 0.))))
 
     def __repr__(self):
-        return('{0}("""'.format(self.__class__.__name__)
-               + '\n'.join(self._tolines())
-               + '""")')
+        return ('{0}("""'.format(self.__class__.__name__)
+                + '\n'.join(self._tolines())
+                + '""")')

--- a/baseband/guppi/header.py
+++ b/baseband/guppi/header.py
@@ -407,5 +407,5 @@ class GUPPIHeader(fits.Header):
     def __repr__(self):
         name = self.__class__.__name__
         vals = super().__repr__()
-        return('<{0} {1}>'.format(name, ("\n  " + len(name) * " ").join(
+        return ('<{0} {1}>'.format(name, ("\n  " + len(name) * " ").join(
             [v.rstrip() for v in vals.split('\n')])))

--- a/baseband/io/__init__.py
+++ b/baseband/io/__init__.py
@@ -62,7 +62,7 @@ def __getattr__(attr):
         # Note: again do not presume the entry points exist, since we may
         # be in a pure source checkout.
         _entries.update({entry_point.name: entry_point for entry_point
-                         in entry_points().get('baseband.io', [])})
+                         in entry_points().select(group='baseband.io')})
         # Need python >= 3.9 to be able to do entry.attr.
         FORMATS.extend([name for name, entry in _entries.items()
                         if not (entry.value.partition(':')[2]

--- a/baseband/io/__init__.py
+++ b/baseband/io/__init__.py
@@ -61,8 +61,14 @@ def __getattr__(attr):
 
         # Note: again do not presume the entry points exist, since we may
         # be in a pure source checkout.
+
+        if hasattr(entry_points(), 'select'):
+            selected_entry_points = entry_points().select(group='baseband.io')
+        else:
+            selected_entry_points = entry_points().get('baseband.io', [])
+
         _entries.update({entry_point.name: entry_point for entry_point
-                         in entry_points().select(group='baseband.io')})
+                         in selected_entry_points})
         # Need python >= 3.9 to be able to do entry.attr.
         FORMATS.extend([name for name, entry in _entries.items()
                         if not (entry.value.partition(':')[2]

--- a/baseband/io/__init__.py
+++ b/baseband/io/__init__.py
@@ -42,7 +42,7 @@ def __getattr__(attr):
     """
     if sys.version_info >= (3, 8):
         from importlib.metadata import EntryPoint, entry_points
-    else:
+    else:  # pragma: no cover
         from importlib_metadata import EntryPoint, entry_points
 
     if attr.startswith('_') or attr in _bad_entries:
@@ -62,10 +62,10 @@ def __getattr__(attr):
         # Note: again do not presume the entry points exist, since we may
         # be in a pure source checkout.
 
-        if hasattr(entry_points(), 'select'):
-            selected_entry_points = entry_points().select(group='baseband.io')
-        else:
-            selected_entry_points = entry_points().get('baseband.io', [])
+        try:
+            selected_entry_points = entry_points(group="baseband.io")
+        except TypeError:  # pragma: no cover
+            selected_entry_points = entry_points().get("baseband.io", [])
 
         _entries.update({entry_point.name: entry_point for entry_point
                          in selected_entry_points})

--- a/baseband/mark4/header.py
+++ b/baseband/mark4/header.py
@@ -715,7 +715,7 @@ class Mark4Header(Mark4TrackHeader):
                'needs to define {2} converters')
         try:
             converter = converters['converter']
-        except(KeyError, ValueError, IndexError):
+        except (KeyError, ValueError, IndexError):
             converter = np.array(converters)
             sb = self['lsb_output'][ta_ch]
             if self.nsb == 2 and len(converter) == len(ta_ch) // 2:
@@ -780,7 +780,7 @@ class Mark4Header(Mark4TrackHeader):
         except IndexError:
             raise IndexError("index {item} is out of bounds.")
 
-        if not(1 <= new_words.ndim <= 2 and new_words.shape[0] == 5):
+        if not (1 <= new_words.ndim <= 2 and new_words.shape[0] == 5):
             raise ValueError("cannot extract {0} from {1} instance."
                              .format(item, type(self)))
 

--- a/baseband/tasks/__init__.py
+++ b/baseband/tasks/__init__.py
@@ -36,7 +36,7 @@ def _get_entry_points():
 
     entries = {'_bad_entries': []}
 
-    for entry_point in entry_points().get('baseband.tasks', []):
+    for entry_point in entry_points().select(group='baseband.tasks'):
         # Only on python >= 3.9 do .module and .attr exist.
         ep_module, _, ep_attr = entry_point.value.partition(':')
         try:

--- a/baseband/tasks/__init__.py
+++ b/baseband/tasks/__init__.py
@@ -31,15 +31,15 @@ def _get_entry_points():
     import sys
     if sys.version_info >= (3, 8):
         from importlib.metadata import entry_points
-    else:
+    else:  # pragma: no cover
         from importlib_metadata import entry_points
 
     entries = {'_bad_entries': []}
 
-    if hasattr(entry_points(), 'select'):
-        selected_entry_points = entry_points().select(group='baseband.tasks')
-    else:
-        selected_entry_points = entry_points().get('baseband.tasks', [])
+    try:
+        selected_entry_points = entry_points(group="baseband.tasks")
+    except TypeError:  # pragma: no cover
+        selected_entry_points = entry_points().get("baseband.tasks", [])
 
     for entry_point in selected_entry_points:
         # Only on python >= 3.9 do .module and .attr exist.

--- a/baseband/tasks/__init__.py
+++ b/baseband/tasks/__init__.py
@@ -36,7 +36,12 @@ def _get_entry_points():
 
     entries = {'_bad_entries': []}
 
-    for entry_point in entry_points().select(group='baseband.tasks'):
+    if hasattr(entry_points(), 'select'):
+        selected_entry_points = entry_points().select(group='baseband.tasks')
+    else:
+        selected_entry_points = entry_points().get('baseband.tasks', [])
+
+    for entry_point in selected_entry_points:
         # Only on python >= 3.9 do .module and .attr exist.
         ep_module, _, ep_attr = entry_point.value.partition(':')
         try:

--- a/baseband/tests/test_entry_points.py
+++ b/baseband/tests/test_entry_points.py
@@ -11,10 +11,10 @@ import pytest
 
 from .. import io as bio, tasks, vdif, base
 
-if hasattr(entry_points(), 'select'):
-    tasks_entry_points = entry_points().select(group='baseband.tasks')
-else:
-    tasks_entry_points = entry_points().get('baseband.tasks', [])
+try:
+    tasks_entry_points = entry_points(group="baseband.tasks")
+except TypeError:
+    tasks_entry_points = entry_points().get("baseband.tasks", [])
 
 
 class TestExistingIOFormat:

--- a/baseband/tests/test_entry_points.py
+++ b/baseband/tests/test_entry_points.py
@@ -148,7 +148,7 @@ class TestTasks:
         assert (set(entry.name for entry in tasks._bad_entries)
                 == {'utils', 'does_not_exist'})
 
-    @pytest.mark.xfail(entry_points().get('baseband.tasks', []),
+    @pytest.mark.xfail(entry_points().select(group='baseband.tasks'),
                        reason='cannot test for lack of entry points')
     def test_message_on_empty_tasks(self):
         with pytest.raises(AttributeError, match='No.*entry points found'):

--- a/baseband/tests/test_entry_points.py
+++ b/baseband/tests/test_entry_points.py
@@ -11,6 +11,11 @@ import pytest
 
 from .. import io as bio, tasks, vdif, base
 
+if hasattr(entry_points(), 'select'):
+    tasks_entry_points = entry_points().select(group='baseband.tasks')
+else:
+    tasks_entry_points = entry_points().get('baseband.tasks', [])
+
 
 class TestExistingIOFormat:
     def setup_method(self):
@@ -148,7 +153,7 @@ class TestTasks:
         assert (set(entry.name for entry in tasks._bad_entries)
                 == {'utils', 'does_not_exist'})
 
-    @pytest.mark.xfail(entry_points().select(group='baseband.tasks'),
+    @pytest.mark.xfail(tasks_entry_points,
                        reason='cannot test for lack of entry points')
     def test_message_on_empty_tasks(self):
         with pytest.raises(AttributeError, match='No.*entry points found'):


### PR DESCRIPTION
The `entry_points` API now recommends using the `.select` method. Using `.get` gives a DeprecationWarning.