### PR TITLE
Error msg fix for improperly-shaped data in Payload.fromdata()

### DIFF
--- a/baseband/base/payload.py
+++ b/baseband/base/payload.py
@@ -162,8 +162,9 @@ class PayloadBase:
         if header:
             bps = header.bps
             if header.sample_shape != sample_shape:
-                raise ValueError(f"header is for sample_shape={header.sample_shape} "
-                                 f"but data has {sample_shape}")
+                raise ValueError(
+                    f"header is for sample_shape={header.sample_shape} "
+                    f"but data has {sample_shape}")
             if header.complex_data != complex_data:
                 raise ValueError("header is for {0} data but data are {1}"
                                  .format(*(('complex' if c else 'real') for c

--- a/baseband/base/payload.py
+++ b/baseband/base/payload.py
@@ -162,8 +162,8 @@ class PayloadBase:
         if header:
             bps = header.bps
             if header.sample_shape != sample_shape:
-                raise ValueError(f"header is for sample_shape={sample_shape} "
-                                 f"but data has {data.shape[1:]}")
+                raise ValueError(f"header is for sample_shape={header.sample_shape} "
+                                 f"but data has {sample_shape}")
             if header.complex_data != complex_data:
                 raise ValueError("header is for {0} data but data are {1}"
                                  .format(*(('complex' if c else 'real') for c


### PR DESCRIPTION
Previous message read "header is for sample_shape={sample_shape} but data has {sample_shape}" which leads to confusion, as those values will always be equal (they are both the incoming actual data shape). New message reports the expected and actual data shapes as intended.